### PR TITLE
Fix crash when exporting to MusicXML after toggling MMRests

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -2522,7 +2522,7 @@ Element* Score::move(const QString& cmd)
                   ftm = firstTrailingMeasure(&cr) ? firstTrailingMeasure(&cr) : lastMeasure();
             if (ftm) {
                   if (score()->styleB(Sid::createMultiMeasureRests) && ftm->hasMMRest())
-                        ftm = ftm->mmRest1();
+                        ftm = ftm->coveringMMRestOrThis();
                   el = !cr ? ftm->first()->nextChordRest(0, false) : ftm->first()->nextChordRest(trackZeroVoice(cr->track()), false);
                   }
             // Note: Due to the nature of this command as being preparatory for input,

--- a/libmscore/line.cpp
+++ b/libmscore/line.cpp
@@ -989,8 +989,9 @@ QPointF SLine::linePos(Grip grip, System** sys) const
                                     }
                               }
                         }
-                  if (score()->styleB(Sid::createMultiMeasureRests))
-                        m = m->mmRest1();
+
+                  m = m->coveringMMRestOrThis();
+
                   Q_ASSERT(m->system());
                   *sys = m->system();
                   }

--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -3367,13 +3367,18 @@ Measure* Measure::mmRestLast() const
       }
 
 //---------------------------------------------------------
-//   mmRest1
-//    return the multi measure rest this measure is covered
-//    by
+//   coveringMMRestOrThis
+//    if multi-measure rests are enabled,
+//        and this measure is covered by an MMRest,
+//            return that MMRest.
+//    otherwise, return the measure itself.
 //---------------------------------------------------------
 
-const Measure* Measure::mmRest1() const
+const Measure* Measure::coveringMMRestOrThis() const
       {
+      if (!score()->styleB(Sid::createMultiMeasureRests))
+            return this;
+
       if (_mmRest)
             return _mmRest;
       if (_mmRestCount != -1)

--- a/libmscore/measure.h
+++ b/libmscore/measure.h
@@ -251,7 +251,7 @@ class Measure final : public MeasureBase {
       bool hasMMRest() const        { return _mmRest != 0; }
       bool isMMRest() const         { return _mmRestCount > 0; }
       Measure* mmRest() const       { return _mmRest;      }
-      const Measure* mmRest1() const;
+      const Measure* coveringMMRestOrThis() const;
       void setMMRest(Measure* m)    { _mmRest = m;         }
       int mmRestCount() const       { return _mmRestCount; }    // number of measures _mmRest spans
       void setMMRestCount(int n)    { _mmRestCount = n;    }

--- a/libmscore/measurebase.cpp
+++ b/libmscore/measurebase.cpp
@@ -556,7 +556,7 @@ MeasureBase* MeasureBase::prevMM() const
       if (_prev
          && _prev->isMeasure()
          && score()->styleB(Sid::createMultiMeasureRests)) {
-            return const_cast<Measure*>(toMeasure(_prev)->mmRest1());
+            return const_cast<Measure*>(toMeasure(_prev)->coveringMMRestOrThis());
             }
       return _prev;
       }

--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -1708,12 +1708,7 @@ Measure* Score::lastMeasure() const
 Measure* Score::lastMeasureMM() const
       {
       Measure* m = lastMeasure();
-      if (m && styleB(Sid::createMultiMeasureRests)) {
-            Measure* m1 = const_cast<Measure*>(toMeasure(m->mmRest1()));
-            if (m1)
-                  return m1;
-            }
-      return m;
+      return m ? const_cast<Measure*>(m->coveringMMRestOrThis()) : nullptr;
       }
 
 //---------------------------------------------------------
@@ -4050,7 +4045,7 @@ ChordRest* Score::cmdNextPrevSystem(ChordRest* cr, bool next)
       {
       auto newCR = cr;
       auto currentMeasure = cr->measure();
-      auto currentSystem = currentMeasure->system() ? currentMeasure->system() : currentMeasure->mmRest1()->system();
+      auto currentSystem = currentMeasure->system() ? currentMeasure->system() : currentMeasure->coveringMMRestOrThis()->system();
       if (!currentSystem)
             return cr;
       auto destinationMeasure = currentSystem->firstMeasure();
@@ -4060,7 +4055,9 @@ ChordRest* Score::cmdNextPrevSystem(ChordRest* cr, bool next)
       if (next) {
             if ((destinationMeasure = currentSystem->lastMeasure()->nextMeasure())) {
                   // There is a next system present: get it and accommodate for MMRest
-                  currentSystem = destinationMeasure->system() ? destinationMeasure->system() : destinationMeasure->mmRest1()->system();
+                  currentSystem = destinationMeasure->system()
+                                  ? destinationMeasure->system()
+                                  : destinationMeasure->coveringMMRestOrThis()->system();
                   if ((destinationMeasure = currentSystem->firstMeasure()))
                         if ((newCR = destinationMeasure->first()->nextChordRest(trackZeroVoice(cr->track()), false)))
                               cr = newCR;
@@ -4089,7 +4086,9 @@ ChordRest* Score::cmdNextPrevSystem(ChordRest* cr, bool next)
                   if (!(destinationMeasure = destinationMeasure->prevMeasure()))
                         if (!(destinationMeasure = destinationMeasure->prevMeasureMM()))
                               return cr;
-                  if (!(currentSystem = destinationMeasure->system() ? destinationMeasure->system() : destinationMeasure->mmRest1()->system()))
+                  if (!(currentSystem = destinationMeasure->system()
+                                        ? destinationMeasure->system()
+                                        : destinationMeasure->coveringMMRestOrThis()->system()))
                         return cr;
                   destinationMeasure = currentSystem->firstMeasure();
                   }
@@ -4220,7 +4219,7 @@ Element* Score::getScoreElementOfMeasureBase(MeasureBase* mb) const
             else if ((currentMeasure = mb->findMeasure())) {
                   // Accommodate for MMRest
                   if (score()->styleB(Sid::createMultiMeasureRests) && currentMeasure->hasMMRest())
-                        currentMeasure = currentMeasure->mmRest1();
+                        currentMeasure = currentMeasure->coveringMMRestOrThis();
                   if ((cr = currentMeasure->first()->nextChordRest(0, false)))
                         el = cr;
                   }
@@ -4309,7 +4308,7 @@ ChordRest* Score::cmdTopStaff(ChordRest* cr)
       if (destinationMeasure) {
             // Accommodate for MMRest
             if (score()->styleB(Sid::createMultiMeasureRests) && destinationMeasure->hasMMRest())
-                  destinationMeasure = destinationMeasure->mmRest1();
+                  destinationMeasure = destinationMeasure->coveringMMRestOrThis();
             // Get first ChordRest of top staff
             cr = destinationMeasure->first()->nextChordRest(0, false);
             }

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -1462,7 +1462,7 @@ void ScoreView::paint(const QRect& r, QPainter& p)
                   // segment is in a measure that has not been laid out yet
                   // this can happen in mmrests
                   // first chordrest segment of mmrest instead
-                  const Measure* mmr = ss->measure()->mmRest1();
+                  const Measure* mmr = ss->measure()->coveringMMRestOrThis();
                   if (mmr && mmr->system())
                         ss = mmr->first(SegmentType::ChordRest);
                   else
@@ -1515,7 +1515,7 @@ void ScoreView::paint(const QRect& r, QPainter& p)
                   system2  = s->measure()->system();
                   if (!system2) {
                         // as before, use mmrest if necessary
-                        const Measure* mmr = s->measure()->mmRest1();
+                        const Measure* mmr = s->measure()->coveringMMRestOrThis();
                         if (mmr)
                               system2 = mmr->system();
                         if (!system2)


### PR DESCRIPTION
The problem: when MMRests are disabled, measures still keep a reference to their MMRest measure (in order to preserve that MMRest measure and its properties). This means that the `mmRest1` method might return this MMRest, even when MMRests are disabled (so the method would be expected to return the measure itself). This is fixed by checking inside that method if MMRests are actually enabled.

Additionally, this commit gives that method a slightly nicer name: `coveringMMRestOrThis()`.

Resolves: #17819, backport of #18038