### PR TITLE
Revert Mac builds to use Qt 5.9

### DIFF
--- a/build/ci/macos/setup.sh
+++ b/build/ci/macos/setup.sh
@@ -86,12 +86,12 @@ installBottleManually libsndfile
 installBottleManually portaudio
 
 
-export QT_SHORT_VERSION=5.15.9
+export QT_SHORT_VERSION=5.9
 export QT_PATH=$HOME/Qt
 export QT_MACOS=$QT_PATH/$QT_SHORT_VERSION/clang_64
 export PATH=$PATH:$QT_MACOS/bin
 echo "PATH=$PATH" >> $GITHUB_ENV
-wget -nv -O qt5.zip https://s3.amazonaws.com/utils.musescore.org/Qt5159_mac.zip
+wget -nv -O qt5.zip https://s3.amazonaws.com/utils.musescore.org/qt598_mac.zip
 mkdir -p $QT_MACOS
 unzip -qq qt5.zip -d $QT_MACOS
 rm qt5.zip


### PR DESCRIPTION
Probably reinstates [macOS 10.5 accessibility setting “Enable Hover Text” causes crash](https://musescore.org/en/node/317323) but should solve the problems described in https://musescore.org/en/node/347226

```
Termination Reason: Namespace DYLD, Code 1 Library missing
Library not loaded:
@loader_path/../Frameworks/QtWebEngineCore.framework/Versions/5/QtWebEngineCore
Referenced from: 
/Applications/MuseScore 3.7.0.4385017570 Devel.app/Contents/MacOS/mscore
Reason: tried: '/Applications/MuseScore 3.7.0.4385017570
Devel.app/Contents/MacOS/../Frameworks/QtWebEngineCore.framework/Versions/5/QtWebEngineCore'
(),
'/System/Volumes/Preboot/Cryptexes/OS@loader_path/../Frameworks/QtWebEngineCore.framework/Versions/5/QtWebEngineCore'
(no such file), '/Applications/MuseScore 3.7.0.4385017570
Devel.app/Contents/MacOS/../Frameworks/QtWebEngineCore.framework/Versions/5/QtWebEngineCore'
(),
'/Library/Frameworks/QtWebEngineCore.framework/Versions/5/QtWebEngineCore'
(no such file),
'/System/Library/Frameworks/QtWebEngineCore.framework/Versions/5/QtWebEngineCore'
(no such file, not in dyld cache)
(terminated at launch; ignore backtrace)
```

Maybe extracting that missing QtWebEngineCore from https://s3.amazonaws.com/utils.musescore.org/Qt5152_mac.zip and placing it somewhere in the lib search path would help?