### PR TITLE
Fix GH#19398: Make sure "reset" command for Beam is fully undoable

### DIFF
--- a/libmscore/beam.cpp
+++ b/libmscore/beam.cpp
@@ -2255,8 +2255,8 @@ void Beam::reset()
             undoChangeProperty(Pid::USER_MODIFIED, false);
             }
       undoChangeProperty(Pid::STEM_DIRECTION, QVariant::fromValue<Direction>(Direction::AUTO));
-      resetProperty(Pid::BEAM_NO_SLOPE);
-      setGenerated(true);
+      undoResetProperty(Pid::BEAM_NO_SLOPE);
+      undoChangeProperty(Pid::GENERATED, true);
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
Resolves: #19398

Backport of #19727