### PR TITLE
Fix GH#15284: Disabled accidentals on tablature, fixing bug where it would always result in C9 or variation upon it

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -1833,6 +1833,8 @@ void Score::changeAccidental(Note* note, AccidentalType accidental)
       if (!estaff)
             return;
       ClefType clef = estaff->clef(tick);
+      if (estaff->isTabStaff(tick))
+            return;
       int step      = ClefInfo::pitchOffset(clef) - note->line();
       while (step < 0)
             step += 7;


### PR DESCRIPTION
Backport of #15307, albeit in a slightly different way

Resolves: #15284