### PR TITLE
Fix crash when Ctrl+A in 206 score with Glissandos without end element

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -1523,6 +1523,18 @@ void Score::connectTies(bool silent)
                               }
                         }
 #endif
+                  for (Chord* gc : c->graceNotes()) {
+                        for (Note* n : gc->notes()) {
+                              // spanner with no end element apparently happens when reading some 206 files
+                              // (and possibly in other situations too)
+                              for (Spanner* spanner : n->spannerFor()) {
+                                   if (spanner->endElement() == nullptr) {
+                                         n->removeSpannerFor(spanner);
+                                         delete spanner;
+                                         }
+                                    }
+                              }
+                        }
                   }
             }
       }


### PR DESCRIPTION
Backport of #17302

Resolves: #15108