### PR TITLE
Fix #321902: Crash on adding note-anchored lines

### DIFF
--- a/libmscore/element.cpp
+++ b/libmscore/element.cpp
@@ -603,7 +603,7 @@ void Element::writeProperties(XmlWriter& xml) const
                   xml.setLidLocalIndex(_links->lid(), xml.assignLocalIndex(loc));
                   }
             else {
-                  if (s->links()) {
+                  if (s && s->links()) {
                         Staff* linkedStaff = toStaff(s->links()->mainElement());
                         loc.setStaff(linkedStaff->idx());
                         }

--- a/libmscore/line.cpp
+++ b/libmscore/line.cpp
@@ -773,7 +773,7 @@ SLine::SLine(const SLine& s)
 QPointF SLine::linePos(Grip grip, System** sys) const
       {
       qreal x = 0.0;
-      qreal sp = staff()->spatium(tick());
+      qreal sp = staff() ? staff()->spatium(tick()) : 0.0;
       switch (anchor()) {
             case Spanner::Anchor::SEGMENT:
                   {


### PR DESCRIPTION
to any but the top part/instrument, if parts have been generated, and another on saving after having added it.

Fixes https://musescore.org/en/node/321902