### PR TITLE
[MU3] Fix GH#15727: Crash on transpose of specific 3.6 score

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -3964,7 +3964,7 @@ void Score::updateInstrumentChangeTranspositions(KeySigEvent& key, Staff* staff,
                               nkey = transposeKey(nkey, previousTranspose);
                               e.setKey(nkey);
                               }
-                        KeySig* keySig = toKeySig(s->element(track));
+                        KeySig* keySig = s ? toKeySig(s->element(track)) : nullptr;
                         if (keySig)
                               undo(new ChangeKeySig(keySig, e, keySig->showCourtesy()));
                         nextTick = kl->nextKeyTick(nextTick);


### PR DESCRIPTION
Resolves: #15727 (but for 3.x, backport of #16770)