### PR TITLE
Corrected access key in Japanese translation

### DIFF
--- a/share/locale/mscore_ja.ts
+++ b/share/locale/mscore_ja.ts
@@ -14370,7 +14370,7 @@ Please select a measure and try again</source>
     <message>
         <location filename="../../mscore/musescore.cpp" line="2161"/>
         <source>N&amp;otes</source>
-        <translation>音符(&amp;O)</translation>
+        <translation>音符(&amp;N)</translation>
     </message>
     <message>
         <location filename="../../mscore/musescore.cpp" line="2162"/>


### PR DESCRIPTION
Reverts "音符(&O)" to "音符(&N)"