### PR TITLE
Detect text style types correctly when reading 4.x mscx files

### DIFF
--- a/libmscore/style.cpp
+++ b/libmscore/style.cpp
@@ -2532,7 +2532,7 @@ const TextStyle* textStyle(Tid idx)
 Tid textStyleFromName(const QString& name)
       {
       for (const auto& s : textStyles) {
-            if (s.name == name)
+            if (QString::compare(s.name, name, Qt::CaseInsensitive) == 0)
                   return s.tid;
             }
       if (name == "Technique")                  // compatibility


### PR DESCRIPTION
The tags for text style names are all lower case in 4.x, but start with a capital letter in 3.x (and earlier).
So when reading a 4.x (mscx) file in 3.x, all test style types are 'detected' as `""`, `Tid::DEFAULT`. Esp. annoying for the texts in the title frame.
Making the comparison case-insensitive should fix this and not harm otherwise.