### PR TITLE
Make sure the Git SHA always has a lenght of 7

### DIFF
--- a/build/git/hooks/post-checkout
+++ b/build/git/hooks/post-checkout
@@ -2,6 +2,6 @@
 # only do this for branch-level checkouts
 case $3 in
 1)    git update-index --assume-unchanged mscore/revision.h
-      git rev-parse --short HEAD >mscore/revision.h
+      git rev-parse --short=7 HEAD >mscore/revision.h
       ;;
 esac


### PR DESCRIPTION
This is or was the default, but for some reason we now sometimes see a length of 9 on self-built versions, at least on Windows. So let's be explict rather than relying on a default.
See https://musescore.org/en/node/152206#comment-699451