### PR TITLE
Fix GH#16658: Position of articulations is incorrect in imported XML files from Reaper

### DIFF
--- a/importexport/musicxml/importmxmlpass2.cpp
+++ b/importexport/musicxml/importmxmlpass2.cpp
@@ -1069,15 +1069,21 @@ static void addArticulationToChord(const Notation& notation, ChordRest* cr)
       const QString place = notation.attribute("placement");
       Articulation* na = new Articulation(articSym, cr->score());
 
-      if (!dir.isNull()) // Only for case where XML attribute is present (isEmpty wouldn't work)
-            na->setUp(dir.isEmpty() || dir == "up");
-      setElementPropertyFlags(na, Pid::DIRECTION, dir);
+      if (dir == "up" || dir == "down") {
+            na->setUp(dir == "up");
+            na->setPropertyFlags(Pid::DIRECTION, PropertyFlags::UNSTYLED);
+            }
 
-      if (place == "above" || dir.isEmpty() || dir == "up")
-            na->setAnchor(ArticulationAnchor::TOP_STAFF);
-      else if (place == "below" || dir == "down")
-            na->setAnchor(ArticulationAnchor::BOTTOM_STAFF);
-      setElementPropertyFlags(na, Pid::DIRECTION, dir, place);
+      // when setting anchor, assume type up/down without explicit placement
+      // implies placement above/below
+      if (place == "above" || (dir == "up" && place == "")) {
+              na->setAnchor(ArticulationAnchor::TOP_CHORD);
+          na->setPropertyFlags(Pid::ARTICULATION_ANCHOR, PropertyFlags::UNSTYLED);
+          }
+      else if (place == "below" || (dir == "down" && place == "")) {
+            na->setAnchor(ArticulationAnchor::BOTTOM_CHORD);
+            na->setPropertyFlags(Pid::ARTICULATION_ANCHOR, PropertyFlags::UNSTYLED);
+            }
 
       cr->add(na);
       }

--- a/mtest/musicxml/io/testArticulationsCombined_ref.mscx
+++ b/mtest/musicxml/io/testArticulationsCombined_ref.mscx
@@ -171,7 +171,7 @@
               <subtype>stringsUpBow</subtype>
               </Articulation>
             <Articulation>
-              <subtype>articAccentStaccatoAbove</subtype>
+              <subtype>articAccentStaccatoBelow</subtype>
               </Articulation>
             <Note>
               <pitch>64</pitch>
@@ -189,7 +189,7 @@
               <subtype>stringsUpBow</subtype>
               </Articulation>
             <Articulation>
-              <subtype>articAccentStaccatoAbove</subtype>
+              <subtype>articAccentStaccatoBelow</subtype>
               </Articulation>
             <Note>
               <pitch>64</pitch>
@@ -210,7 +210,7 @@
               <subtype>ornamentTremblement</subtype>
               </Articulation>
             <Articulation>
-              <subtype>articTenutoAccentAbove</subtype>
+              <subtype>articTenutoAccentBelow</subtype>
               </Articulation>
             <StemDirection>up</StemDirection>
             <Note>
@@ -285,7 +285,7 @@
               <text>gal</text>
               </Lyrics>
             <Articulation>
-              <subtype>articTenutoStaccatoAbove</subtype>
+              <subtype>articTenutoStaccatoBelow</subtype>
               </Articulation>
             <Articulation>
               <subtype>stringsDownBow</subtype>
@@ -324,7 +324,7 @@
               <text>ly</text>
               </Lyrics>
             <Articulation>
-              <subtype>articAccentStaccatoAbove</subtype>
+              <subtype>articAccentStaccatoBelow</subtype>
               </Articulation>
             <StemDirection>up</StemDirection>
             <Note>
@@ -353,10 +353,12 @@
               <text>strea</text>
               </Lyrics>
             <Articulation>
-              <subtype>articStaccatoAbove</subtype>
+              <subtype>articStaccatoBelow</subtype>
+              <anchor>4</anchor>
               </Articulation>
             <Articulation>
               <subtype>articMarcatoAbove</subtype>
+              <anchor>3</anchor>
               </Articulation>
             <Note>
               <Accidental>
@@ -451,6 +453,7 @@
               </Lyrics>
             <Articulation>
               <subtype>articMarcatoTenutoAbove</subtype>
+              <anchor>3</anchor>
               </Articulation>
             <StemDirection>up</StemDirection>
             <Note>

--- a/mtest/musicxml/io/testCueNotes3_ref.mscx
+++ b/mtest/musicxml/io/testCueNotes3_ref.mscx
@@ -254,7 +254,7 @@
               <text>stars</text>
               </Lyrics>
             <Articulation>
-              <subtype>articStaccatoAbove</subtype>
+              <subtype>articStaccatoBelow</subtype>
               </Articulation>
             <StemDirection>up</StemDirection>
             <Note>


### PR DESCRIPTION
Articulations without placement or type attributes import as "chord automatic".
Articulations with placement or type attributes import as "above chord" or "below chord".

Backport of #16751 to Mu3

Resolves: #16658