### PR TITLE
Hairpins, ottavas, voltas, pedal, let ring and palm mute lines can get lost on Mu4 mscz import, hairpins loose their custom line style

### DIFF
--- a/libmscore/hairpin.cpp
+++ b/libmscore/hairpin.cpp
@@ -694,6 +694,19 @@ void Hairpin::read(XmlReader& e)
             const QStringRef& tag(e.name());
             if (tag == "subtype")
                   setHairpinType(HairpinType(e.readInt()));
+            else if (tag == "lineStyle" && score()->mscVersion() > MSCVERSION) { // 4.x compat
+                  QString lineStyle = e.readElementText();
+                  if (lineStyle == "dashed") { // closest guesses, better than loosing them entirely
+                        if (isLineType())
+                              setLineStyle(Qt::CustomDashLine);
+                        else
+                              setLineStyle(Qt::DashLine);
+                        }
+                  else if (lineStyle == "dotted")
+                        setLineStyle(Qt::DotLine);
+                  else
+                        setLineStyle(Qt::SolidLine);
+                  }
             else if (readStyledProperty(e, tag))
                   ;
             else if (tag == "hairpinCircledTip")

--- a/libmscore/line.cpp
+++ b/libmscore/line.cpp
@@ -1312,10 +1312,10 @@ bool SLine::readProperties(XmlReader& e)
       else if (tag == "lineStyle")
             if (score()->mscVersion() > MSCVERSION) { // 4.x compat
                   QString lineStyle = e.readElementText();
-                  if (lineStyle == "dotted")
-                        _lineStyle = Qt::DotLine;
-                  else if (lineStyle == "dashed")
+                  if (lineStyle == "dashed")
                         _lineStyle = Qt::DashLine;
+                  else if (lineStyle == "dotted")
+                        _lineStyle = Qt::DotLine;
                   else
                         _lineStyle = Qt::SolidLine;
                   }

--- a/libmscore/style.cpp
+++ b/libmscore/style.cpp
@@ -3050,16 +3050,72 @@ void MStyle::load(XmlReader& e)
                   _customChordList = true;
                   chordListTag = true;
                   }
-            else if (tag == "lyricsDashMaxLegth") // pre-3.6 typo
+            else if (tag == "lyricsDashMaxLegth") // pre-3.6 typo, now: "lyricsDashMaxLength"
                   set(Sid::lyricsDashMaxLength, e.readDouble());
-            else if (tag == "dontHideStavesInFirstSystem") // pre-4.0 typo
-                  set(Sid::dontHideStavesInFirstSystem, e.readBool());
-            else if (tag == "useWideBeams") // beamDistance maps to useWideBeams in 4.0
-                  set(Sid::beamDistance, e.readDouble() > 0.75);
-            else if (tag == "pedalLineStyle") // pre-4.0 typo
-                  set(Sid::pedalLineStyle, e.readInt());
+// start 4.x compat
             else if (tag == "chordlineThickness") // Ignoring pre-4.1 value as it was wrong (it wasn't user-editable anyway)
                   e.skipCurrentElement();
+            else if (tag == "dontHideStavesInFirstSystem") // pre-4.0 typo: "dontHidStavesInFirstSystm"
+                  set(Sid::dontHideStavesInFirstSystem, e.readBool());
+            else if (tag == "hairpinLineStyle") {
+                  int _lineStyle = Qt::SolidLine;
+                  QString lineStyle = e.readElementText();
+                  if (lineStyle == "dotted")
+                        _lineStyle = Qt::DotLine;
+                  else if (lineStyle == "dashed")
+                        _lineStyle = Qt::DashLine;
+                  set(Sid::hairpinLineStyle, _lineStyle);
+                  }
+            else if (tag == "hairpinLineLineStyle") {
+                  int _lineStyle = Qt::CustomDashLine;
+                  QString lineStyle = e.readElementText();
+                  if (lineStyle == "dotted")
+                        _lineStyle = Qt::DotLine;
+                  else if (lineStyle == "solid")
+                        _lineStyle = Qt::SolidLine;
+                  set(Sid::hairpinLineLineStyle, _lineStyle);
+                  }
+            else if (tag == "letRingLineStyle") {
+                  int _lineStyle = Qt::DashLine;
+                  QString lineStyle = e.readElementText();
+                  if (lineStyle == "dotted")
+                        _lineStyle = Qt::DotLine;
+                  else if (lineStyle == "solid")
+                        _lineStyle = Qt::SolidLine;
+                  set(Sid::letRingLineStyle, _lineStyle);
+                  }
+            else if (tag == "palmMuteLineStyle") {
+                  int _lineStyle = Qt::DashLine;
+                  QString lineStyle = e.readElementText();
+                  if (lineStyle == "dotted")
+                        _lineStyle = Qt::DotLine;
+                  else if (lineStyle == "solid")
+                        _lineStyle = Qt::SolidLine;
+                  set(Sid::palmMuteLineStyle, _lineStyle);
+                  }
+            else if (tag == "pedalLineStyle") { // pre-4.0 typo: "pedalListStyle"
+                  int _lineStyle = Qt::SolidLine;
+                  QString lineStyle = e.readElementText();
+                  if (lineStyle == "dotted")
+                        _lineStyle = Qt::DotLine;
+                  else if (lineStyle == "dashed")
+                        _lineStyle = Qt::DashLine;
+                  set(Sid::pedalLineStyle, _lineStyle);
+                  }
+            else if (tag == "useWideBeams") // beamDistance maps to useWideBeams in 4.0 and later
+                  set(Sid::beamDistance, e.readDouble() > 0.75);
+            else if (tag == "voltaLineStyle") {
+                  int _lineStyle = Qt::SolidLine;
+                  QString lineStyle = e.readElementText();
+                  if (lineStyle == "dotted")
+                        _lineStyle = Qt::DotLine;
+                  else if (lineStyle == "dashed")
+                        _lineStyle = Qt::DashLine;
+                  set(Sid::voltaLineStyle, _lineStyle);
+                  }
+            else if (tag == "tempoChangeLineStyle") // doesn't exist in Mu3
+                  e.skipCurrentElement();
+// end 4.x compat
             else if (!readProperties(e))
                   e.unknown();
             }


### PR DESCRIPTION
Resolves: #175. Actually their lines just just go invisible, having no line style at all. Same issue with newly added hairpins, voltas, ottavas let ring and palm mute lines

Also resolves #179 for harpins (for others it got fixed earlier already)