### PR TITLE
Fix GH#15090: add annotations within tuplet consistent with non-tuplet segments

### DIFF
--- a/libmscore/range.cpp
+++ b/libmscore/range.cpp
@@ -77,6 +77,13 @@ void TrackList::appendTuplet(Tuplet* srcTuplet, Tuplet* dstTuplet)
                   Tuplet* dt = toTuplet(e);
                   appendTuplet(st, dt);
                   }
+            else if (de->parent() && de->parent()->isSegment()) {
+                  Segment* seg = toSegment(de->parent());
+                  for (Element* ee : seg->annotations()) {
+                        if (ee->track() == e->track())
+                              _range->annotations.push_back({ e->tick(), ee->clone() });
+                        }
+                  }
             }
       }
 


### PR DESCRIPTION
Backport of #15129

Resolves: #132
Came up in https://musescore.org/en/node/351689