### PR TITLE
Fix GH#95: Loss of image

### DIFF
--- a/libmscore/image.cpp
+++ b/libmscore/image.cpp
@@ -43,7 +43,7 @@ Image::Image(Score* s)
       _autoScale       = defaultAutoScale;
       _sizeIsSpatium   = defaultSizeIsSpatium;
       _linkIsValid     = false;
-      _used            = false;
+      _used            = true;
       }
 
 Image::Image(const Image& img)
@@ -61,7 +61,7 @@ Image::Image(const Image& img)
             _storeItem->reference(this);
       _linkPath        = img._linkPath;
       _linkIsValid     = img._linkIsValid;
-      _used            = false;
+      _used            = true;
       if (imageType == ImageType::RASTER)
             rasterDoc = img.rasterDoc ? new QImage(*img.rasterDoc) : 0;
       else if (imageType == ImageType::SVG)


### PR DESCRIPTION
Fixes #95, to fix an earlier fix from #7871 (a 3.x version of #7740 for master) that was supposed to fix https://musescore.org/en/node/318772