### PR TITLE
Fix GH#10403: Moving notes between strings

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -1480,7 +1480,14 @@ static void setTpc(Note* oNote, int tpc, int& newTpc1, int& newTpc2)
 
 void Score::upDown(bool up, UpDownMode mode)
       {
-      QList<Note*> el = selection().uniqueNotes();
+      std::list<Note*> el = selection().uniqueNotes();
+
+      el.sort([up](Note* a, Note* b) {
+            if (up)
+                  return a->string() < b->string();
+            else
+                  return a->string() > b->string();
+            });
 
       for (Note* oNote : qAsConst(el)) {
             Fraction tick     = oNote->chord()->tick();

--- a/libmscore/select.cpp
+++ b/libmscore/select.cpp
@@ -1275,9 +1275,9 @@ bool Selection::measureRange(Measure** m1, Measure** m2) const
 //    elements show up in the list.
 //---------------------------------------------------------
 
-const QList<Element*> Selection::uniqueElements() const
+const std::list<Element*> Selection::uniqueElements() const
       {
-      QList<Element*> l;
+      std::list<Element*> l;
 
       for (Element* e : elements()) {
             bool alreadyThere = false;
@@ -1288,7 +1288,7 @@ const QList<Element*> Selection::uniqueElements() const
                         }
                   }
             if (!alreadyThere)
-                  l.append(e);
+                  l.push_back(e);
             }
       return l;
       }
@@ -1300,9 +1300,9 @@ const QList<Element*> Selection::uniqueElements() const
 //    elements show up in the list.
 //---------------------------------------------------------
 
-QList<Note*> Selection::uniqueNotes(int track) const
+std::list<Note*> Selection::uniqueNotes(int track) const
       {
-      QList<Note*> l;
+      std::list<Note*> l;
 
       for (Note* nn : noteList(track)) {
             for (Note* note : nn->tiedNotes()) {
@@ -1314,7 +1314,7 @@ QList<Note*> Selection::uniqueNotes(int track) const
                               }
                         }
                   if (!alreadyThere)
-                        l.append(note);
+                        l.push_back(note);
                   }
             }
       return l;

--- a/libmscore/select.h
+++ b/libmscore/select.h
@@ -189,8 +189,8 @@ class Selection {
       const QList<Element*>& elements() const { return _el; }
       std::vector<Note*> noteList(int track = -1) const;
 
-      const QList<Element*> uniqueElements() const;
-      QList<Note*> uniqueNotes(int track = -1) const;
+      const std::list<Element*> uniqueElements() const;
+      std::list<Note*> uniqueNotes(int track = -1) const;
 
       bool isSingle() const                   { return (_state == SelState::LIST) && (_el.size() == 1); }
 

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -2364,8 +2364,8 @@ void ScoreView::cmd(const char* s)
                   cv->score()->upDown(false, UpDownMode::DIATONIC);
                   }},
             {{"move-up"}, [](ScoreView* cv, const QByteArray) {
-                  QList<Element*> el = cv->score()->selection().uniqueElements();
-                  foreach (Element* e, el) {
+                  std::list<Element*> el = cv->score()->selection().uniqueElements();
+                  for (Element* e : el) {
                         ChordRest* cr = nullptr;
                         if (e->type() == ElementType::NOTE)
                               cr = static_cast<Note*>(e)->chord();
@@ -2376,8 +2376,8 @@ void ScoreView::cmd(const char* s)
                         }
                   }},
             {{"move-down"}, [](ScoreView* cv, const QByteArray&) {
-                  QList<Element*> el = cv->score()->selection().uniqueElements();
-                  foreach (Element* e, el) {
+                  std::list<Element*> el = cv->score()->selection().uniqueElements();
+                  for (Element* e : el) {
                         ChordRest* cr = nullptr;
                         if (e->type() == ElementType::NOTE)
                               cr = static_cast<Note*>(e)->chord();
@@ -4178,7 +4178,7 @@ void ScoreView::cmdAddNoteLine()
 void ScoreView::cmdChangeEnharmonic(bool both)
       {
       _score->startCmd();
-      QList<Note*> notes = _score->selection().uniqueNotes();
+      std::list<Note*> notes = _score->selection().uniqueNotes();
       for (Note* n : notes) {
             Staff* staff = n->staff();
             if (staff->part()->instrument(n->tick())->useDrumset())


### PR DESCRIPTION
Sort the notes by string, so that moved notes don't block each other.

Backport of #17410, converting `Selection::uniqueNotes()` from using `QList` to `std::list` in the due course, as that's how Mu4 does it too, and here avoids the use of the obsolete `QList::toStdList()`. While at it, doing the same for `Selection::uniqueElements()`.