### PR TITLE
Harmonize DPI settings for PDF and PNG export

### DIFF
--- a/mscore/exportdialog.ui
+++ b/mscore/exportdialog.ui
@@ -125,10 +125,10 @@
                   <string/>
                  </property>
                  <property name="maximum">
-                  <number>720</number>
+                  <number>2400</number>
                  </property>
                  <property name="value">
-                  <number>300</number>
+                  <number>360</number>
                  </property>
                 </widget>
                </item>
@@ -201,10 +201,10 @@
                   <string/>
                  </property>
                  <property name="maximum">
-                  <number>720</number>
+                  <number>5000</number>
                  </property>
                  <property name="value">
-                  <number>300</number>
+                  <number>360</number>
                  </property>
                 </widget>
                </item>

--- a/mscore/fotomode.cpp
+++ b/mscore/fotomode.cpp
@@ -369,7 +369,7 @@ void ScoreView::fotoContextPopup(QContextMenuEvent* ev)
                tr("Set Output Resolution"),
                tr("Set output resolution for PNG"),
                preferences.getDouble(PREF_EXPORT_PNG_RESOLUTION),
-               16.0, 2400.0, 1,
+               0.0, 5000.0, 0,
                &ok
                );
             if (ok) {

--- a/mscore/prefsdialog.ui
+++ b/mscore/prefsdialog.ui
@@ -3597,9 +3597,6 @@ Adjusting latency can help synchronize your MIDI hardware with MuseScore's inter
             <property name="suffix">
              <string extracomment="dots per inch">DPI</string>
             </property>
-            <property name="minimum">
-             <number>32</number>
-            </property>
             <property name="maximum">
              <number>5000</number>
             </property>
@@ -3716,14 +3713,11 @@ Adjusting latency can help synchronize your MIDI hardware with MuseScore's inter
             <property name="suffix">
              <string extracomment="dots per inch">DPI</string>
             </property>
-            <property name="minimum">
-             <number>75</number>
-            </property>
             <property name="maximum">
              <number>2400</number>
             </property>
             <property name="value">
-             <number>300</number>
+             <number>360</number>
             </property>
            </widget>
           </item>


### PR DESCRIPTION
so that Preferences dialog, Export dialog and Foto mode dialog agree on min., max., default and decimals.

Resolves: #12772 (sort of, and in an entirely different way)
