### PR TITLE
Fix Qt related compiler warnings (3.x)

### DIFF
--- a/audio/midi/fluid/sfont.cpp
+++ b/audio/midi/fluid/sfont.cpp
@@ -785,7 +785,7 @@ bool SFont::load()
             }
       f.close();
       /* sort preset list by bank, preset # */
-      qSort(presets.begin(), presets.end(), preset_compare);
+      std::sort(presets.begin(), presets.end(), preset_compare);
       return true;
       }
 

--- a/audio/midi/midifile.cpp
+++ b/audio/midi/midifile.cpp
@@ -907,7 +907,7 @@ void MidiFile::separateChannel()
             int nn = channel.size();
             if (nn <= 1)
                   continue;
-            qSort(channel);
+            std::sort(channel.begin(), channel.end());
                         // -- split --
                         // insert additional tracks, assign to them found channels
             for (int ii = 1; ii < nn; ++ii) {

--- a/avsomr/ui/recognitionproccessdialog.h
+++ b/avsomr/ui/recognitionproccessdialog.h
@@ -54,7 +54,7 @@ class RecognitionProccessDialog : private QProgressDialog
       IAvsOmrRecognizer::Step _lastStep;
 
       QTimer _updater;
-      QTime _time;
+      QElapsedTimer _time;
       QPushButton* _closeBtn{nullptr};
       TaskbarProgress* _taskbarProgress{nullptr};
       };

--- a/awl/aslider.cpp
+++ b/awl/aslider.cpp
@@ -127,7 +127,7 @@ void AbstractSlider::wheelEvent(QWheelEvent* ev)
       int div = 50;
       if (ev->modifiers() & Qt::ShiftModifier)
             div = 15;
-      _value += (ev->delta() * lineStep()) / div;
+      _value += (ev->angleDelta().y() * lineStep()) / div;
       if (_value < _minValue)
             _value = _minValue;
       else if (_value > _maxValue)

--- a/awl/pitchlabel.cpp
+++ b/awl/pitchlabel.cpp
@@ -76,7 +76,7 @@ void PitchLabel::setValue(int val)
       if (_pitchMode)
             s = pitch2string(_value);
       else
-            s.sprintf("%d", _value);
+            s = QString::asprintf("%d", _value);
       setText(s);
       }
 

--- a/awl/poslabel.cpp
+++ b/awl/poslabel.cpp
@@ -88,12 +88,12 @@ void PosLabel::updateValue()
       if (_smpte) {
             int min, sec, frame, subframe;
             pos.msf(&min, &sec, &frame, &subframe);
-            s.sprintf("%03d:%02d:%02d:%02d", min, sec, frame, subframe);
+            s = QString::asprintf("%03d:%02d:%02d:%02d", min, sec, frame, subframe);
             }
       else {
             int measure, beat, tick;
             pos.mbt(&measure, &beat, &tick);
-            s.sprintf("%04d.%02d.%03u", measure+1, beat+1, tick);
+            s = QString::asprintf("%04d.%02d.%03u", measure+1, beat+1, tick);
             }
       setText(s);
       }

--- a/awl/utils.cpp
+++ b/awl/utils.cpp
@@ -60,7 +60,7 @@ QString pitch2string(int v)
             return QString("----");
       int octave = (v / 12) - 1;
       QString o;
-      o.sprintf("%d", octave);
+      o = QString::asprintf("%d", octave);
       int i = v % 12;
       return qApp->translate("awlutils", octave < 0 ? valu[i] : vall[i]) + o;
       }

--- a/importexport/bww/parser.cpp
+++ b/importexport/bww/parser.cpp
@@ -204,7 +204,7 @@ static void determineTimesig(QList<Bww::MeasureDescription> const& measures, int
   QMap<int, int>::const_iterator i = map.constBegin();
   while (i != map.constEnd())
   {
-    qDebug() << "measureDurations:" << i.key() << i.value() << endl;
+    qDebug() << "measureDurations:" << i.key() << i.value();
     if (i.value() > max)
     {
       commonDur = i.key();

--- a/importexport/midiimport/importmidi_chord.cpp
+++ b/importexport/midiimport/importmidi_chord.cpp
@@ -105,9 +105,9 @@ ReducedFraction maxNoteLen(const std::pair<const ReducedFraction, MidiChord> &ch
 
 void removeOverlappingNotes(QList<MidiNote> &notes)
       {
-      QLinkedList<MidiNote> tempNotes;
+      std::list<MidiNote> tempNotes;
       for (const auto &note: notes)
-            tempNotes.append(note);
+            tempNotes.push_back(note);
 
       for (auto noteIt1 = tempNotes.begin(); noteIt1 != tempNotes.end(); ++noteIt1) {
             for (auto noteIt2 = std::next(noteIt1); noteIt2 != tempNotes.end(); ) {
@@ -410,7 +410,7 @@ void sortNotesByPitch(std::multimap<ReducedFraction, MidiChord> &chords)
       for (auto &chordEvent: chords) {
                         // in each chord sort notes by pitches
             auto &notes = chordEvent.second.notes;
-            qSort(notes.begin(), notes.end(), pitchSort);
+            std::sort(notes.begin(), notes.end(), pitchSort);
             }
       }
 
@@ -426,7 +426,7 @@ void sortNotesByLength(std::multimap<ReducedFraction, MidiChord> &chords)
       for (auto &chordEvent: chords) {
                         // in each chord sort notes by lengths
             auto &notes = chordEvent.second.notes;
-            qSort(notes.begin(), notes.end(), lenSort);
+            std::sort(notes.begin(), notes.end(), lenSort);
             }
       }
 

--- a/importexport/midiimport/importmidi_model.cpp
+++ b/importexport/midiimport/importmidi_model.cpp
@@ -944,7 +944,7 @@ Qt::ItemFlags TracksModel::editableFlags(int row, int col) const
 Qt::ItemFlags TracksModel::flags(const QModelIndex &index) const
       {
       if (!index.isValid())
-            return 0;
+            return {};
 
       Qt::ItemFlags flags = Qt::ItemFlags(Qt::ItemIsEnabled | Qt::ItemIsSelectable);
       const int trackIndex = trackIndexFromRow(index.row());

--- a/importexport/musicxml/importmxmlpass2.cpp
+++ b/importexport/musicxml/importmxmlpass2.cpp
@@ -912,7 +912,7 @@ static void handleTupletStop(Tuplet*& tuplet, const int normalNotes)
 //---------------------------------------------------------
 
 static void setElementPropertyFlags(ScoreElement* element, const Pid propertyId,
-                                    const QString value1, const QString value2 = QString::null)
+                                    const QString value1, const QString value2 = QString())
       {
       if (value1.isEmpty()) // Set as an implicit value
             element->setPropertyFlags(propertyId, PropertyFlags::STYLED);

--- a/importexport/musicxml/importxml.cpp
+++ b/importexport/musicxml/importxml.cpp
@@ -184,8 +184,8 @@ static bool extractRootfile(QFile* qf, QByteArray& data)
 
 static Score::FileError doValidate(const QString& name, QIODevice* dev)
       {
-      QTime t;
-      t.start();
+      //QElapsedTimer t;
+      //t.start();
 
       // initialize the schema
       ValidatorMessageHandler messageHandler;

--- a/importexport/ove/ove.cpp
+++ b/importexport/ove/ove.cpp
@@ -7646,7 +7646,7 @@ void OveOrganizer::organizeContainers(int /*part*/, int /*track*/,
             }
 
       // shift voices
-      qSort(voices.begin(), voices.end());
+      std::sort(voices.begin(), voices.end());
 
       for (i = 0; i < voices.size(); ++i) {
             int voice = voices[i];

--- a/libmscore/element.h
+++ b/libmscore/element.h
@@ -132,7 +132,7 @@ class EditData {
       bool vRaster                     { false };
 
       int key                          { 0     };
-      Qt::KeyboardModifiers modifiers  { 0     };
+      Qt::KeyboardModifiers modifiers  { /*0*/ };   // '0' initialized via default constructor, doing it here too results in compiler warning with Qt 5.15
       QString s;
 
       Qt::MouseButtons buttons         { Qt::NoButton };

--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -222,7 +222,7 @@ void Score::layoutChords1(Segment* segment, int staffIdx)
 
             // layout upstem noteheads
             if (upVoices > 1) {
-                  qSort(upStemNotes.begin(), upStemNotes.end(),
+                  std::sort(upStemNotes.begin(), upStemNotes.end(),
                      [](Note* n1, const Note* n2) ->bool {return n1->line() > n2->line(); } );
                   }
             if (upVoices) {
@@ -232,7 +232,7 @@ void Score::layoutChords1(Segment* segment, int staffIdx)
 
             // layout downstem noteheads
             if (downVoices > 1) {
-                  qSort(downStemNotes.begin(), downStemNotes.end(),
+                  std::sort(downStemNotes.begin(), downStemNotes.end(),
                      [](Note* n1, const Note* n2) ->bool {return n1->line() > n2->line(); } );
                   }
             if (downVoices) {
@@ -349,7 +349,7 @@ void Score::layoutChords1(Segment* segment, int staffIdx)
                               else
                                     break;
                               }
-                        qSort(overlapNotes.begin(), overlapNotes.end(),
+                        std::sort(overlapNotes.begin(), overlapNotes.end(),
                            [](Note* n1, const Note* n2) ->bool {return n1->line() > n2->line(); } );
 
                         // determine nature of overlap
@@ -567,7 +567,7 @@ void Score::layoutChords1(Segment* segment, int staffIdx)
             if (downVoices)
                   notes.insert(notes.end(), downStemNotes.begin(), downStemNotes.end());
             if (upVoices + downVoices > 1)
-                  qSort(notes.begin(), notes.end(),
+                  std::sort(notes.begin(), notes.end(),
                      [](Note* n1, const Note* n2) ->bool {return n1->line() > n2->line(); } );
             layoutChords3(notes, staff, segment);
             }
@@ -1092,7 +1092,7 @@ void Score::layoutChords3(std::vector<Note*>& notes, const Staff* staff, Segment
                   }
             nAcc = umi.size();
             if (nAcc > 1)
-                  qSort(umi);
+                  std::sort(umi.begin(), umi.end());
 
             // lay out columns
             for (int i = 0; i < nColumns; ++i) {

--- a/libmscore/mscoreview.cpp
+++ b/libmscore/mscoreview.cpp
@@ -74,7 +74,7 @@ const QList<Element*> MuseScoreView::elementsAt(const QPointF& p)
       Page* page = point2page(p);
       if (page) {
             el = page->items(p - page->pos());
-            qSort(el.begin(), el.end(), elementLower);
+            std::sort(el.begin(), el.end(), elementLower);
             }
       return el;
       }

--- a/libmscore/realizedharmony.cpp
+++ b/libmscore/realizedharmony.cpp
@@ -535,7 +535,7 @@ RealizedHarmony::PitchMap RealizedHarmony::normalizeNoteMap(const PitchMap& inte
       //redo insertions if we must have a specific number of notes with insertMulti
       if (enforceMaxAsGoal) {
             while (ret.size() < max) {
-                  ret.insertMulti(rootPitch, rootTpc); //duplicate root
+                  ret.insert(rootPitch, rootTpc); //duplicate root
 
                   int size = max - ret.size();
                   itr = PitchMapIterator(intervals); //reset iterator
@@ -543,12 +543,12 @@ RealizedHarmony::PitchMap RealizedHarmony::normalizeNoteMap(const PitchMap& inte
                         if (!itr.hasNext())
                               break;
                         itr.next();
-                        ret.insertMulti((itr.key() % 128 + rootPitch) % PITCH_DELTA_OCTAVE, itr.value());
+                        ret.insert((itr.key() % 128 + rootPitch) % PITCH_DELTA_OCTAVE, itr.value());
                         }
                   }
             }
       else if (ret.size() < max) //insert another root if we have room in general
-            ret.insertMulti(rootPitch, rootTpc);
+            ret.insert(rootPitch, rootTpc);
       return ret;
       }
 

--- a/libmscore/realizedharmony.h
+++ b/libmscore/realizedharmony.h
@@ -59,7 +59,7 @@ enum class HDuration : signed char {
 class RealizedHarmony {
 
    public:
-      using PitchMap = QMap<int, int>; //map from pitch to tpc
+      using PitchMap = QMultiMap<int, int>; //map from pitch to tpc
       using PitchMapIterator = QMapIterator<int, int>;
 
    private:

--- a/libmscore/scorefile.cpp
+++ b/libmscore/scorefile.cpp
@@ -1016,7 +1016,7 @@ void Score::print(QPainter* painter, int pageNo)
       QRectF fr  = page->abbox();
 
       QList<Element*> ell = page->items(fr);
-      qStableSort(ell.begin(), ell.end(), elementLessThan);
+      std::stable_sort(ell.begin(), ell.end(), elementLessThan);
       for (const Element* e : ell) {
             if (!e->visible())
                   continue;

--- a/libmscore/skyline.cpp
+++ b/libmscore/skyline.cpp
@@ -250,7 +250,7 @@ void Skyline::paint(QPainter& p) const
       p.save();
 
       p.setBrush(Qt::NoBrush);
-      QMatrix matrix = p.matrix();
+      QMatrix matrix = p.worldTransform().toAffine();
       p.setPen(QPen(QBrush(Qt::darkYellow), 2.0 / matrix.m11()));
       _north.paint(p);
       p.setPen(QPen(QBrush(Qt::green), 2.0 / matrix.m11()));

--- a/libmscore/textbase.cpp
+++ b/libmscore/textbase.cpp
@@ -3111,7 +3111,7 @@ void TextBase::drawEditMode(QPainter* p, EditData& ed)
       if (!_cursor->hasSelection())
             p->drawRect(_cursor->cursorRect());
 
-      QMatrix matrix = p->matrix();
+      QMatrix matrix = p->worldTransform().toAffine();
       p->translate(-pos);
       p->setPen(QPen(QBrush(Qt::lightGray), 4.0 / matrix.m11()));  // 4 pixel pen size
       p->setBrush(Qt::NoBrush);

--- a/libmscore/textedit.cpp
+++ b/libmscore/textedit.cpp
@@ -370,7 +370,7 @@ bool TextBase::edit(EditData& ed)
 
                   case Qt::Key_Tab:
                         s = " ";
-                        ed.modifiers = 0;
+                        ed.modifiers = {};
                         break;
 
                   case Qt::Key_Space:
@@ -385,7 +385,7 @@ bool TextBase::edit(EditData& ed)
                                     }
                               s = " ";
                               }
-                        ed.modifiers = 0;
+                        ed.modifiers = {};
                         break;
 
                   case Qt::Key_Minus:

--- a/libmscore/tuplet.cpp
+++ b/libmscore/tuplet.cpp
@@ -1035,7 +1035,7 @@ static bool tickGreater(const DurationElement* a, const DurationElement* b)
 
 void Tuplet::sortElements()
       {
-      qSort(_elements.begin(), _elements.end(), tickGreater);
+      std::sort(_elements.begin(), _elements.end(), tickGreater);
       }
 
 //---------------------------------------------------------

--- a/libmscore/utils.cpp
+++ b/libmscore/utils.cpp
@@ -490,7 +490,7 @@ QString pitch2string(int v)
             return QString("----");
       int octave = (v / 12) - 1;
       QString o;
-      o.sprintf("%d", octave);
+      o = QString::asprintf("%d", octave);
       int i = v % 12;
       return qApp->translate("utils", octave < 0 ? valu[i] : vall[i]) + o;
       }

--- a/mscore/abstractdialog.h
+++ b/mscore/abstractdialog.h
@@ -32,7 +32,7 @@ class AbstractDialog : public QDialog
    Q_OBJECT
 
    public:
-      AbstractDialog(QWidget * parent = 0, Qt::WindowFlags f = 0);
+      AbstractDialog(QWidget * parent = 0, Qt::WindowFlags f = {});
       virtual ~AbstractDialog();
 
    protected:

--- a/mscore/chordview.cpp
+++ b/mscore/chordview.cpp
@@ -340,7 +340,7 @@ void ChordView::moveLocator()
 
 void ChordView::wheelEvent(QWheelEvent* event)
       {
-      int step    = event->delta() / 120;
+      int step    = event->angleDelta().y() / 120;
       double xmag = transform().m11();
       double ymag = transform().m22();
 

--- a/mscore/continuouspanel.cpp
+++ b/mscore/continuouspanel.cpp
@@ -106,7 +106,7 @@ void ContinuousPanel::paint(const QRect&, QPainter& painter)
             _visible = false;
             return;
             }
-      qStableSort(el.begin(), el.end(), elementLessThan);
+      std::stable_sort(el.begin(), el.end(), elementLessThan);
 
       const Measure*_currentMeasure = 0;
       for (const Element* e : el) {

--- a/mscore/debugger/debugger.cpp
+++ b/mscore/debugger/debugger.cpp
@@ -533,13 +533,13 @@ bool Debugger::searchElement(QTreeWidgetItem* pi, Element* el)
             ElementItem* ei = (ElementItem*)item;
             if (ei->element() == el) {
                   QTreeWidget* tw = pi->treeWidget();
-                  tw->setItemExpanded(item, true);
+                  item->setExpanded(true);
                   tw->setCurrentItem(item);
                   tw->scrollToItem(item);
                   return true;
                   }
             if (searchElement(item, el)) {
-                  pi->treeWidget()->setItemExpanded(item, true);
+                  item->setExpanded(true);
                   return true;
                   }
             }
@@ -608,7 +608,7 @@ void Debugger::updateElement(Element* el)
                   continue;
             ElementItem* ei = static_cast<ElementItem*>(item);
             if (ei->element() == el) {
-                  list->setItemExpanded(item, true);
+                  item->setExpanded(true);
                   list->setCurrentItem(item);
                   list->scrollToItem(item);
                   found = true;

--- a/mscore/drumview.cpp
+++ b/mscore/drumview.cpp
@@ -337,7 +337,7 @@ void DrumView::moveLocator(int i)
 
 void DrumView::wheelEvent(QWheelEvent* event)
       {
-      int step = event->delta() / 120;
+      int step = event->angleDelta().y() / 120;
       double xmag = transform().m11();
       double ymag = transform().m22();
 

--- a/mscore/editdrumset.cpp
+++ b/mscore/editdrumset.cpp
@@ -69,7 +69,7 @@ NoteHead::Group noteHeadNames[] = {
 bool EditDrumsetTreeWidgetItem::operator<(const QTreeWidgetItem & other) const
       {
       if (treeWidget()->sortColumn() == Column::PITCH)
-            return data(Column::PITCH, Qt::UserRole) < other.data(Column::PITCH, Qt::UserRole);
+            return data(Column::PITCH, Qt::UserRole).toInt() < other.data(Column::PITCH, Qt::UserRole).toInt();
       else
             return QTreeWidgetItem::operator<(other);
       }

--- a/mscore/editlyrics.cpp
+++ b/mscore/editlyrics.cpp
@@ -77,7 +77,7 @@ bool ScoreView::editKeyLyrics()
             case Qt::Key_Underscore:
                   if (editData.control(textEditing)) {
                         // change into normal underscore
-                        editData.modifiers = 0; // &= ~CONTROL_MODIFIER;
+                        editData.modifiers = {}; // &= ~CONTROL_MODIFIER;
                         return false;
                         }
                   else

--- a/mscore/exampleview.cpp
+++ b/mscore/exampleview.cpp
@@ -198,7 +198,7 @@ void ExampleView::paintEvent(QPaintEvent* ev)
             QRegion r1(r);
             Page* page = _score->pages().front();
             QList<Element*> ell = page->items(fr);
-            qStableSort(ell.begin(), ell.end(), elementLessThan);
+            std::stable_sort(ell.begin(), ell.end(), elementLessThan);
             drawElements(p, ell);
             }
       QFrame::paintEvent(ev);

--- a/mscore/file.cpp
+++ b/mscore/file.cpp
@@ -1070,7 +1070,7 @@ QString MuseScore::getSaveScoreName(const QString& title, QString& name, const Q
 
       if (preferences.getBool(PREF_UI_APP_USENATIVEDIALOGS)) {
             QString s;
-            QFileDialog::Options options = selectFolder ? QFileDialog::ShowDirsOnly : QFileDialog::Options(0);
+            QFileDialog::Options options = selectFolder ? QFileDialog::ShowDirsOnly : QFileDialog::Options();
             return QFileDialog::getSaveFileName(this, title, name, filter, &s, options);
             }
 
@@ -1841,7 +1841,7 @@ void MuseScore::exportFile()
 
       QString name;
 #ifdef Q_OS_WIN
-      if (QSysInfo::WindowsVersion == QSysInfo::WV_XP) {
+      if (QOperatingSystemVersion::current() <= QOperatingSystemVersion(QOperatingSystemVersion::Windows, 5, 1)) {   //XP
             if (!cs->isMaster())
                   name = QString("%1/%2-%3").arg(saveDirectory).arg(cs->masterScore()->fileInfo()->completeBaseName()).arg(createDefaultFileName(cs->title()));
             else
@@ -1925,7 +1925,7 @@ bool MuseScore::exportParts()
       QString scoreName = cs->isMaster() ? cs->masterScore()->fileInfo()->completeBaseName() : cs->title();
       QString name;
 #ifdef Q_OS_WIN
-      if (QSysInfo::WindowsVersion == QSysInfo::WV_XP)
+      if (QOperatingSystemVersion::current() <= QOperatingSystemVersion(QOperatingSystemVersion::Windows, 5, 1))   //XP
             name = QString("%1/%2").arg(saveDirectory).arg(scoreName);
       else
 #endif
@@ -2564,7 +2564,7 @@ bool MuseScore::saveAs(Score* cs_, bool saveCopy)
 
       QString name;
 #ifdef Q_OS_WIN
-      if (QSysInfo::WindowsVersion == QSysInfo::WV_XP) {
+      if (QOperatingSystemVersion::current() <= QOperatingSystemVersion(QOperatingSystemVersion::Windows, 5, 1)) {   //XP
             if (!cs_->isMaster())
                   name = QString("%1/%2-%3").arg(saveDirectory).arg(fileBaseName).arg(createDefaultFileName(cs->title()));
             else
@@ -2825,7 +2825,7 @@ bool MuseScore::savePng(Score* score, QIODevice* device, int pageNumber, bool dr
             p.translate(-r.topLeft());
 
       QList< Element*> pel = page->elements();
-      qStableSort(pel.begin(), pel.end(), elementLessThan);
+      std::stable_sort(pel.begin(), pel.end(), elementLessThan);
       paintElements(p, pel);
        if (format == QImage::Format_Indexed8) {
             //convert to grayscale & respect alpha
@@ -3135,7 +3135,7 @@ bool MuseScore::saveSvg(Score* score, QIODevice* device, int pageNumber, bool dr
             }
       // 2nd pass: the rest of the elements
       QList<Element*> pel = page->elements();
-      qStableSort(pel.begin(), pel.end(), elementLessThan);
+      std::stable_sort(pel.begin(), pel.end(), elementLessThan);
       ElementType eType;
 
       int lastNoteIndex = -1;

--- a/mscore/fotomode.cpp
+++ b/mscore/fotomode.cpp
@@ -649,7 +649,7 @@ void ScoreView::fotoDragDrop(QMouseEvent*)
       mimeData->setUrls(ul);
 
       drag->setMimeData(mimeData);
-      drag->start(Qt::CopyAction);
+      drag->exec(Qt::CopyAction);
       }
 }
 

--- a/mscore/importmidi_ui/importmidi_panel.cpp
+++ b/mscore/importmidi_ui/importmidi_panel.cpp
@@ -147,7 +147,7 @@ void ImportMidiPanel::fillCharsetList()
 
       _ui->comboBoxCharset->clear();
       QList<QByteArray> charsets = QTextCodec::availableCodecs();
-      qSort(charsets.begin(), charsets.end());
+      std::sort(charsets.begin(), charsets.end());
       int idx = 0;
       int maxWidth = 0;
       for (const auto &charset: charsets) {

--- a/mscore/importmidi_ui/importmidi_view.cpp
+++ b/mscore/importmidi_ui/importmidi_view.cpp
@@ -382,7 +382,7 @@ bool TracksView::viewportEvent(QEvent *event)
 
 void TracksView::wheelEvent(QWheelEvent *event)
       {
-      const int degrees = event->delta() / 8;
+      const int degrees = event->angleDelta().y() / 8;
       const int steps = degrees / 15;
 
       if ((event->modifiers() & Qt::ShiftModifier) || (event->modifiers() & Qt::ControlModifier)) {

--- a/mscore/importmidi_ui/importmidi_view.h
+++ b/mscore/importmidi_ui/importmidi_view.h
@@ -29,13 +29,13 @@ class SeparatorDelegate : public QStyledItemDelegate
 
             if (index.row() == _frozenRowIndex) {
                   painter->save();
-                  painter->setPen(option.palette.foreground().color());
+                  painter->setPen(option.palette.windowText().color());
                   painter->drawLine(option.rect.bottomLeft(), option.rect.bottomRight());
                   painter->restore();
                   }
             if (index.column() == _frozenColIndex) {
                   painter->save();
-                  painter->setPen(option.palette.foreground().color());
+                  painter->setPen(option.palette.windowText().color());
                               // use -1 padding to create double-line effect
                   const int x = option.rect.right() - 1;
                   painter->drawLine(x, option.rect.top(), x, option.rect.bottom());

--- a/mscore/instrwidget.cpp
+++ b/mscore/instrwidget.cpp
@@ -487,7 +487,7 @@ void InstrumentsWidget::genPartList(Score* cs)
                   sli->setStaffType(s->staffType(Fraction(0,1)));    // TODO
                   }
             pli->updateClefs();
-            partiturList->setItemExpanded(pli, true);
+            pli->setExpanded(true);
             }
       partiturList->resizeColumnToContents(2);  // adjust width of "Clef " and "Staff type" columns
       partiturList->resizeColumnToContents(4);
@@ -614,7 +614,7 @@ void InstrumentsWidget::on_addButton_clicked()
                   sli->setStaffType(it->staffTypePreset);
                   }
             pli->updateClefs();
-            partiturList->setItemExpanded(pli, true);
+            pli->setExpanded(true);
             partiturList->clearSelection();     // should not be necessary
             partiturList->setCurrentItem(pli);
             }
@@ -723,7 +723,7 @@ void InstrumentsWidget::on_upButton_clicked()
       QTreeWidgetItem* item = wi.front();
 
       if (item->type() == PART_LIST_ITEM) {
-            bool isExpanded = partiturList->isItemExpanded(item);
+            bool isExpanded = item->isExpanded();
             int idx = partiturList->indexOfTopLevelItem(item);
             // if part item not first, move one slot up
             if (idx) {
@@ -755,7 +755,7 @@ void InstrumentsWidget::on_upButton_clicked()
                         staffItem->initStaffTypeCombo(true);
                         staffItem->setStaffType(staffIdx[itemIdx]);
                         }
-                  partiturList->setItemExpanded(item1, isExpanded);
+                  item1->setExpanded(isExpanded);
                   partiturList->setCurrentItem(item1);
                   }
             }
@@ -812,7 +812,7 @@ void InstrumentsWidget::on_downButton_clicked()
             return;
       QTreeWidgetItem* item = wi.front();
       if (item->type() == PART_LIST_ITEM) {
-            bool isExpanded = partiturList->isItemExpanded(item);
+            bool isExpanded = item->isExpanded();
             int idx = partiturList->indexOfTopLevelItem(item);
             int n = partiturList->topLevelItemCount();
             // if part not last, move one slot down
@@ -846,7 +846,7 @@ void InstrumentsWidget::on_downButton_clicked()
                         staffItem->initStaffTypeCombo(true);
                         staffItem->setStaffType(staffIdx[itemIdx]);
                         }
-                  partiturList->setItemExpanded(item1, isExpanded);
+                  item1->setExpanded(isExpanded);
                   partiturList->setCurrentItem(item1);
                   }
             }

--- a/mscore/miconengine.cpp
+++ b/mscore/miconengine.cpp
@@ -196,7 +196,7 @@ QPixmap MIconEngine::pixmap(const QSize &size, QIcon::Mode mode, QIcon::State st
       QString pmckey(d->pmcKey(size, mode, state));
       pmckey.prepend("Ms");
 
-      if (QPixmapCache::find(pmckey, pm))
+      if (QPixmapCache::find(pmckey, &pm))
             return pm;
 
       if (d->addedPixmaps) {

--- a/mscore/mixer/mixer.cpp
+++ b/mscore/mixer/mixer.cpp
@@ -54,6 +54,7 @@ namespace Ms {
       __x->blockSignals(false);
 
 
+#if 0
 double volumeToUserRange(char v) { return v * 100.0 / 128.0; }
 double panToUserRange(char v) { return (v / 128.0) * 360.0; }
 double chorusToUserRange(char v) { return v * 100.0 / 128.0; }
@@ -67,6 +68,7 @@ char userRangeToPan(double v) { return (char)qBound(0, static_cast<int>((v / 360
 char userRangeToChorus(double v) { return (char)qBound(0, static_cast<int>(v / 100.0 * 128.0), 127); }
 //0 to 100
 char userRangeToReverb(double v) { return (char)qBound(0, static_cast<int>(v / 100.0 * 128.0), 127); }
+#endif
 
 //---------------------------------------------------------
 //   Mixer

--- a/mscore/mixer/mixer.h
+++ b/mscore/mixer/mixer.h
@@ -41,6 +41,7 @@ class MixerDetails;
 class MixerTrack;
 class MidiMapping;
 
+#if 0
 double volumeToUserRange(char v);
 double panToUserRange(char v);
 double chorusToUserRange(char v);
@@ -54,6 +55,7 @@ char userRangeToPan(double v);
 char userRangeToChorus(double v);
 //0 to 100
 char userRangeToReverb(double v);
+#endif
 
 
 //---------------------------------------------------------

--- a/mscore/mixer/mixer.ui
+++ b/mscore/mixer/mixer.ui
@@ -9,7 +9,7 @@
    <bool>false</bool>
   </property>
   <property name="features">
-   <set>QDockWidget::AllDockWidgetFeatures</set>
+   <set>QDockWidget::DockWidgetClosable|QDockWidget::DockWidgetMovable|QDockWidget::DockWidgetFloatable</set>
   </property>
   <property name="geometry">
    <rect>

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -744,7 +744,7 @@ bool MuseScore::importExtension(QString path)
       infoMsgBox->setTextFormat(Qt::RichText);
       infoMsgBox->setMinimumSize(300, 100);
       infoMsgBox->setMaximumSize(300, 100);
-      infoMsgBox->setStandardButtons(0);
+      infoMsgBox->setStandardButtons({});
       infoMsgBox->setText(QString("<p align='center'>") + tr("Please wait; unpacking extension…") + QString("</p>"));
 
       //setup async run of long operations
@@ -1041,7 +1041,7 @@ MuseScore::MuseScore()
       QScreen* screen = QGuiApplication::primaryScreen();
       if (userDPI == 0.0) {
 #if defined(Q_OS_WIN)
-      if (QSysInfo::WindowsVersion <= QSysInfo::WV_WINDOWS7)
+      if (QOperatingSystemVersion::current() <= QOperatingSystemVersion(QOperatingSystemVersion::Windows, 7))
             _physicalDotsPerInch = screen->logicalDotsPerInch() * screen->devicePixelRatio();
       else
             _physicalDotsPerInch = screen->physicalDotsPerInch();  // physical resolution
@@ -4168,10 +4168,12 @@ bool MuseScore::readLanguages(const QString& path)
             int line, column;
             QString err;
             if (!doc.setContent(&qf, false, &err, &line, &column)) {
+                  QString error;
+                  error = QString::asprintf(qPrintable(tr("Error reading language file %s at line %d column %d: %s\n")),
+                                            qPrintable(qf.fileName()), line, column, qPrintable(err));
                   QMessageBox::warning(0,
                      QWidget::tr("Load Languages Failed:"),
-                     tr("Error reading language file %1 at line %2 column %3: %4")
-                        .arg(qf.fileName()).arg(line).arg(column).arg(err),
+                     error,
                      QString(), QWidget::tr("Quit"), QString(), 0, 1);
                   return false;
                   }
@@ -5877,13 +5879,13 @@ GreendotButton::GreendotButton(QWidget* parent)
 QRectF drawHandle(QPainter& p, const QPointF& pos, bool active)
       {
       p.save();
-      p.setPen(QPen(QColor(MScore::selectColor[0]), 2.0/p.matrix().m11()));
+      p.setPen(QPen(QColor(MScore::selectColor[0]), 2.0/p.worldTransform().toAffine().m11()));
       if (active)
             p.setBrush(MScore::selectColor[0]);
       else
             p.setBrush(Qt::NoBrush);
-      qreal w = 8.0 / p.matrix().m11();
-      qreal h = 8.0 / p.matrix().m22();
+      qreal w = 8.0 / p.worldTransform().toAffine().m11();
+      qreal h = 8.0 / p.worldTransform().toAffine().m22();
 
       QRectF r(-w/2, -h/2, w, h);
       r.translate(pos);

--- a/mscore/navigator.cpp
+++ b/mscore/navigator.cpp
@@ -115,7 +115,7 @@ Navigator::Navigator(NScrollArea* sa, QWidget* parent)
   : QWidget(parent)
       {
       setObjectName("Navigator");
-      setAttribute(Qt::WA_NoBackground);
+      setAttribute(Qt::WA_OpaquePaintEvent);
       _score         = 0;
       scrollArea     = sa;
       scrollArea->setWidgetResizable(true);

--- a/mscore/palette.h
+++ b/mscore/palette.h
@@ -135,7 +135,7 @@ class Palette : public QWidget {
       void nextPaletteElement();
       void prevPaletteElement();
       void applyPaletteElement();
-      static bool applyPaletteElement(Element* element, Qt::KeyboardModifiers modifiers = 0);
+      static bool applyPaletteElement(Element* element, Qt::KeyboardModifiers modifiers = {});
       PaletteCell* append(Element*, const QString& name, QString tag = QString(),
          qreal mag = 1.0);
       PaletteCell* add(int idx, Element*, const QString& name,

--- a/mscore/pianoroll/pianoview.cpp
+++ b/mscore/pianoroll/pianoview.cpp
@@ -580,7 +580,7 @@ void PianoView::zoomView(int step, bool horizontal, int centerX, int centerY)
 
 void PianoView::wheelEvent(QWheelEvent* event)
       {
-      int step = event->delta() / 120;
+      int step = event->angleDelta().y() / 120;
 
       if (event->modifiers() == 0) {
             //Vertical scroll

--- a/mscore/pianotools.cpp
+++ b/mscore/pianotools.cpp
@@ -471,7 +471,7 @@ void PianoTools::changeEvent(QEvent *event)
 void HPiano::wheelEvent(QWheelEvent* event)
       {
       static int deltaSum = 0;
-      deltaSum += event->delta();
+      deltaSum += event->angleDelta().y();
       int step = deltaSum / 120;
       deltaSum %= 120;
       qreal mag = scaleVal;

--- a/mscore/playpanel.ui
+++ b/mscore/playpanel.ui
@@ -20,7 +20,7 @@
    <bool>true</bool>
   </property>
   <property name="features">
-   <set>QDockWidget::AllDockWidgetFeatures</set>
+   <set>QDockWidget::DockWidgetClosable|QDockWidget::DockWidgetMovable|QDockWidget::DockWidgetFloatable</set>
   </property>
   <property name="windowTitle">
    <string>Play Panel</string>

--- a/mscore/plugin/qmledit.cpp
+++ b/mscore/plugin/qmledit.cpp
@@ -282,7 +282,7 @@ void JSHighlighter::mark(const QString &str, Qt::CaseSensitivity caseSensitivity
 
 QStringList JSHighlighter::keywords() const
       {
-      return m_keywords.toList();
+      return m_keywords.values();
       }
 
 //---------------------------------------------------------

--- a/mscore/preferenceslistwidget.cpp
+++ b/mscore/preferenceslistwidget.cpp
@@ -289,7 +289,7 @@ void IntPreferenceItem::setDefaultValue()
             }
       else if (_editorComboBox) {
             int index = _editorComboBox->findData(preferences.defaultValue(name()).toInt());
-            qDebug() << "Preference: " << name() << ":" << index << " != " << "-1" << endl;
+            qDebug() << "Preference: " << name() << ":" << index << " != " << "-1";
             _editorComboBox->setCurrentIndex(index);
             }
       if (_applyFunction)

--- a/mscore/prefsdialog.cpp
+++ b/mscore/prefsdialog.cpp
@@ -1219,7 +1219,7 @@ void PreferenceDialog::applyActivate()
 
 void PreferenceDialog::checkApplyActivation()
       {
-      qDebug() << modifiedWidgets.size() << " " << modifiedUiWidgets.size() << " " << modifiedAudioWidgets.size() << endl;
+      qDebug() << modifiedWidgets.size() << " " << modifiedUiWidgets.size() << " " << modifiedAudioWidgets.size();
       if (modifiedWidgets.size() == 0 && modifiedUiWidgets.size() == 0 && modifiedAudioWidgets.size() == 0)
             applySetActive(false);
       }
@@ -1430,7 +1430,7 @@ void PreferenceDialog::apply()
       modifiedAudioWidgets.clear();
 
       buttonBox->button(QDialogButtonBox::Apply)->setText(tr("Apply"));
-      qDebug() << "Final: " << timer.elapsed() << endl;
+      qDebug() << "Final: " << timer.elapsed();
       }
 
 //---------------------------------------------------------

--- a/mscore/qml/palettes/Palette.qml
+++ b/mscore/qml/palettes/Palette.qml
@@ -767,7 +767,7 @@ GridView {
                 // force not hiding palette cell if it is being dragged to a score
                 enabled: paletteCell.paletteDrag
                 target: mscore
-                onElementDraggedToScoreView: paletteCell.paletteDrag = false
+                function onElementDraggedToScoreView() { paletteCell.paletteDrag = false }
             }
         } // end ItemDelegate
     } // end DelegateModel

--- a/mscore/qml/palettes/PaletteTree.qml
+++ b/mscore/qml/palettes/PaletteTree.qml
@@ -763,7 +763,7 @@ ListView {
 
     Connections {
         target: palettesWidget
-        onHasFocusChanged: {
+        function onHasFocusChanged() {
             if (!palettesWidget.hasFocus) {
                 paletteSelectionModel.clearSelection();
                 expandedPopupIndex = null;

--- a/mscore/qml/palettes/PalettesWidgetHeader.qml
+++ b/mscore/qml/palettes/PalettesWidgetHeader.qml
@@ -130,7 +130,7 @@ Item {
 
     Connections {
         target: palettesWidget
-        onHasFocusChanged: {
+        function onHasFocusChanged() {
             if (!palettesWidget.hasFocus && !palettePopup.inMenuAction)
                 palettePopup.visible = false;
         }
@@ -138,7 +138,7 @@ Item {
 
     Connections {
         target: mscore
-        onPaletteSearchRequested: {
+        function onPaletteSearchRequested() {
             searchTextInput.forceActiveFocus()
             searchTextInput.selectAll()
         }

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -1186,7 +1186,7 @@ static void drawDebugInfo(QPainter& p, const Element* _e)
       e->shape().paint(p);
 
       p.setPen(QPen(Qt::red, 0.0));             // red x at 0,0 of bbox
-      qreal w = 5.0 / p.matrix().m11();
+      qreal w = 5.0 / p.worldTransform().toAffine().m11();
       qreal h = w;
       qreal x = 0; // e->bbox().x();
       qreal y = 0; // e->bbox().y();
@@ -1221,7 +1221,7 @@ static void drawDebugInfo(QPainter& p, const Element* _e)
 
 void ScoreView::drawElements(QPainter& painter, QList<Element*>& el, Element* editElement)
       {
-      qStableSort(el.begin(), el.end(), elementLessThan);
+      std::stable_sort(el.begin(), el.end(), elementLessThan);
       for (const Element* e : el) {
             e->itemDiscovered = 0;
 
@@ -1463,7 +1463,7 @@ void ScoreView::paint(const QRect& r, QPainter& p)
 
             QPen pen;
             pen.setColor(MScore::selectColor[0]);
-            pen.setWidthF(2.0 / p.matrix().m11());
+            pen.setWidthF(2.0 / p.worldTransform().toAffine().m11());
 
             pen.setStyle(Qt::SolidLine);
 
@@ -5083,7 +5083,7 @@ QList<Element*> ScoreView::elementsNear(QPointF p)
                   }
             }
       if (!ll.empty())
-            qSort(ll.begin(), ll.end(), elementLower);
+            std::sort(ll.begin(), ll.end(), elementLower);
       return ll;
       }
 

--- a/mscore/timeline.cpp
+++ b/mscore/timeline.cpp
@@ -726,7 +726,7 @@ Timeline::Timeline(TDockWidget* dockWidget, QWidget* parent)
       {
       setFocusPolicy(Qt::NoFocus);
       setAlignment(Qt::Alignment((Qt::AlignLeft | Qt::AlignTop)));
-      setAttribute(Qt::WA_NoBackground);
+      setAttribute(Qt::WA_OpaquePaintEvent);
 
       // theming
       _lightTheme.backgroundColor      = QColor(Qt::lightGray);

--- a/mscore/zoombox.cpp
+++ b/mscore/zoombox.cpp
@@ -93,7 +93,7 @@ ZoomBox::ZoomBox(QWidget* parent)
       setWhatsThis(tr("Zoom"));
       setAccessibleName(tr("Zoom"));
       setValidator(new ZoomValidator(this));
-      setAutoCompletion(false);
+      setCompleter(nullptr);
       setFocusPolicy(Qt::StrongFocus);
       setFixedHeight(preferences.getInt(PREF_UI_THEME_ICONHEIGHT) + 8);  // hack
       setMaxCount(static_cast<int>(zoomEntries.size()));

--- a/thirdparty/google_analytics/CMakeLists.txt
+++ b/thirdparty/google_analytics/CMakeLists.txt
@@ -27,6 +27,13 @@ target_link_libraries(google_analytics Qt5::Core Qt5::Network)
 
 if (MSVC)
   set_target_properties( google_analytics PROPERTIES
-    COMPILE_FLAGS "/wd4458 /wd4127"
+    COMPILE_FLAGS "/wd4127 /wd4458 /wd4996"
   )
+else (MSVC)
+    if (MINGW)
+        set_target_properties( google_analytics PROPERTIES
+          COMPILE_FLAGS "-Wno-deprecated-declarations"
+        )
+    endif (MINGW)
+
 endif (MSVC)


### PR DESCRIPTION
as seen with MSVC and Qt 5.15, but only those that apply to older Qt versions too.

These changes are in master since quite long (and unconditionally), see b7b35643a1, so basically a backport of #5616.

Brings us down to 126 deprecation warnings with Qt5.15 ;-), while building still fine with Qt 5.12 and (hopefully, CI will tell) 5.9 and even 5.8 (where needed)