### PR TITLE
Use newer Qt version (5.15.9) on macOS

### DIFF
--- a/build/ci/macos/setup.sh
+++ b/build/ci/macos/setup.sh
@@ -86,12 +86,12 @@ installBottleManually libsndfile
 installBottleManually portaudio
 
 
-export QT_SHORT_VERSION=5.15.2
+export QT_SHORT_VERSION=5.15.9
 export QT_PATH=$HOME/Qt
 export QT_MACOS=$QT_PATH/$QT_SHORT_VERSION/clang_64
 export PATH=$PATH:$QT_MACOS/bin
 echo "PATH=$PATH" >> $GITHUB_ENV
-wget -nv -O qt5.zip https://s3.amazonaws.com/utils.musescore.org/Qt5152_mac.zip
+wget -nv -O qt5.zip https://s3.amazonaws.com/utils.musescore.org/Qt5159_mac.zip
 mkdir -p $QT_MACOS
 unzip -qq qt5.zip -d $QT_MACOS
 rm qt5.zip


### PR DESCRIPTION
Resolves: [musescore#16533](https://www.github.com/musescore/MuseScore/issues/16533)
Resolves: [musescore#17740](https://www.github.com/musescore/MuseScore/issues/17740)

Backport of #17772, needed as this branch also used Qt 5.15 and not 5.9 like 3.6.2 and earlier

Needs QWebEngine though, that so far isn't part of https://s3.amazonaws.com/utils.musescore.org/Qt5159_mac.zip
Edit: we no longer use/need that.