### PR TITLE
Fix GH#19819: Allow approximately equal signs to work on tempo text

### DIFF
--- a/libmscore/tempotext.cpp
+++ b/libmscore/tempotext.cpp
@@ -289,6 +289,11 @@ void TempoText::updateTempo()
       QString s = plainText();
       s.replace(",", ".");
       s.replace("<sym>space</sym>"," ");
+      s.replace("≒", "=");
+      s.replace("≈", "=");
+      s.replace("~", "=");
+      s.replace("ca.", "");
+      s.replace("approx.", "");
       for (const TempoPattern& pa : tp) {
             QRegExp re;
             if (!regexps.contains(pa.pattern)) {


### PR DESCRIPTION
Resolves: #19819

`Backport' of #19822