### PR TITLE
free disk space for MacOS CI compilation

### DIFF
--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -74,6 +74,12 @@ jobs:
         echo "DO_PUBLISH=$DO_PUBLISH" >> $GITHUB_ENV
         echo "DO_PUBLISH: $DO_PUBLISH"
     
+    - name: Free disk space
+      if: env.DO_BUILD == 'true'
+      run: |
+        sudo rm -rf "/Applications/Visual Studio.app"
+        sudo rm -rf "/Applications/Visual Studio 2019.app"
+        sudo rm -rf "/Users/runner/Library/Android/sdk"
     - name: Setup environment
       if: env.DO_BUILD == 'true'
       run: |

--- a/build/ci/macos/setup.sh
+++ b/build/ci/macos/setup.sh
@@ -16,8 +16,17 @@ rm bottles/freetype* | $SKIP_ERR_FLAG
 
 brew update >/dev/null | $SKIP_ERR_FLAG
 
-# fixing install python 3.9 error (it is a dependency for JACK)
+# fixing install python 3.11 error (it is a dependency for JACK)
 rm '/usr/local/bin/2to3'
+rm '/usr/local/bin/2to3-3.11'
+rm '/usr/local/bin/idle3'
+rm '/usr/local/bin/idle3.11'
+rm '/usr/local/bin/pydoc3'
+rm '/usr/local/bin/pydoc3.11'
+rm '/usr/local/bin/python3'
+rm '/usr/local/bin/python3.11'
+rm '/usr/local/bin/python3-config'
+rm '/usr/local/bin/python3.11-config'
 
 # additional dependencies
 brew install jack lame

--- a/build/package_mac
+++ b/build/package_mac
@@ -108,7 +108,7 @@ function change_rpath_QWebEngine() {
 rm ${WORKING_DIRECTORY}/${COMPRESSEDDMGNAME}
 
 #tip: increase the size if error on copy or macdeployqt
-hdiutil create -size 500m -fs HFS+ -volname ${VOLNAME} ${WORKING_DIRECTORY}/${DMGNAME}
+hdiutil create -size 800m -fs HFS+ -volname ${VOLNAME} ${WORKING_DIRECTORY}/${DMGNAME}
 
 # Mount the disk image
 hdiutil attach ${WORKING_DIRECTORY}/${DMGNAME}


### PR DESCRIPTION
Trying to solve the packaging problem with Qt5.15.2

Some softwares of the virtual machine not directly used for the compilation were deleted.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [ ] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
