### PR TITLE
Fix incorrect choice of accidentals on notes with same midi pitches on capx file import.

### DIFF
--- a/importexport/capella/capella.cpp
+++ b/importexport/capella/capella.cpp
@@ -793,7 +793,6 @@ static Fraction readCapVoice(Score* score, CapVoice* cvoice, int staffIdx, const
                               chord->add(note);
                               note->setPitch(pitch);
                               note->setHeadGroup(NoteHead::Group(n.headGroup));
-                              // TODO: compute tpc from pitch & line
                               note->setTpcFromPitch();
                               if (o->rightTie) {
                                     Tie* tie = new Tie(score);
@@ -967,6 +966,7 @@ static Fraction readCapVoice(Score* score, CapVoice* cvoice, int staffIdx, const
                   }
             }
       Fraction endTick = tick;
+      score->spell();   //Call respell-pitches to correct accidentals
 
       //
       // pass II

--- a/libmscore/pitchspelling.h
+++ b/libmscore/pitchspelling.h
@@ -36,7 +36,7 @@ enum {
       };
 #endif
 
-// a list of tpc's, with legal ranges, not really an enum, so no way to cnvert into a class
+// a list of tpc's, with legal ranges, not really an enum, so no way to convert into a class
 enum Tpc : signed char {
       TPC_INVALID = -9,
       TPC_F_BBB, TPC_C_BBB, TPC_G_BBB, TPC_D_BBB, TPC_A_BBB, TPC_E_BBB, TPC_B_BBB,

--- a/mtest/capella/io/test4.cap-ref.mscx
+++ b/mtest/capella/io/test4.cap-ref.mscx
@@ -54,7 +54,7 @@
             </TimeSig>
           <Beam>
             <l1>8</l1>
-            <l2>4</l2>
+            <l2>7</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>
@@ -84,10 +84,10 @@
             <durationType>eighth</durationType>
             <Note>
               <Accidental>
-                <subtype>accidentalFlat</subtype>
+                <subtype>accidentalSharp</subtype>
                 </Accidental>
               <pitch>63</pitch>
-              <tpc>11</tpc>
+              <tpc>23</tpc>
               </Note>
             </Chord>
           <Beam>
@@ -97,9 +97,6 @@
           <Chord>
             <durationType>eighth</durationType>
             <Note>
-              <Accidental>
-                <subtype>accidentalNatural</subtype>
-                </Accidental>
               <pitch>64</pitch>
               <tpc>18</tpc>
               </Note>
@@ -160,18 +157,15 @@
             <durationType>eighth</durationType>
             <Note>
               <Accidental>
-                <subtype>accidentalFlat</subtype>
+                <subtype>accidentalSharp</subtype>
                 </Accidental>
               <pitch>70</pitch>
-              <tpc>12</tpc>
+              <tpc>24</tpc>
               </Note>
             </Chord>
           <Chord>
             <durationType>eighth</durationType>
             <Note>
-              <Accidental>
-                <subtype>accidentalNatural</subtype>
-                </Accidental>
               <pitch>71</pitch>
               <tpc>19</tpc>
               </Note>

--- a/mtest/capella/io/test4.capx-ref.mscx
+++ b/mtest/capella/io/test4.capx-ref.mscx
@@ -54,7 +54,7 @@
             </TimeSig>
           <Beam>
             <l1>8</l1>
-            <l2>4</l2>
+            <l2>7</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>
@@ -84,10 +84,10 @@
             <durationType>eighth</durationType>
             <Note>
               <Accidental>
-                <subtype>accidentalFlat</subtype>
+                <subtype>accidentalSharp</subtype>
                 </Accidental>
               <pitch>63</pitch>
-              <tpc>11</tpc>
+              <tpc>23</tpc>
               </Note>
             </Chord>
           <Beam>
@@ -97,9 +97,6 @@
           <Chord>
             <durationType>eighth</durationType>
             <Note>
-              <Accidental>
-                <subtype>accidentalNatural</subtype>
-                </Accidental>
               <pitch>64</pitch>
               <tpc>18</tpc>
               </Note>
@@ -160,18 +157,15 @@
             <durationType>eighth</durationType>
             <Note>
               <Accidental>
-                <subtype>accidentalFlat</subtype>
+                <subtype>accidentalSharp</subtype>
                 </Accidental>
               <pitch>70</pitch>
-              <tpc>12</tpc>
+              <tpc>24</tpc>
               </Note>
             </Chord>
           <Chord>
             <durationType>eighth</durationType>
             <Note>
-              <Accidental>
-                <subtype>accidentalNatural</subtype>
-                </Accidental>
               <pitch>71</pitch>
               <tpc>19</tpc>
               </Note>

--- a/mtest/capella/io/test7.cap-ref.mscx
+++ b/mtest/capella/io/test7.cap-ref.mscx
@@ -405,8 +405,11 @@
           <Chord>
             <durationType>eighth</durationType>
             <Note>
+              <Accidental>
+                <subtype>accidentalFlat</subtype>
+                </Accidental>
               <pitch>61</pitch>
-              <tpc>21</tpc>
+              <tpc>9</tpc>
               </Note>
             </Chord>
           </voice>


### PR DESCRIPTION
(Back)port of #6032 resp. #20288, , plus adjusting 2 unit tests (both for test 4), which actually prove the fix right.

Resolves: https://musescore.org/en/node/304625 issue (b) (issue a) seems fixed in MusicXML import since long, but still exists in Capella import)