### PR TITLE
Fix losing spaces when in-between symbols

### DIFF
--- a/libmscore/textbase.cpp
+++ b/libmscore/textbase.cpp
@@ -213,7 +213,8 @@ void TextCursor::updateCursorFormat()
       {
       TextBlock* block = &_text->_layout[_row];
       int col = hasSelection() ? selectColumn() : column();
-      const CharFormat* format = block->formatAt(col);
+      // Get format at the LEFT of the cursor position
+      const CharFormat* format = block->formatAt(std::max((col) -1, 0));
       if (!format || format->fontFamily() == "ScoreText")
             init();
       else


### PR DESCRIPTION
Backport of #17739

Resolves: #15629, although I'm not yet sure whether 3.x is affected by that in the first place