### PR TITLE
Fix GH#18404: Transpose tool will only transpose initial key signature on a system if there is a key change

### DIFF
--- a/libmscore/transpose.cpp
+++ b/libmscore/transpose.cpp
@@ -434,7 +434,7 @@ bool Score::transpose(TransposeMode mode, TransposeDirection direction, Key trKe
                   else if (e->isKeySig() && trKeys && mode != TransposeMode::DIATONICALLY) {
                         KeySig* ks = toKeySig(e);
                         Fraction tick = segment->tick();
-                        bool startKey = tick == s1->tick();
+                        bool startKey = tick == s1->tick() && !isFirstSystemKeySig(ks);
                         bool addKey = ks->isChange();
                         if ((startKey || addKey) && !ks->isCustom() && !ks->isAtonal()) {
                               Staff* staff = ks->staff();

--- a/libmscore/utils.cpp
+++ b/libmscore/utils.cpp
@@ -15,6 +15,7 @@
 #include "page.h"
 #include "segment.h"
 #include "clef.h"
+#include "keysig.h"
 #include "utils.h"
 #include "system.h"
 #include "measure.h"
@@ -1069,6 +1070,16 @@ double yStaffDifference(const System* system1, int staffIdx1, const System* syst
       if (!staff1 || !staff2)
             return 0.0;
       return staff1->y() - staff2->y();
+      }
+
+bool isFirstSystemKeySig(const KeySig* ks)
+      {
+      if (!ks)
+            return false;
+      const System* sys = ks->measure()->system();
+      if (!sys)
+            return false;
+      return ks->tick() == sys->firstMeasure()->tick();
       }
 }
 

--- a/libmscore/utils.h
+++ b/libmscore/utils.h
@@ -19,6 +19,8 @@
 
 namespace Ms {
 
+class KeySig;
+
 enum class Key;
 
 //---------------------------------------------------------
@@ -92,6 +94,7 @@ extern Fraction actualTicks(Fraction duration, Tuplet* tuplet, Fraction timeStre
 
 
 extern double yStaffDifference(const System* system1, int staffIdx1, const System* system2, int staffIdx2);
+extern bool isFirstSystemKeySig(const KeySig* ks);
 }     // namespace Ms
 #endif
 


### PR DESCRIPTION
If the first key signature on a system is a change to the measure before, it will be transposed. Otherwise it will be left untouched.

Resolves: #18404

Backport of #18530

