### PR TITLE
fix #296044: Capture tool images are different in size compared to original

### DIFF
--- a/mscore/preferences.cpp
+++ b/mscore/preferences.cpp
@@ -110,7 +110,7 @@ void Preferences::init(bool storeInMemoryOnly)
             {PREF_EXPORT_MUSICXML_EXPORTBREAKS,                    new EnumPreference(QVariant::fromValue(MusicxmlExportBreaks::ALL), false)},
             {PREF_EXPORT_MUSICXML_EXPORTLAYOUT,                    new BoolPreference(true, false)},
             {PREF_EXPORT_PDF_DPI,                                  new IntPreference(300, false)},
-            {PREF_EXPORT_PNG_RESOLUTION,                           new DoublePreference(300.0, false)},
+            {PREF_EXPORT_PNG_RESOLUTION,                           new DoublePreference(DPI, false)},
             {PREF_EXPORT_PNG_USETRANSPARENCY,                      new BoolPreference(true, false)},
             {PREF_IMPORT_GUITARPRO_CHARSET,                        new StringPreference("UTF-8", false)},
             {PREF_IMPORT_MUSICXML_IMPORTBREAKS,                    new BoolPreference(true, false)},

--- a/mscore/prefsdialog.ui
+++ b/mscore/prefsdialog.ui
@@ -3527,7 +3527,7 @@ Adjusting latency can help synchronize your MIDI hardware with MuseScore's inter
              <number>5000</number>
             </property>
             <property name="value">
-             <number>300</number>
+             <number>360</number>
             </property>
            </widget>
           </item>


### PR DESCRIPTION
fixes https://musescore.org/en/node/296044

takes effect only on new installs, after a factory reset, or after resetting that dialog page to its defaults