### PR TITLE
Prevent crash when opening score with `Part` with no staves

### DIFF
--- a/libmscore/part.cpp
+++ b/libmscore/part.cpp
@@ -514,6 +514,8 @@ bool Part::setProperty(Pid id, const QVariant& property)
 
 int Part::startTrack() const
       {
+      if (_staves.empty())
+            return -1;
       return _staves.front()->idx() * VOICES;
       }
 
@@ -523,6 +525,8 @@ int Part::startTrack() const
 
 int Part::endTrack() const
       {
+      if (_staves.empty())
+            return -1;
       return _staves.back()->idx() * VOICES + VOICES;
       }
 


### PR DESCRIPTION
Resolves: #17720
Resolves: #19698

It is questionable though how much sense this makes; it will enable the user to open the score, but it is still corrupted so it is very likely that a crash will occur anyway later while working with it.

Backport of #19708

Prevents the crash (actually an assertion failure) on opening these scores, but unlike the original PR still crashes (dies on a SIGSEGV) when opening the broken part (Alto Sax and Organ, respectively).
OTOH you can at least open the score and fix it, quite a bit better than crashing on loading it.

[ajr_Worlds_Smallest_Violin.zip](https://github.com/Jojo-Schmitz/MuseScore/files/12898550/ajr_Worlds_Smallest_Violin.zip)
[Joyful we adore thee.zip](https://github.com/Jojo-Schmitz/MuseScore/files/12898228/Joyful.we.adore.thee.zip)
