### PR TITLE
Install qoffscreen platform plugin on Windows

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -210,6 +210,7 @@ if (MINGW)
 
     install(FILES
       ${QT_INSTALL_PLUGINS}/platforms/qwindows.dll
+      ${QT_INSTALL_PLUGINS}/platforms/qoffscreen.dll
       DESTINATION bin/platforms)
 
     install(FILES
@@ -443,6 +444,7 @@ else (MINGW)
 
       install(FILES
          ${QT_INSTALL_PLUGINS}/platforms/qwindows.dll
+         ${QT_INSTALL_PLUGINS}/platforms/qoffscreen.dll
          DESTINATION bin/platforms)
 
       install(FILES


### PR DESCRIPTION
Resolved comment: https://github.com/musescore/MuseScore/issues/17247#issuecomment-1763501983

Backport of #19726

Not sure whether it is needed for Mu3, but it sure doesn't harm either.