### PR TITLE
Fix #346989: Single-key shortcuts conflict with typing in MS3

### DIFF
--- a/mscore/shortcut.cpp
+++ b/mscore/shortcut.cpp
@@ -2091,12 +2091,7 @@ Shortcut Shortcut::_sc[] = {
          },
       {
          MsWidget::MAIN_WINDOW,
-#ifdef Q_OS_MAC
-         //Avoid conflict with M in text
-         STATE_NORMAL | STATE_NOTE_ENTRY | STATE_PLAY,
-#else
          STATE_NORMAL | STATE_NOTE_ENTRY | STATE_EDIT | STATE_PLAY,
-#endif
          "toggle-mixer",
          QT_TRANSLATE_NOOP("action","Mixer"),
          QT_TRANSLATE_NOOP("action","Toggle 'Mixer'"),


### PR DESCRIPTION
due to some special casing on Mac and there only.

Resolves: https://musescore.org/en/node/346989

That code was in there since MuseScore 0.9.6, hopefully no longer needed, needs testing (of a Mac user)