### PR TITLE
MusicXML fixes for time signatures cut time

### DIFF
--- a/importexport/musicxml/exportxml.cpp
+++ b/importexport/musicxml/exportxml.cpp
@@ -1997,10 +1997,6 @@ void ExportMusicXml::timesig(TimeSig* tsig)
             tagName += " symbol=\"common\"";
       else if (st == TimeSigType::ALLA_BREVE)
             tagName += " symbol=\"cut\"";
-      else if (st == TimeSigType::CUT_BACH)
-            tagName += " symbol=\"cut2\"";
-      else if (st == TimeSigType::CUT_TRIPLE)
-            tagName += " symbol=\"cut3\"";
       if (!tsig->visible())
             tagName += " print-object=\"no\"";
       tagName += color2xml(tsig);

--- a/importexport/musicxml/importmxmlpass1.cpp
+++ b/importexport/musicxml/importmxmlpass1.cpp
@@ -2700,18 +2700,6 @@ static bool determineTimeSig(MxmlLogger* logger, const QXmlStreamReader* const x
             btp = 4;
             return true;
             }
-      else if (beats == "2" && beatType == "2" && timeSymbol == "cut2") {
-            st = TimeSigType::CUT_BACH;
-            bts = 2;
-            btp = 2;
-            return true;
-            }
-      else if (beats == "9" && beatType == "8" && timeSymbol == "cut3") {
-            st = TimeSigType::CUT_TRIPLE;
-            bts = 9;
-            btp = 8;
-            return true;
-            }
       else {
             if (!timeSymbol.isEmpty() && timeSymbol != "normal") {
                   logger->logError(QString("time symbol '%1' not recognized with beats=%2 and beat-type=%3")

--- a/importexport/musicxml/importmxmlpass1.cpp
+++ b/importexport/musicxml/importmxmlpass1.cpp
@@ -2688,30 +2688,20 @@ static bool determineTimeSig(MxmlLogger* logger, const QXmlStreamReader* const x
       bts = 0;             // the beats (max 4 separated by "+") as integer
       btp = 0;             // beat-type as integer
       // determine if timesig is valid
-      if (beats == "2" && beatType == "2" && timeSymbol == "cut") {
+      if (timeSymbol == "cut")
             st = TimeSigType::ALLA_BREVE;
-            bts = 2;
-            btp = 2;
-            return true;
-            }
-      else if (beats == "4" && beatType == "4" && timeSymbol == "common") {
+      else if (timeSymbol == "common")
             st = TimeSigType::FOUR_FOUR;
-            bts = 4;
-            btp = 4;
-            return true;
+      else if (!timeSymbol.isEmpty() && timeSymbol != "normal") {
+            logger->logError(QString("time symbol '%1' not recognized")
+                             .arg(timeSymbol), xmlreader);
+            return false;
             }
-      else {
-            if (!timeSymbol.isEmpty() && timeSymbol != "normal") {
-                  logger->logError(QString("time symbol '%1' not recognized with beats=%2 and beat-type=%3")
-                                   .arg(timeSymbol, beats, beatType), xmlreader);
-                  return false;
-                  }
 
-            btp = beatType.toInt();
-            QStringList list = beats.split("+");
-            for (int i = 0; i < list.size(); i++)
-                  bts += list.at(i).toInt();
-            }
+      btp = beatType.toInt();
+      QStringList list = beats.split("+");
+      for (int i = 0; i < list.size(); i++)
+            bts += list.at(i).toInt();
 
       // determine if bts and btp are valid
       if (bts <= 0 || btp <=0) {

--- a/importexport/musicxml/importmxmlpass2.cpp
+++ b/importexport/musicxml/importmxmlpass2.cpp
@@ -4981,18 +4981,6 @@ static bool determineTimeSig(const QString beats, const QString beatType, const 
             btp = 4;
             return true;
             }
-      else if (beats == "2" && beatType == "2" && timeSymbol == "cut2") {
-            st = TimeSigType::CUT_BACH;
-            bts = 2;
-            btp = 2;
-            return true;
-            }
-      else if (beats == "9" && beatType == "8" && timeSymbol == "cut3") {
-            st = TimeSigType::CUT_TRIPLE;
-            bts = 9;
-            btp = 8;
-            return true;
-            }
       else {
             if (!timeSymbol.isEmpty() && timeSymbol != "normal") {
                   qDebug("determineTimeSig: time symbol <%s> not recognized with beats=%s and beat-type=%s",

--- a/importexport/musicxml/importmxmlpass2.cpp
+++ b/importexport/musicxml/importmxmlpass2.cpp
@@ -4969,30 +4969,19 @@ static bool determineTimeSig(const QString beats, const QString beatType, const 
       bts = 0;       // the beats (max 4 separated by "+") as integer
       btp = 0;       // beat-type as integer
       // determine if timesig is valid
-      if (beats == "2" && beatType == "2" && timeSymbol == "cut") {
+      if (timeSymbol == "cut")
             st = TimeSigType::ALLA_BREVE;
-            bts = 2;
-            btp = 2;
-            return true;
-            }
-      else if (beats == "4" && beatType == "4" && timeSymbol == "common") {
+      else if (timeSymbol == "common")
             st = TimeSigType::FOUR_FOUR;
-            bts = 4;
-            btp = 4;
-            return true;
+      else if (!timeSymbol.isEmpty() && timeSymbol != "normal") {
+            qDebug("determineTimeSig: time symbol <%s> not recognized", qPrintable(timeSymbol)); // TODO
+            return false;
             }
-      else {
-            if (!timeSymbol.isEmpty() && timeSymbol != "normal") {
-                  qDebug("determineTimeSig: time symbol <%s> not recognized with beats=%s and beat-type=%s",
-                         qPrintable(timeSymbol), qPrintable(beats), qPrintable(beatType)); // TODO
-                  return false;
-                  }
 
-            btp = beatType.toInt();
-            QStringList list = beats.split("+");
-            for (int i = 0; i < list.size(); i++)
-                  bts += list.at(i).toInt();
-            }
+      btp = beatType.toInt();
+      QStringList list = beats.split("+");
+      for (int i = 0; i < list.size(); i++)
+            bts += list.at(i).toInt();
 
       // determine if bts and btp are valid
       if (bts <= 0 || btp <=0) {


### PR DESCRIPTION
* Invalid MusicXML exported for time signatures cut time (Bach) and cut triple time
    Came in via #7089
    Resolves: #20196
* MusicXML import of common and cut time is too strict
    Resolves: #20207 

Backport of #20197