### PR TITLE
[MusicXML] Export system/page breaks along with the rest of the layout

### DIFF
--- a/mscore/exportdialog.cpp
+++ b/mscore/exportdialog.cpp
@@ -454,14 +454,22 @@ void ExportDialog::accept()
                   saveFormat = "xml";
             else
                   saveFormat = "mxl";
-            if (musicxmlExportAllLayout->isChecked() && !preferences.getBool(PREF_EXPORT_MUSICXML_EXPORTLAYOUT))
+            if (musicxmlExportAllLayout->isChecked() && !preferences.getBool(PREF_EXPORT_MUSICXML_EXPORTLAYOUT)) {
                   preferences.setPreference(PREF_EXPORT_MUSICXML_EXPORTLAYOUT, true);
-            else if (musicxmlExportAllBreaks->isChecked() && preferences.musicxmlExportBreaks() != MusicxmlExportBreaks::ALL)
                   preferences.setCustomPreference<MusicxmlExportBreaks>(PREF_EXPORT_MUSICXML_EXPORTBREAKS, MusicxmlExportBreaks::ALL);
-            else if (musicxmlExportManualBreaks->isChecked() && preferences.musicxmlExportBreaks() != MusicxmlExportBreaks::MANUAL)
+            }
+            else if (musicxmlExportAllBreaks->isChecked() && preferences.musicxmlExportBreaks() != MusicxmlExportBreaks::ALL) {
+                  preferences.setPreference(PREF_EXPORT_MUSICXML_EXPORTLAYOUT, false);
+                  preferences.setCustomPreference<MusicxmlExportBreaks>(PREF_EXPORT_MUSICXML_EXPORTBREAKS, MusicxmlExportBreaks::ALL);
+                  }
+            else if (musicxmlExportManualBreaks->isChecked() && preferences.musicxmlExportBreaks() != MusicxmlExportBreaks::MANUAL) {
+                  preferences.setPreference(PREF_EXPORT_MUSICXML_EXPORTLAYOUT, false);
                   preferences.setCustomPreference<MusicxmlExportBreaks>(PREF_EXPORT_MUSICXML_EXPORTBREAKS, MusicxmlExportBreaks::MANUAL);
-            else if (musicxmlExportNoBreaks->isChecked() && preferences.musicxmlExportBreaks() != MusicxmlExportBreaks::NO)
+                  }
+            else if (musicxmlExportNoBreaks->isChecked() && preferences.musicxmlExportBreaks() != MusicxmlExportBreaks::NO) {
+                  preferences.setPreference(PREF_EXPORT_MUSICXML_EXPORTLAYOUT, false);
                   preferences.setCustomPreference<MusicxmlExportBreaks>(PREF_EXPORT_MUSICXML_EXPORTBREAKS, MusicxmlExportBreaks::NO);
+                  }
       } else if (currentIndex == 9)
             saveFormat = "mscx";
 


### PR DESCRIPTION
If you select the option "No system or page breaks" (or "System and page breaks" or "Manually added system and page breaks only"), that setting gets stored in MuseScore3.ini under `musicXML\exportBreaks`, and stays there, even if later you change to "All layout", which uses a different setting. `musicXML\exportLayout`, and really should include "Systems and page breaks"

But the contrary is true too, once "All layout" has been chosen, it stays chosen indefinitely, without regards to the system and page break settings, instead of unsetting "All layout".

As these are radio buttons in the export dialog and the preferences, those options are really mutaually exclusive, or rather should be... Seems in preferences it is handled correctly, but not in the export dialog.

Mu4 (at least 4.1.1) does it right.