### PR TITLE
Fix #15170: Fixed MU giving the finger on deleting letters in dynamics

### DIFF
--- a/libmscore/textbase.cpp
+++ b/libmscore/textbase.cpp
@@ -126,6 +126,20 @@ bool CharFormat::operator==(const CharFormat& cf) const
       }
 
 //---------------------------------------------------------
+//   operator=
+//---------------------------------------------------------
+
+CharFormat& CharFormat::operator=(const CharFormat& cf)
+      {
+      setStyle(cf.style());
+      setValign(cf.valign());
+      setFontSize(cf.fontSize());
+      setFontFamily(cf.fontFamily());
+
+      return *this;
+      }
+
+//---------------------------------------------------------
 //   clearSelection
 //---------------------------------------------------------
 

--- a/libmscore/textbase.h
+++ b/libmscore/textbase.h
@@ -71,7 +71,9 @@ class CharFormat {
 
    public:
       CharFormat() {}
-      bool operator==(const CharFormat&) const;
+      CharFormat(const CharFormat& cf) { *this = cf; }
+      bool operator==(const CharFormat& cf) const;
+      CharFormat& operator=(const CharFormat& cf);
 
       FontStyle style() const                { return _style;                         }
       void setStyle(FontStyle s)             { _style = s;                            }

--- a/libmscore/textedit.cpp
+++ b/libmscore/textedit.cpp
@@ -494,6 +494,7 @@ void TextBase::movePosition(EditData& ed, QTextCursor::MoveOperation op)
 void ChangeText::insertText(EditData* ed)
       {
       TextCursor tc = c;
+      tc.setFormat(format); // To undo TextCursor::updateCursorFormat()
       c.text()->editInsertText(&tc, s);
       if (ed) {
             TextCursor* ttc = c.text()->cursor(*ed);
@@ -510,6 +511,7 @@ void ChangeText::removeText(EditData* ed)
       TextCursor tc = c;
       TextBlock& l  = c.curLine();
       int column    = c.column();
+      format = *l.formatAt(column + s.size() - 1);
 
       for (int n = 0; n < s.size(); ++n)
             l.remove(column, &c);

--- a/libmscore/textedit.h
+++ b/libmscore/textedit.h
@@ -58,13 +58,14 @@ class TextEditUndoCommand : public UndoCommand {
 
 class ChangeText : public TextEditUndoCommand {
       QString s;
+      CharFormat format;
 
    protected:
       void insertText(EditData*);
       void removeText(EditData*);
 
    public:
-      ChangeText(const TextCursor* tc, const QString& t) : TextEditUndoCommand(*tc), s(t) {}
+      ChangeText(const TextCursor* tc, const QString& t) : TextEditUndoCommand(*tc), s(t), format(*tc->format()) {}
       virtual void undo(EditData*) override = 0;
       virtual void redo(EditData*) override = 0;
       const TextCursor& cursor() const { return c; }


### PR DESCRIPTION
Backport of #15529. Mu3 doesn't give a finger but a wrongly styled dynamics glyph

Resolves: #15170 for 3.x