### PR TITLE
Fix #307530: MusicXML export for hidden staves

### DIFF
--- a/importexport/musicxml/exportxml.cpp
+++ b/importexport/musicxml/exportxml.cpp
@@ -3064,8 +3064,11 @@ void ExportMusicXml::chordAttributes(Chord* chord, Notations& notations, Technic
                         _xml.tagE("natural");
                         _xml.etag();
                         }
-                  else // TODO: check additional modifier (attr) for other symbols
-                        _xml.tagE(mxmlTechn);
+                  else {
+                        if (placement != "")
+                              attr += QString(" placement=\"%1\"").arg(placement);
+                        _xml.tagE(mxmlTechn + attr);
+                        }
                   }
             }
 

--- a/importexport/musicxml/exportxml.cpp
+++ b/importexport/musicxml/exportxml.cpp
@@ -6509,11 +6509,13 @@ static void writeStaffDetails(XmlWriter& xml, const Part* part)
       //       currently exported as a two staff part ...
       for (int i = 0; i < staves; i++) {
             Staff* st = part->staff(i);
-            if (st->lines(Fraction(0,1)) != 5 || st->isTabStaff(Fraction(0,1))) {
+            if (st->lines(Fraction(0,1)) != 5 || st->isTabStaff(Fraction(0,1)) || !st->show()) {
+                  QString details = "staff-details";
                   if (staves > 1)
-                        xml.stag(QString("staff-details number=\"%1\"").arg(i+1));
-                  else
-                        xml.stag("staff-details");
+                        details += QString(" number=\"%1\"").arg(i+1);
+                  if (!st->show())
+                        details += " print-object=\"no\"";
+                  xml.stag(details);
                   xml.tag("staff-lines", st->lines(Fraction(0,1)));
                   if (st->isTabStaff(Fraction(0,1)) && instrument->stringData()) {
                         QList<instrString> l = instrument->stringData()->stringList();

--- a/importexport/musicxml/importmxml.cpp
+++ b/importexport/musicxml/importmxml.cpp
@@ -93,6 +93,34 @@ static int musicXMLImportErrorDialog(QString text, QString detailedText)
       return errorDialog.exec();
       }
 
+#if 0
+static void updateNamesForAccidentals(Instrument* inst)
+      {
+      auto replace = [](QString name) {
+            name = name.replace(QRegExp(
+                                  R"(((?:^|\s)([A-Ga-g]|[Uu][Tt]|[Dd][Oo]|[Rr][EeÉé]|[MmSsTt][Ii]|[FfLl][Aa]|[Ss][Oo][Ll]))b(?=\s|$))"),
+                                QString::fromStdString(R"($1♭)"));
+
+            name = name.replace(QRegExp(
+                                  R"(((?:^|\s)([A-Ga-g]|[Uu][Tt]|[Dd][Oo]|[Rr][EeÉé]|[MmSsTt][Ii]|[FfLl][Aa]|[Ss][Oo][Ll]))#(?=\s|$))"),
+                                QString::fromStdString(R"($1♯)"));
+
+            return name;
+            };
+      // change staff names from simple text (eg 'Eb') to text using accidental symbols (eg 'E♭')
+
+      // Instrument::longNames() is const af so we need to make a deep copy, update it, and then set it again
+      QList<StaffName> longNamesCopy = inst->longNames();
+      for (StaffName& sn : longNamesCopy)
+            sn.setName(replace(sn.name()));
+      QList<StaffName> shortNamesCopy = inst->shortNames();
+      for (StaffName& sn : shortNamesCopy)
+            sn.setName(replace(sn.name()));
+      inst->setLongNames(longNamesCopy);
+      inst->setShortNames(shortNamesCopy);
+      }
+#endif
+
 //---------------------------------------------------------
 //   importMusicXMLfromBuffer
 //---------------------------------------------------------
@@ -124,6 +152,15 @@ Score::FileError importMusicXMLfromBuffer(Score* score, const QString& /*name*/,
           dev->seek(0);
           res = pass2.parse(dev);
       }
+
+#if 0
+      for (const Part* part : score->parts()) {
+            for (const auto& pair : *part->instruments()) {
+                  pair.second->updateInstrumentId();
+                  updateNamesForAccidentals(pair.second);
+                  }
+            }
+#endif
 
       // report result
       const auto pass2_errors = pass2.errors();

--- a/importexport/musicxml/importmxmlpass2.cpp
+++ b/importexport/musicxml/importmxmlpass2.cpp
@@ -2258,6 +2258,16 @@ void MusicXMLParserPass2::part()
             setStaffTypePercussion(msPart, drumset);
             }
 
+      bool showPart = false;
+            for (Staff* staff : *msPart->staves()) {
+            if (!staff->invisible(Fraction(0,1))) {
+                  showPart = true;
+                  break;
+            }
+      }
+
+      msPart->setShow(showPart);
+
       addError(checkAtEndElement(_e, "part"));
       }
 
@@ -2824,6 +2834,12 @@ void MusicXMLParserPass2::staffDetails(const QString& partId)
       int staffIdx = _score->staffIdx(part) + n;
 
       StringData* t = new StringData;
+      QString visible = _e.attributes().value("print-object").toString();
+      if (visible == "no" )
+            _score->staff(staffIdx)->setInvisible(Fraction(0,1), true);
+      else if (!visible.isEmpty() && visible != "yes")
+            _logger->logError(QString("print-object should be \"yes\" or \"no\""));
+
       int staffLines = 0;
       while (_e.readNextStartElement()) {
             if (_e.name() == "staff-lines") {

--- a/importexport/musicxml/importmxmlpass2.cpp
+++ b/importexport/musicxml/importmxmlpass2.cpp
@@ -2561,6 +2561,19 @@ void MusicXMLParserPass2::measure(const QString& partId,
       measure->setRepeatStart(false);
       measure->setRepeatEnd(false);
 
+      /* TODO: for cutaway measures, i believe we can expect the staff to continue to be cutaway until another
+       * print-object="yes" attribute is found. Here is the code that does that, though I don't want to actually commit this until
+       * we have the exporter dealing with this sort of stuff as well.
+       *
+       * When print-object="yes" is encountered, the measure will explicitly be set to visible (see MusicXMLParserPass2::staffDetails)
+      MeasureBase* prevBase = measure->prev();
+      if (prevBase) {
+            Part* part = _pass1.getPart(partId);
+            staff_idx_t staffIdx = _score->staffIdx(part);
+            if (!toMeasure(prevBase)->visible(staffIdx))
+                 measure->setStaffVisible(staffIdx, false);
+            } */
+
       Fraction mTime; // current time stamp within measure
       Fraction prevTime; // time stamp within measure previous chord
       Chord* prevChord = 0;       // previous chord
@@ -2780,7 +2793,7 @@ void MusicXMLParserPass2::attributes(const QString& partId, Measure* measure, co
             else if (_e.name() == "measure-style")
                   measureStyle(measure);
             else if (_e.name() == "staff-details")
-                  staffDetails(partId);
+                  staffDetails(partId, measure);
             else if (_e.name() == "time")
                   time(partId, measure, tick);
             else if (_e.name() == "transpose")
@@ -2812,7 +2825,7 @@ static void setStaffLines(Score* score, int staffIdx, int stafflines)
  Parse the /score-partwise/part/measure/attributes/staff-details node.
  */
 
-void MusicXMLParserPass2::staffDetails(const QString& partId)
+void MusicXMLParserPass2::staffDetails(const QString& partId, Measure* measure)
       {
       //logDebugTrace("MusicXMLParserPass2::staffDetails");
 
@@ -2835,9 +2848,33 @@ void MusicXMLParserPass2::staffDetails(const QString& partId)
 
       StringData* t = new StringData;
       QString visible = _e.attributes().value("print-object").toString();
-      if (visible == "no" )
-            _score->staff(staffIdx)->setInvisible(Fraction(0,1), true);
-      else if (!visible.isEmpty() && visible != "yes")
+      QString spacing = _e.attributes().value("print-spacing").toString();
+      if (visible == "no" ) {
+            // EITHER:
+            //  1) this indicates an empty staff that is hidden
+            //  2) this indicates a cutaway measure. if it is a cutaway measure then print-spacing will be yes
+            if (spacing == "yes") {
+                  measure->setStaffVisible(staffIdx, false);
+                  }
+            else if (measure && !measure->hasVoices(staffIdx) && measure->isOnlyRests(staffIdx * VOICES)) {
+                  // measures with print-object="no" are generally exported by exporters such as dolet when empty staves are hidden.
+                  // for this reason, if we see print-object="no" (and no print-spacing), we can assume that this indicates we should set
+                  // the hide empty staves style.
+                  _score->style().set(Sid::hideEmptyStaves, true);
+                  _score->style().set(Sid::dontHideStavesInFirstSystem, false);
+                  }
+            else {
+                  // this doesn't apply to a measure, so we'll assume the entire staff has to be hidden.
+                  _score->staff(staffIdx)->setInvisible(Fraction(0,1), true);
+                  }
+            }
+      else if (visible == "yes") {
+            if (measure) {
+                  _score->staff(staffIdx)->setInvisible(Fraction(0,1), false);
+                  measure->setStaffVisible(staffIdx, true);
+                  }
+            }
+      else
             _logger->logError(QString("print-object should be \"yes\" or \"no\""));
 
       int staffLines = 0;

--- a/importexport/musicxml/importmxmlpass2.cpp
+++ b/importexport/musicxml/importmxmlpass2.cpp
@@ -2868,7 +2868,7 @@ void MusicXMLParserPass2::staffDetails(const QString& partId, Measure* measure)
                   _score->staff(staffIdx)->setInvisible(Fraction(0,1), true);
                   }
             }
-      else if (visible == "yes") {
+      else if (visible == "yes" || visible == "") {
             if (measure) {
                   _score->staff(staffIdx)->setInvisible(Fraction(0,1), false);
                   measure->setStaffVisible(staffIdx, true);

--- a/importexport/musicxml/importmxmlpass2.h
+++ b/importexport/musicxml/importmxmlpass2.h
@@ -308,7 +308,7 @@ private:
       void timeModification(Fraction& timeMod, TDuration& normalType);
       void stem(Direction& sd, bool& nost);
       void doEnding(const QString& partId, Measure* measure, const QString& number, const QString& type, const QString& text, const bool print);
-      void staffDetails(const QString& partId);
+      void staffDetails(const QString& partId, Measure* measure = nullptr);
       void staffTuning(StringData* t);
       void addCopyrightVBox();
       void skipLogCurrElem();

--- a/mtest/musicxml/io/testExcessHiddenStaves_ref.mscx
+++ b/mtest/musicxml/io/testExcessHiddenStaves_ref.mscx
@@ -55,7 +55,9 @@
       <Staff id="1">
         <StaffType group="pitched">
           <name>stdNormal</name>
+          <invisible>1</invisible>
           </StaffType>
+        <invisible>1</invisible>
         <hideWhenEmpty>3</hideWhenEmpty>
         <bracket type="1" span="2" col="1"/>
         <barLineSpan>2</barLineSpan>

--- a/mtest/musicxml/io/testExcessHiddenStaves_ref.mscx
+++ b/mtest/musicxml/io/testExcessHiddenStaves_ref.mscx
@@ -16,6 +16,8 @@
       <chordSymbolAFontSize>10</chordSymbolAFontSize>
       <chordSymbolBFontSize>10</chordSymbolBFontSize>
       <nashvilleNumberFontSize>10</nashvilleNumberFontSize>
+      <hideEmptyStaves>1</hideEmptyStaves>
+      <dontHidStavesInFirstSystm>0</dontHidStavesInFirstSystm>
       <tupletFontSize>10</tupletFontSize>
       <fingeringFontSize>10</fingeringFontSize>
       <lhGuitarFingeringFontSize>10</lhGuitarFingeringFontSize>
@@ -55,9 +57,7 @@
       <Staff id="1">
         <StaffType group="pitched">
           <name>stdNormal</name>
-          <invisible>1</invisible>
           </StaffType>
-        <invisible>1</invisible>
         <hideWhenEmpty>3</hideWhenEmpty>
         <bracket type="1" span="2" col="1"/>
         <barLineSpan>2</barLineSpan>

--- a/mtest/musicxml/io/testHiddenStaves.xml
+++ b/mtest/musicxml/io/testHiddenStaves.xml
@@ -1,0 +1,272 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 4.0 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="4.0">
+  <work>
+    <work-title>Untitled Score</work-title>
+    </work>
+  <identification>
+    <creator type="composer">Composer / arranger</creator>
+    <encoding>
+      <software>MuseScore 0.7.0</software>
+      <encoding-date>2007-09-10</encoding-date>
+      <supports element="accidental" type="yes"/>
+      <supports element="beam" type="yes"/>
+      <supports element="print" attribute="new-page" type="no"/>
+      <supports element="print" attribute="new-system" type="no"/>
+      <supports element="stem" type="yes"/>
+      </encoding>
+    </identification>
+  <part-list>
+    <part-group type="start" number="1">
+      <group-symbol>bracket</group-symbol>
+      </part-group>
+    <score-part id="P1">
+      <part-name>Flute</part-name>
+      <part-abbreviation>Fl.</part-abbreviation>
+      <score-instrument id="P1-I1">
+        <instrument-name>Flute</instrument-name>
+        </score-instrument>
+      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-instrument id="P1-I1">
+        <midi-channel>1</midi-channel>
+        <midi-program>74</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    <score-part id="P2">
+      <part-name>Bassoon</part-name>
+      <part-abbreviation>Bsn.</part-abbreviation>
+      <score-instrument id="P2-I1">
+        <instrument-name>Bassoon</instrument-name>
+        </score-instrument>
+      <midi-device id="P2-I1" port="1"></midi-device>
+      <midi-instrument id="P2-I1">
+        <midi-channel>2</midi-channel>
+        <midi-program>71</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    <part-group type="stop" number="1"/>
+    <score-part id="P3">
+      <part-name>Harpsichord</part-name>
+      <part-abbreviation>Hch.</part-abbreviation>
+      <score-instrument id="P3-I1">
+        <instrument-name>Harpsichord</instrument-name>
+        </score-instrument>
+      <midi-device id="P3-I1" port="1"></midi-device>
+      <midi-instrument id="P3-I1">
+        <midi-channel>3</midi-channel>
+        <midi-program>7</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    <score-part id="P4">
+      <part-name>Piano</part-name>
+      <part-abbreviation>Pno.</part-abbreviation>
+      <score-instrument id="P4-I1">
+        <instrument-name>Piano</instrument-name>
+        </score-instrument>
+      <midi-device id="P4-I1" port="1"></midi-device>
+      <midi-instrument id="P4-I1">
+        <midi-channel>4</midi-channel>
+        <midi-program>1</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>0</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        </attributes>
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="2">
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  <part id="P2">
+    <measure number="1">
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>0</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>F</sign>
+          <line>4</line>
+          </clef>
+        <staff-details print-object="no">
+          <staff-lines>5</staff-lines>
+          </staff-details>
+        </attributes>
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="2">
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  <part id="P3">
+    <measure number="1">
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>0</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <staves>2</staves>
+        <clef number="1">
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        <clef number="2">
+          <sign>F</sign>
+          <line>4</line>
+          </clef>
+        <staff-details number="1" print-object="no">
+          <staff-lines>5</staff-lines>
+          </staff-details>
+        <staff-details number="2" print-object="no">
+          <staff-lines>5</staff-lines>
+          </staff-details>
+        </attributes>
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        <staff>1</staff>
+        </note>
+      <backup>
+        <duration>4</duration>
+        </backup>
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>5</voice>
+        <staff>2</staff>
+        </note>
+      </measure>
+    <measure number="2">
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        <staff>1</staff>
+        </note>
+      <backup>
+        <duration>4</duration>
+        </backup>
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>5</voice>
+        <staff>2</staff>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  <part id="P4">
+    <measure number="1">
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>0</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <staves>2</staves>
+        <clef number="1">
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        <clef number="2">
+          <sign>F</sign>
+          <line>4</line>
+          </clef>
+        </attributes>
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        <staff>1</staff>
+        </note>
+      <backup>
+        <duration>4</duration>
+        </backup>
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>5</voice>
+        <staff>2</staff>
+        </note>
+      </measure>
+    <measure number="2">
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        <staff>1</staff>
+        </note>
+      <backup>
+        <duration>4</duration>
+        </backup>
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>5</voice>
+        <staff>2</staff>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  </score-partwise>

--- a/mtest/musicxml/io/tst_mxml_io.cpp
+++ b/mtest/musicxml/io/tst_mxml_io.cpp
@@ -147,7 +147,6 @@ private slots:
       void hello() { mxmlIoTest("testHello"); }
       void helloReadCompr() { mxmlReadTestCompr("testHello"); }
       void helloReadWriteCompr() { mxmlReadWriteTestCompr("testHello"); }
-      void hiddenStaves() { mxmlIoTest("testHiddenStaves"); }
       void implicitMeasure1() { mxmlIoTest("testImplicitMeasure1"); }
       void incompleteTuplet() { mxmlIoTestRef("testIncompleteTuplet"); }
       void incorrectStaffNumber1() { mxmlIoTestRef("testIncorrectStaffNumber1"); }
@@ -297,6 +296,12 @@ private slots:
       void wedge3() { mxmlIoTest("testWedge3"); }
       void words1() { mxmlIoTest("testWords1"); }
       // void words2() { mxmlIoTest("testWords2"); }
+      void hiddenStaves()
+            {
+            MasterScore* score = readScore(DIR + "testHiddenStaves.xml");
+
+            QVERIFY(score->style().value(Sid::hideEmptyStaves).toBool());
+            }
       };
 
 //---------------------------------------------------------

--- a/mtest/musicxml/io/tst_mxml_io.cpp
+++ b/mtest/musicxml/io/tst_mxml_io.cpp
@@ -147,6 +147,7 @@ private slots:
       void hello() { mxmlIoTest("testHello"); }
       void helloReadCompr() { mxmlReadTestCompr("testHello"); }
       void helloReadWriteCompr() { mxmlReadWriteTestCompr("testHello"); }
+      void hiddenStaves() { mxmlIoTest("testHiddenStaves"); }
       void implicitMeasure1() { mxmlIoTest("testImplicitMeasure1"); }
       void incompleteTuplet() { mxmlIoTestRef("testIncompleteTuplet"); }
       void incorrectStaffNumber1() { mxmlIoTestRef("testIncorrectStaffNumber1"); }


### PR DESCRIPTION
Backport of #11953

Resolves: https://musescore.org/en/node/307530

Introduces #16135 though, so needs a(n at least partial) backport of #18556, resp. #17033, #17035 and #17118 too, to resolve #16497 (optional and rather unrelated), #16135 and #17037 (optional and rather unrelated).
And that in turn should get accompanied by #19901.

So that's what this PR does also ;-)