### PR TITLE
Fix GH#17625: Sync figured bass between parts & score 

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -4565,7 +4565,8 @@ void Score::undoAddElement(Element* element)
          && et != ElementType::TREMOLOBAR
          && et != ElementType::FRET_DIAGRAM
          && et != ElementType::FERMATA
-         && et != ElementType::HARMONY)
+         && et != ElementType::HARMONY
+         && et != ElementType::FIGURED_BASS)
             ) {
             undo(new AddElement(element));
             return;
@@ -4741,7 +4742,8 @@ void Score::undoAddElement(Element* element)
                      || element->isSticking()
                      || element->isFretDiagram()
                      || element->isFermata()
-                     || element->isHarmony()) {
+                     || element->isHarmony()
+                     || element->isFiguredBass()) {
                         Segment* segment = element->parent()->isFretDiagram() ? toSegment(element->parent()->parent()) : toSegment(element->parent());
                         Fraction tick    = segment->tick();
                         Measure* m       = score->tick2measure(tick);

--- a/libmscore/figuredbass.cpp
+++ b/libmscore/figuredbass.cpp
@@ -295,7 +295,7 @@ int FiguredBassItem::parseParenthesis(QString& str, int parenthIdx)
             code = Parenthesis::ROUNDCLOSED;
             break;
       case '[':
-            code =Parenthesis::SQUAREDOPEN;
+            code = Parenthesis::SQUAREDOPEN;
             break;
       case ']':
             code = Parenthesis::SQUAREDCLOSED;
@@ -1415,11 +1415,11 @@ qreal FiguredBass::additionalContLineX(qreal pagePosY) const
             // if item has cont.line but nothing before it
             // and item Y coord near enough to pagePosY
             if(fbi->contLine() != FiguredBassItem::ContLine::NONE
-                  && fbi->digit() == FBIDigitNone
-                     && fbi->prefix() == FiguredBassItem::Modifier::NONE
-                        && fbi->suffix() == FiguredBassItem::Modifier::NONE
-                           && fbi->parenth4() == FiguredBassItem::Parenthesis::NONE
-                              && qAbs(pgPos.y() + fbi->ipos().y() - pagePosY) < 0.05)
+               && fbi->digit() == FBIDigitNone
+               && fbi->prefix() == FiguredBassItem::Modifier::NONE
+               && fbi->suffix() == FiguredBassItem::Modifier::NONE
+               && fbi->parenth4() == FiguredBassItem::Parenthesis::NONE
+               && qAbs(pgPos.y() + fbi->ipos().y() - pagePosY) < 0.05)
                   return pgPos.x() + fbi->ipos().x();
 
       return 0.0;                               // no suitable line
@@ -1768,7 +1768,7 @@ FiguredBass* Score::addFiguredBass()
             }
 
       FiguredBass * fb;
-      bool bNew;
+      bool bNew = true;
       if (el->isNote()) {
             ChordRest * cr = toNote(el)->chord();
             fb = FiguredBass::addFiguredBassToSegment(cr->segment(), cr->staffIdx() * VOICES, Fraction(0,1), &bNew);

--- a/libmscore/figuredbass.h
+++ b/libmscore/figuredbass.h
@@ -140,7 +140,7 @@ class FiguredBassItem final : public Element {
 
       void              setDisplayText(const QString& s)    { _displayText = s;       }
       // read / write MusicXML support
-      QString                   Modifier2MusicXML(FiguredBassItem::Modifier prefix) const;
+      QString           Modifier2MusicXML(FiguredBassItem::Modifier prefix) const;
 
    public:
       FiguredBassItem(Score * s = 0, int line = 0);
@@ -164,7 +164,7 @@ class FiguredBassItem final : public Element {
       bool              startsWithParenthesis() const;
 
       // specific API
-      const FiguredBass *    figuredBass() const      { return (FiguredBass*)(parent()); }
+      const FiguredBass*    figuredBass() const       { return (FiguredBass*)(parent()); }
       bool              parse(QString& text);
 
       // getters / setters

--- a/libmscore/scoreElement.cpp
+++ b/libmscore/scoreElement.cpp
@@ -25,7 +25,7 @@ namespace Ms {
 ElementStyle const ScoreElement::emptyStyle;
 
 //
-// list has to be synchronized with ElementType enum
+// list has to be synchronized with ElementType enum in types.h
 //
 static const ElementName elementNames[] = {
       { ElementType::INVALID,              "invalid",              QT_TRANSLATE_NOOP("elementName", "Invalid") },


### PR DESCRIPTION
Backport of #20139 (of its pretty minimal first version, the rest introduces a crash on undo, and apparently Mu3 doesn't have the undo issue of Mu4/master in the first place)

Resolves: #17625