### PR TITLE
Fix #346638: Crash - select title frame > previous in-staff element

### DIFF
--- a/libmscore/system.cpp
+++ b/libmscore/system.cpp
@@ -1367,17 +1367,20 @@ Element* System::nextSegmentElement()
 
 Element* System::prevSegmentElement()
       {
-      Segment* seg = firstMeasure()->first();
       Element* re = 0;
-      while (!re) {
-            seg = seg->prev1MM();
-            if (!seg)
-                  return score()->firstElement();
+      Measure* m = firstMeasure();
+      if (m) {
+            Segment* seg = m->first();
+            while (!re) {
+                  seg = seg->prev1MM();
+                  if (!seg)
+                        return score()->firstElement();
 
-            if (seg->segmentType() == SegmentType::EndBarLine)
-                  score()->inputState().setTrack((score()->staves().size() - 1) * VOICES); //correction
+                  if (seg->segmentType() == SegmentType::EndBarLine)
+                        score()->inputState().setTrack((score()->staves().size() - 1) * VOICES); //correction
 
-            re = seg->lastElement(score()->staves().size() - 1);
+                  re = seg->lastElement(score()->staves().size() - 1);
+                  }
             }
       return re;
       }


### PR DESCRIPTION
Backport of #16840

Resolves: https://musescore.org/en/node/346638

Same issue (and fix) in Mu3 and Mu4 (so not a regression)

To reproduce the crash select a title frame and press Shift+Ctrl+Alt+Left (shortcut for "Select previous in-staff element")
