### PR TITLE
Properly support BPM and TIFF images for frames and canvas

### DIFF
--- a/mscore/file.cpp
+++ b/mscore/file.cpp
@@ -2588,10 +2588,13 @@ void MuseScore::addImage(Score* score, Element* e)
          0,
          tr("Insert Image"),
          "",            // lastOpenPath,
-         tr("All Supported Files") + " (*.svg *.jpg *.jpeg *.png);;" +
+         tr("All Supported Files") + " (*.svg *.jpg *.jpeg *.png *.bmp *.tif *.tiff);;" +
          tr("Scalable Vector Graphics") + " (*.svg);;" +
          tr("JPEG") + " (*.jpg *.jpeg);;" +
-         tr("PNG Bitmap Graphic") + " (*.png)",
+         tr("PNG Bitmap Graphic") + " (*.png);;" +
+         tr("Bitmap") + " (*.bmp);;" +
+         tr("TIFF") + " (*.tif *.tiff);;" +
+         tr("All") + " (*)",
          0,
          preferences.getBool(PREF_UI_APP_USENATIVEDIALOGS) ? QFileDialog::Options() : QFileDialog::DontUseNativeDialog
          );
@@ -2604,7 +2607,7 @@ void MuseScore::addImage(Score* score, Element* e)
 
       if (suffix == "svg")
             s->setImageType(ImageType::SVG);
-      else if (suffix == "jpg" || suffix == "jpeg" || suffix == "png")
+      else if (suffix == "jpg" || suffix == "jpeg" || suffix == "png" || suffix == "bmp"|| suffix == "tif"|| suffix == "tiff")
             s->setImageType(ImageType::RASTER);
       else
             return;
@@ -2841,7 +2844,7 @@ void WallpaperPreview::setImage(const QString& path)
 
 QString MuseScore::getWallpaper(const QString& caption)
       {
-      QString filter = tr("Images") + " (*.jpg *.jpeg *.png);;" + tr("All") + " (*)";
+      QString filter = tr("Images") + " (*.jpg *.jpeg *.png *.bmp *.tif *.tiff);;" + tr("All") + " (*)";
       QString d = mscoreGlobalShare + "/wallpaper";
 
       if (preferences.getBool(PREF_UI_APP_USENATIVEDIALOGS)) {

--- a/mscore/palette.cpp
+++ b/mscore/palette.cpp
@@ -1867,6 +1867,9 @@ void Palette::dragEnterEvent(QDragEnterEvent* event)
                      || suffix == "jpg"
                      || suffix == "jpeg"
                      || suffix == "png"
+                     || suffix == "bpm"
+                     || suffix == "tif"
+                     || suffix == "tiff"
                      ) {
                         event->acceptProposedAction();
                         }


### PR DESCRIPTION
via https://musescore.org/en/handbook/3/images I've just learned that BMP and TIF files are supported image formats, but then found that for the frames' "Add image" dialog and Edit > Preferences > Canvas these formats are not being offered.
While for the former "drag'n'drop" is a workaround, for the latter it is to change the filter to "all files".

Backport of #19917