### PR TITLE
Fix warnings

### DIFF
--- a/importexport/midiimport/importmidi_quant.cpp
+++ b/importexport/midiimport/importmidi_quant.cpp
@@ -743,7 +743,7 @@ bool areTupletChordsConsistent(
       {
       auto it = chords.begin();
       const bool isInTuplet = (*it)->second.isInTuplet;
-      for (std::next(it); it != chords.end(); ++it) {
+      for ((void)std::next(it); it != chords.end(); ++it) {
             if (isInTuplet && (!(*it)->second.isInTuplet
                                || (*it)->second.tuplet != (*chords.begin())->second.tuplet)) {
                   return false;

--- a/importexport/musicxml/exportxml.cpp
+++ b/importexport/musicxml/exportxml.cpp
@@ -2181,14 +2181,14 @@ void ExportMusicXml::keysig(const KeySig* ks, ClefType ct, int staff, bool visib
                   int step = (po - line) % 7;
                   _xml.tag("key-step", QString(QChar(table2[step])));
                   _xml.tag("key-alter", accSymId2alter(ksym.sym));
-                  QString tagName = "key-accidental";
+                  QString tag = "key-accidental";
                   QString s = accSymId2MxmlString(ksym.sym);
                   //qDebug(" keysym sym %d spos %g,%g pos %g,%g -> line %d step %d s '%s' name '%s'",
                   //       static_cast<int>(ksym.sym), ksym.spos.x(), ksym.spos.y(), ksym.pos.x(), ksym.pos.y(),
                   //       line, step, qPrintable(s), Sym::id2name(ksym.sym));
                   if (s == "other")
-                        tagName += QString(" smufl=\"%1\"").arg(Sym::id2name(ksym.sym));
-                  _xml.tag(tagName, s);
+                        tag += QString(" smufl=\"%1\"").arg(Sym::id2name(ksym.sym));
+                  _xml.tag(tag, s);
                   }
             }
       else {

--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -4189,8 +4189,8 @@ void Score::cmdApplyInputState()
       // apply accidental state
       AccidentalType acc = _is.accidentalType();
       if (acc != AccidentalType::NONE && e->isNote()) {
-            Note* n = toNote(e);
-            n->setAccidentalType(acc);
+            Note* no = toNote(e);
+            no->setAccidentalType(acc);
             _is.setAccidentalType(AccidentalType::NONE);
             }
 

--- a/libmscore/realizedharmony.h
+++ b/libmscore/realizedharmony.h
@@ -67,13 +67,13 @@ class RealizedHarmony {
 
       PitchMap _notes;
 
-      Voicing _voicing;
-      HDuration _duration;
+      Voicing _voicing = Voicing::INVALID;
+      HDuration _duration = HDuration::INVALID;
 
       //whether or not the current notes QMap is up to date
       bool _dirty;
 
-      bool _literal; //use all notes when possible and do not add any notes
+      bool _literal = false; //use all notes when possible and do not add any notes
 
    public:
       RealizedHarmony() : _harmony(0), _notes(PitchMap()), _dirty(1) {}

--- a/libmscore/scorefile.cpp
+++ b/libmscore/scorefile.cpp
@@ -868,14 +868,14 @@ Score::FileError MasterScore::loadCompressedMsc(QIODevice* io, bool ignoreVersio
 
       QByteArray sbuf = uz.fileData("score_style.mss"); // exists in Mu4 scores only
       if (!sbuf.isEmpty()) {
-            XmlReader e(sbuf);
-            while (e.readNextStartElement()) {
-                  if (e.name() == "museScore") {
-                        while (e.readNextStartElement()) {
-                              if (e.name() == "Style")
-                                    masterScore()->style().load(e);
+            XmlReader el(sbuf);
+            while (el.readNextStartElement()) {
+                  if (el.name() == "museScore") {
+                        while (el.readNextStartElement()) {
+                              if (el.name() == "Style")
+                                    masterScore()->style().load(el);
                               else
-                                    e.unknown();
+                                    el.unknown();
                               }
                         }
                   }

--- a/share/locale/mscore_af.ts
+++ b/share/locale/mscore_af.ts
@@ -13169,7 +13169,7 @@ oop te maak, het misluk: %2</translation>
         <translation>Ionies</translation>
     </message>
     <message>
-        <location filename="../../mscore/inspector/inspector.cpp" line="997"/>
+        <location filename="../../mscore/inspector/inspector.cpp" line="998"/>
         <source>Locrian</source>
         <translation>Lokries</translation>
     </message>

--- a/share/locale/mscore_ar.ts
+++ b/share/locale/mscore_ar.ts
@@ -13175,7 +13175,7 @@ failed: %2</translation>
         <translation>Ionian</translation>
     </message>
     <message>
-        <location filename="../../mscore/inspector/inspector.cpp" line="997"/>
+        <location filename="../../mscore/inspector/inspector.cpp" line="998"/>
         <source>Locrian</source>
         <translation>Locrian</translation>
     </message>

--- a/share/locale/mscore_ar_DZ.ts
+++ b/share/locale/mscore_ar_DZ.ts
@@ -13030,7 +13030,7 @@ failed: %2</source>
     </message>
     <message>
         <location filename="../../mscore/inspector/inspector.cpp" line="996"/>
-        <source>Ionian</source>
+        <source>Aeolian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/share/locale/mscore_ar_EG.ts
+++ b/share/locale/mscore_ar_EG.ts
@@ -13043,7 +13043,7 @@ failed: %2</source>
     </message>
     <message>
         <location filename="../../mscore/inspector/inspector.cpp" line="996"/>
-        <source>Ionian</source>
+        <source>Aeolian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/share/locale/mscore_ar_SD.ts
+++ b/share/locale/mscore_ar_SD.ts
@@ -13175,7 +13175,7 @@ failed: %2</translation>
         <translation>Ionian</translation>
     </message>
     <message>
-        <location filename="../../mscore/inspector/inspector.cpp" line="997"/>
+        <location filename="../../mscore/inspector/inspector.cpp" line="998"/>
         <source>Locrian</source>
         <translation>Locrian</translation>
     </message>

--- a/share/locale/mscore_be.ts
+++ b/share/locale/mscore_be.ts
@@ -13082,7 +13082,7 @@ failed: %2</source>
     </message>
     <message>
         <location filename="../../mscore/inspector/inspector.cpp" line="996"/>
-        <source>Ionian</source>
+        <source>Aeolian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/share/locale/mscore_bg.ts
+++ b/share/locale/mscore_bg.ts
@@ -13043,7 +13043,7 @@ failed: %2</source>
     </message>
     <message>
         <location filename="../../mscore/inspector/inspector.cpp" line="996"/>
-        <source>Ionian</source>
+        <source>Aeolian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/share/locale/mscore_br.ts
+++ b/share/locale/mscore_br.ts
@@ -13037,7 +13037,7 @@ failed: %2</source>
     </message>
     <message>
         <location filename="../../mscore/inspector/inspector.cpp" line="996"/>
-        <source>Ionian</source>
+        <source>Aeolian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/share/locale/mscore_ca.ts
+++ b/share/locale/mscore_ca.ts
@@ -13176,7 +13176,7 @@ error: %2</translation>
         <translation>Jònic</translation>
     </message>
     <message>
-        <location filename="../../mscore/inspector/inspector.cpp" line="997"/>
+        <location filename="../../mscore/inspector/inspector.cpp" line="998"/>
         <source>Locrian</source>
         <translation>Locri</translation>
     </message>

--- a/share/locale/mscore_ca@valencia.ts
+++ b/share/locale/mscore_ca@valencia.ts
@@ -13143,7 +13143,7 @@ en obrir el fitxer
         <translation>Jònic</translation>
     </message>
     <message>
-        <location filename="../../mscore/inspector/inspector.cpp" line="997"/>
+        <location filename="../../mscore/inspector/inspector.cpp" line="998"/>
         <source>Locrian</source>
         <translation>Locri</translation>
     </message>

--- a/share/locale/mscore_cs.ts
+++ b/share/locale/mscore_cs.ts
@@ -13180,7 +13180,7 @@ se nezdařilo: %2</translation>
         <translation>Jónský</translation>
     </message>
     <message>
-        <location filename="../../mscore/inspector/inspector.cpp" line="997"/>
+        <location filename="../../mscore/inspector/inspector.cpp" line="998"/>
         <source>Locrian</source>
         <translation>Lokrický</translation>
     </message>

--- a/share/locale/mscore_cy.ts
+++ b/share/locale/mscore_cy.ts
@@ -13084,7 +13084,7 @@ methodd: %2</translation>
     </message>
     <message>
         <location filename="../../mscore/inspector/inspector.cpp" line="996"/>
-        <source>Ionian</source>
+        <source>Aeolian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/share/locale/mscore_da.ts
+++ b/share/locale/mscore_da.ts
@@ -13173,7 +13173,7 @@ slog fejl: %2</translation>
         <translation>Jonisk</translation>
     </message>
     <message>
-        <location filename="../../mscore/inspector/inspector.cpp" line="997"/>
+        <location filename="../../mscore/inspector/inspector.cpp" line="998"/>
         <source>Locrian</source>
         <translation>Lokrisk</translation>
     </message>

--- a/share/locale/mscore_de.ts
+++ b/share/locale/mscore_de.ts
@@ -13189,7 +13189,7 @@ fehlgeschlagen: %2</translation>
         <translation>Ionisch</translation>
     </message>
     <message>
-        <location filename="../../mscore/inspector/inspector.cpp" line="997"/>
+        <location filename="../../mscore/inspector/inspector.cpp" line="998"/>
         <source>Locrian</source>
         <translation>Lokrisch</translation>
     </message>

--- a/share/locale/mscore_el.ts
+++ b/share/locale/mscore_el.ts
@@ -13162,7 +13162,7 @@ failed: %2</source>
         <translation>Ιωνικός</translation>
     </message>
     <message>
-        <location filename="../../mscore/inspector/inspector.cpp" line="997"/>
+        <location filename="../../mscore/inspector/inspector.cpp" line="998"/>
         <source>Locrian</source>
         <translation>Λοκρικός</translation>
     </message>

--- a/share/locale/mscore_en.ts
+++ b/share/locale/mscore_en.ts
@@ -13175,7 +13175,7 @@ failed: %2</translation>
         <translation>Ionian</translation>
     </message>
     <message>
-        <location filename="../../mscore/inspector/inspector.cpp" line="997"/>
+        <location filename="../../mscore/inspector/inspector.cpp" line="998"/>
         <source>Locrian</source>
         <translation>Locrian</translation>
     </message>

--- a/share/locale/mscore_en_GB.ts
+++ b/share/locale/mscore_en_GB.ts
@@ -13189,7 +13189,7 @@ failed: %2</translation>
         <translation>Ionian</translation>
     </message>
     <message>
-        <location filename="../../mscore/inspector/inspector.cpp" line="997"/>
+        <location filename="../../mscore/inspector/inspector.cpp" line="998"/>
         <source>Locrian</source>
         <translation>Locrian</translation>
     </message>

--- a/share/locale/mscore_en_US.ts
+++ b/share/locale/mscore_en_US.ts
@@ -13096,7 +13096,7 @@ failed: %2</source>
     </message>
     <message>
         <location filename="../../mscore/inspector/inspector.cpp" line="996"/>
-        <source>Ionian</source>
+        <source>Aeolian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/share/locale/mscore_eo.ts
+++ b/share/locale/mscore_eo.ts
@@ -13054,7 +13054,7 @@ failed: %2</source>
     </message>
     <message>
         <location filename="../../mscore/inspector/inspector.cpp" line="996"/>
-        <source>Ionian</source>
+        <source>Aeolian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/share/locale/mscore_es.ts
+++ b/share/locale/mscore_es.ts
@@ -13176,7 +13176,7 @@ falló: %2</translation>
         <translation>Jónico</translation>
     </message>
     <message>
-        <location filename="../../mscore/inspector/inspector.cpp" line="997"/>
+        <location filename="../../mscore/inspector/inspector.cpp" line="998"/>
         <source>Locrian</source>
         <translation>Locriano</translation>
     </message>

--- a/share/locale/mscore_et.ts
+++ b/share/locale/mscore_et.ts
@@ -13116,7 +13116,7 @@ avamine ebaõnnestus: %2</translation>
         <translation>Ioonia</translation>
     </message>
     <message>
-        <location filename="../../mscore/inspector/inspector.cpp" line="997"/>
+        <location filename="../../mscore/inspector/inspector.cpp" line="998"/>
         <source>Locrian</source>
         <translation type="unfinished"></translation>
     </message>

--- a/share/locale/mscore_eu.ts
+++ b/share/locale/mscore_eu.ts
@@ -13165,7 +13165,7 @@ huts egin du: %2</translation>
         <translation>Joniar</translation>
     </message>
     <message>
-        <location filename="../../mscore/inspector/inspector.cpp" line="997"/>
+        <location filename="../../mscore/inspector/inspector.cpp" line="998"/>
         <source>Locrian</source>
         <translation>Lokrio</translation>
     </message>

--- a/share/locale/mscore_fa.ts
+++ b/share/locale/mscore_fa.ts
@@ -13050,7 +13050,7 @@ failed: %2</source>
     </message>
     <message>
         <location filename="../../mscore/inspector/inspector.cpp" line="996"/>
-        <source>Ionian</source>
+        <source>Aeolian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/share/locale/mscore_fi.ts
+++ b/share/locale/mscore_fi.ts
@@ -13140,7 +13140,7 @@ avaaminen epäonnistui: %2</translation>
         <translation>Jooninen</translation>
     </message>
     <message>
-        <location filename="../../mscore/inspector/inspector.cpp" line="997"/>
+        <location filename="../../mscore/inspector/inspector.cpp" line="998"/>
         <source>Locrian</source>
         <translation>Lokrinen</translation>
     </message>

--- a/share/locale/mscore_fil.ts
+++ b/share/locale/mscore_fil.ts
@@ -13080,7 +13080,7 @@ nabigo: %2</translation>
     </message>
     <message>
         <location filename="../../mscore/inspector/inspector.cpp" line="996"/>
-        <source>Ionian</source>
+        <source>Aeolian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/share/locale/mscore_fo.ts
+++ b/share/locale/mscore_fo.ts
@@ -13180,7 +13180,7 @@ miseydnað: %2</translation>
         <translation>Ioniskur</translation>
     </message>
     <message>
-        <location filename="../../mscore/inspector/inspector.cpp" line="997"/>
+        <location filename="../../mscore/inspector/inspector.cpp" line="998"/>
         <source>Locrian</source>
         <translation>Lokriskur</translation>
     </message>

--- a/share/locale/mscore_fr.ts
+++ b/share/locale/mscore_fr.ts
@@ -13174,7 +13174,7 @@ a échoué : %2</translation>
         <translation>Ionien</translation>
     </message>
     <message>
-        <location filename="../../mscore/inspector/inspector.cpp" line="997"/>
+        <location filename="../../mscore/inspector/inspector.cpp" line="998"/>
         <source>Locrian</source>
         <translation>Locrien</translation>
     </message>

--- a/share/locale/mscore_ga.ts
+++ b/share/locale/mscore_ga.ts
@@ -13058,7 +13058,7 @@ failed: %2</source>
     </message>
     <message>
         <location filename="../../mscore/inspector/inspector.cpp" line="996"/>
-        <source>Ionian</source>
+        <source>Aeolian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/share/locale/mscore_gd.ts
+++ b/share/locale/mscore_gd.ts
@@ -13103,7 +13103,7 @@ fhosgladh: %2</translation>
     </message>
     <message>
         <location filename="../../mscore/inspector/inspector.cpp" line="996"/>
-        <source>Ionian</source>
+        <source>Aeolian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/share/locale/mscore_gl.ts
+++ b/share/locale/mscore_gl.ts
@@ -13167,7 +13167,7 @@ o ficheiro %1: %2</translation>
         <translation>Xonia</translation>
     </message>
     <message>
-        <location filename="../../mscore/inspector/inspector.cpp" line="997"/>
+        <location filename="../../mscore/inspector/inspector.cpp" line="998"/>
         <source>Locrian</source>
         <translation>Locria</translation>
     </message>

--- a/share/locale/mscore_he.ts
+++ b/share/locale/mscore_he.ts
@@ -13103,7 +13103,7 @@ failed: %2</source>
     </message>
     <message>
         <location filename="../../mscore/inspector/inspector.cpp" line="996"/>
-        <source>Ionian</source>
+        <source>Aeolian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/share/locale/mscore_hi_IN.ts
+++ b/share/locale/mscore_hi_IN.ts
@@ -13034,7 +13034,7 @@ failed: %2</source>
     </message>
     <message>
         <location filename="../../mscore/inspector/inspector.cpp" line="996"/>
-        <source>Ionian</source>
+        <source>Aeolian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/share/locale/mscore_hr.ts
+++ b/share/locale/mscore_hr.ts
@@ -13051,7 +13051,7 @@ failed: %2</source>
     </message>
     <message>
         <location filename="../../mscore/inspector/inspector.cpp" line="996"/>
-        <source>Ionian</source>
+        <source>Aeolian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/share/locale/mscore_hu.ts
+++ b/share/locale/mscore_hu.ts
@@ -13179,7 +13179,7 @@ nem sikerült: %2</translation>
         <translation>Ión</translation>
     </message>
     <message>
-        <location filename="../../mscore/inspector/inspector.cpp" line="997"/>
+        <location filename="../../mscore/inspector/inspector.cpp" line="998"/>
         <source>Locrian</source>
         <translation>Lokriszi</translation>
     </message>

--- a/share/locale/mscore_hy.ts
+++ b/share/locale/mscore_hy.ts
@@ -13155,7 +13155,7 @@ failed: %2</source>
     </message>
     <message>
         <location filename="../../mscore/inspector/inspector.cpp" line="996"/>
-        <source>Ionian</source>
+        <source>Aeolian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/share/locale/mscore_id.ts
+++ b/share/locale/mscore_id.ts
@@ -13047,7 +13047,7 @@ failed: %2</source>
     </message>
     <message>
         <location filename="../../mscore/inspector/inspector.cpp" line="996"/>
-        <source>Ionian</source>
+        <source>Aeolian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/share/locale/mscore_it.ts
+++ b/share/locale/mscore_it.ts
@@ -13184,7 +13184,7 @@ fallita: %2</translation>
         <translation>Ionio</translation>
     </message>
     <message>
-        <location filename="../../mscore/inspector/inspector.cpp" line="997"/>
+        <location filename="../../mscore/inspector/inspector.cpp" line="998"/>
         <source>Locrian</source>
         <translation>Locrio</translation>
     </message>

--- a/share/locale/mscore_ja.ts
+++ b/share/locale/mscore_ja.ts
@@ -13178,7 +13178,7 @@ failed: %2</source>
         <translation>アイオニアン</translation>
     </message>
     <message>
-        <location filename="../../mscore/inspector/inspector.cpp" line="997"/>
+        <location filename="../../mscore/inspector/inspector.cpp" line="998"/>
         <source>Locrian</source>
         <translation>ロクリアン</translation>
     </message>

--- a/share/locale/mscore_ka.ts
+++ b/share/locale/mscore_ka.ts
@@ -13043,7 +13043,7 @@ failed: %2</source>
     </message>
     <message>
         <location filename="../../mscore/inspector/inspector.cpp" line="996"/>
-        <source>Ionian</source>
+        <source>Aeolian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/share/locale/mscore_ko.ts
+++ b/share/locale/mscore_ko.ts
@@ -13144,7 +13144,7 @@ failed: %2</source>
         <translation>아이오니안</translation>
     </message>
     <message>
-        <location filename="../../mscore/inspector/inspector.cpp" line="997"/>
+        <location filename="../../mscore/inspector/inspector.cpp" line="998"/>
         <source>Locrian</source>
         <translation>로크리안</translation>
     </message>

--- a/share/locale/mscore_lt.ts
+++ b/share/locale/mscore_lt.ts
@@ -13086,7 +13086,7 @@ failed: %2</source>
     </message>
     <message>
         <location filename="../../mscore/inspector/inspector.cpp" line="996"/>
-        <source>Ionian</source>
+        <source>Aeolian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/share/locale/mscore_lv.ts
+++ b/share/locale/mscore_lv.ts
@@ -13030,7 +13030,7 @@ failed: %2</source>
     </message>
     <message>
         <location filename="../../mscore/inspector/inspector.cpp" line="996"/>
-        <source>Ionian</source>
+        <source>Aeolian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/share/locale/mscore_ml.ts
+++ b/share/locale/mscore_ml.ts
@@ -13030,7 +13030,7 @@ failed: %2</source>
     </message>
     <message>
         <location filename="../../mscore/inspector/inspector.cpp" line="996"/>
-        <source>Ionian</source>
+        <source>Aeolian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/share/locale/mscore_mn_MN.ts
+++ b/share/locale/mscore_mn_MN.ts
@@ -13046,7 +13046,7 @@ failed: %2</source>
     </message>
     <message>
         <location filename="../../mscore/inspector/inspector.cpp" line="996"/>
-        <source>Ionian</source>
+        <source>Aeolian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/share/locale/mscore_nb.ts
+++ b/share/locale/mscore_nb.ts
@@ -13166,7 +13166,7 @@ feilet: %2</translation>
         <translation>Jonisk</translation>
     </message>
     <message>
-        <location filename="../../mscore/inspector/inspector.cpp" line="997"/>
+        <location filename="../../mscore/inspector/inspector.cpp" line="998"/>
         <source>Locrian</source>
         <translation>Lokrisk</translation>
     </message>

--- a/share/locale/mscore_nl.ts
+++ b/share/locale/mscore_nl.ts
@@ -13180,7 +13180,7 @@ mislukt: %2</translation>
         <translation>Ionisch</translation>
     </message>
     <message>
-        <location filename="../../mscore/inspector/inspector.cpp" line="997"/>
+        <location filename="../../mscore/inspector/inspector.cpp" line="998"/>
         <source>Locrian</source>
         <translation>Locrisch</translation>
     </message>

--- a/share/locale/mscore_nn.ts
+++ b/share/locale/mscore_nn.ts
@@ -13083,7 +13083,7 @@ failed: %2</source>
     </message>
     <message>
         <location filename="../../mscore/inspector/inspector.cpp" line="996"/>
-        <source>Ionian</source>
+        <source>Aeolian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/share/locale/mscore_pl.ts
+++ b/share/locale/mscore_pl.ts
@@ -13180,7 +13180,7 @@ zakończone niepowodzeniem: %2.</translation>
         <translation>joński</translation>
     </message>
     <message>
-        <location filename="../../mscore/inspector/inspector.cpp" line="997"/>
+        <location filename="../../mscore/inspector/inspector.cpp" line="998"/>
         <source>Locrian</source>
         <translation>lokrycki</translation>
     </message>

--- a/share/locale/mscore_pt.ts
+++ b/share/locale/mscore_pt.ts
@@ -13099,7 +13099,7 @@ failed: %2</source>
     </message>
     <message>
         <location filename="../../mscore/inspector/inspector.cpp" line="996"/>
-        <source>Ionian</source>
+        <source>Aeolian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/share/locale/mscore_pt_BR.ts
+++ b/share/locale/mscore_pt_BR.ts
@@ -13181,7 +13181,7 @@ falhou: %2</translation>
         <translation>Jônio</translation>
     </message>
     <message>
-        <location filename="../../mscore/inspector/inspector.cpp" line="997"/>
+        <location filename="../../mscore/inspector/inspector.cpp" line="998"/>
         <source>Locrian</source>
         <translation>Lócrio</translation>
     </message>

--- a/share/locale/mscore_ro.ts
+++ b/share/locale/mscore_ro.ts
@@ -13083,7 +13083,7 @@ a eșuat: %2</translation>
     </message>
     <message>
         <location filename="../../mscore/inspector/inspector.cpp" line="996"/>
-        <source>Ionian</source>
+        <source>Aeolian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/share/locale/mscore_ru.ts
+++ b/share/locale/mscore_ru.ts
@@ -13184,7 +13184,7 @@ failed: %2</source>
         <translation>Ионийский</translation>
     </message>
     <message>
-        <location filename="../../mscore/inspector/inspector.cpp" line="997"/>
+        <location filename="../../mscore/inspector/inspector.cpp" line="998"/>
         <source>Locrian</source>
         <translation>Локрийский</translation>
     </message>

--- a/share/locale/mscore_sk.ts
+++ b/share/locale/mscore_sk.ts
@@ -13095,7 +13095,7 @@ zlyhalo: %2</translation>
     </message>
     <message>
         <location filename="../../mscore/inspector/inspector.cpp" line="996"/>
-        <source>Ionian</source>
+        <source>Aeolian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/share/locale/mscore_sl.ts
+++ b/share/locale/mscore_sl.ts
@@ -13179,7 +13179,7 @@ je spodletelo: %2</translation>
         <translation>Jonski</translation>
     </message>
     <message>
-        <location filename="../../mscore/inspector/inspector.cpp" line="997"/>
+        <location filename="../../mscore/inspector/inspector.cpp" line="998"/>
         <source>Locrian</source>
         <translation>Lokrijski</translation>
     </message>

--- a/share/locale/mscore_sr.ts
+++ b/share/locale/mscore_sr.ts
@@ -13050,7 +13050,7 @@ failed: %2</source>
     </message>
     <message>
         <location filename="../../mscore/inspector/inspector.cpp" line="996"/>
-        <source>Ionian</source>
+        <source>Aeolian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/share/locale/mscore_sr_RS.ts
+++ b/share/locale/mscore_sr_RS.ts
@@ -13070,7 +13070,7 @@ failed: %2</source>
     </message>
     <message>
         <location filename="../../mscore/inspector/inspector.cpp" line="996"/>
-        <source>Ionian</source>
+        <source>Aeolian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/share/locale/mscore_sv.ts
+++ b/share/locale/mscore_sv.ts
@@ -13180,7 +13180,7 @@ failed: %2</source>
         <translation>Jonisk</translation>
     </message>
     <message>
-        <location filename="../../mscore/inspector/inspector.cpp" line="997"/>
+        <location filename="../../mscore/inspector/inspector.cpp" line="998"/>
         <source>Locrian</source>
         <translation>Lokrisk</translation>
     </message>

--- a/share/locale/mscore_th.ts
+++ b/share/locale/mscore_th.ts
@@ -13045,7 +13045,7 @@ failed: %2</source>
     </message>
     <message>
         <location filename="../../mscore/inspector/inspector.cpp" line="996"/>
-        <source>Ionian</source>
+        <source>Aeolian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/share/locale/mscore_tr.ts
+++ b/share/locale/mscore_tr.ts
@@ -13176,7 +13176,7 @@ başarısız: %2</translation>
         <translation>Ionian</translation>
     </message>
     <message>
-        <location filename="../../mscore/inspector/inspector.cpp" line="997"/>
+        <location filename="../../mscore/inspector/inspector.cpp" line="998"/>
         <source>Locrian</source>
         <translation>Locrian</translation>
     </message>

--- a/share/locale/mscore_uk.ts
+++ b/share/locale/mscore_uk.ts
@@ -13087,7 +13087,7 @@ failed: %2</source>
     </message>
     <message>
         <location filename="../../mscore/inspector/inspector.cpp" line="996"/>
-        <source>Ionian</source>
+        <source>Aeolian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/share/locale/mscore_uz@Latn.ts
+++ b/share/locale/mscore_uz@Latn.ts
@@ -13030,7 +13030,7 @@ failed: %2</source>
     </message>
     <message>
         <location filename="../../mscore/inspector/inspector.cpp" line="996"/>
-        <source>Ionian</source>
+        <source>Aeolian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/share/locale/mscore_vi.ts
+++ b/share/locale/mscore_vi.ts
@@ -13122,7 +13122,7 @@ báo lỗi: %2</translation>
     </message>
     <message>
         <location filename="../../mscore/inspector/inspector.cpp" line="996"/>
-        <source>Ionian</source>
+        <source>Aeolian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/share/locale/mscore_zh_CN.ts
+++ b/share/locale/mscore_zh_CN.ts
@@ -13176,7 +13176,7 @@ failed: %2</source>
         <translation>伊奥尼亚调式</translation>
     </message>
     <message>
-        <location filename="../../mscore/inspector/inspector.cpp" line="997"/>
+        <location filename="../../mscore/inspector/inspector.cpp" line="998"/>
         <source>Locrian</source>
         <translation>洛克利亚调式</translation>
     </message>

--- a/share/locale/mscore_zh_HK.ts
+++ b/share/locale/mscore_zh_HK.ts
@@ -13142,7 +13142,7 @@ failed: %2</source>
         <translation>伊奧尼亞調式</translation>
     </message>
     <message>
-        <location filename="../../mscore/inspector/inspector.cpp" line="997"/>
+        <location filename="../../mscore/inspector/inspector.cpp" line="998"/>
         <source>Locrian</source>
         <translation>洛克利亞調式</translation>
     </message>

--- a/share/locale/mscore_zh_TW.ts
+++ b/share/locale/mscore_zh_TW.ts
@@ -13155,7 +13155,7 @@ failed: %2</source>
         <translation>伊奧尼亞調式</translation>
     </message>
     <message>
-        <location filename="../../mscore/inspector/inspector.cpp" line="997"/>
+        <location filename="../../mscore/inspector/inspector.cpp" line="998"/>
         <source>Locrian</source>
         <translation>洛克利亞調式</translation>
     </message>


### PR DESCRIPTION
* Fix MSVC compiler warnings
    * reg. declaration hides previous local declaration (C4456)
    * reg. discarding return value of function with 'nodiscard' attribute (C4834)
* Fix lrelease warnings reg. duplicate entries
* Fix gcc compiler warnings reg. variable is used uninitialized in this function [-Wuninitialized]