### PR TITLE
Fix GH#20490: Export scores not starting with measure 1 correctly

### DIFF
--- a/importexport/musicxml/exportxml.cpp
+++ b/importexport/musicxml/exportxml.cpp
@@ -285,6 +285,7 @@ public:
 private:
       void init();
       int _measureNo;                           // number of next regular measure
+      int _measureNoOffset;                     // measure number offset
       int _irregularMeasureNo;                  // number of next irregular measure
       int _pickupMeasureNo;                     // number of next pickup measure
       QString _cachedAttributes;                // attributes calculated by updateForMeasure()
@@ -6725,6 +6726,7 @@ MeasureNumberStateHandler::MeasureNumberStateHandler()
 void MeasureNumberStateHandler::init()
       {
       _measureNo = 1;
+      _measureNoOffset = 0;
       _irregularMeasureNo = 1;
       _pickupMeasureNo = 1;
       }
@@ -6745,8 +6747,9 @@ void MeasureNumberStateHandler::updateForMeasure(const Measure* const m)
             }
 
       // update measure numbers and cache result
+      _measureNoOffset = m->noOffset();
+      _measureNo += _measureNoOffset;
       _cachedAttributes = " number=";
-      _measureNo += m->noOffset();
       if ((_irregularMeasureNo + _measureNo) == 2 && m->irregular()) {
             _cachedAttributes += "\"0\" implicit=\"yes\"";
             _pickupMeasureNo++;
@@ -6764,7 +6767,7 @@ QString MeasureNumberStateHandler::measureNumber() const
 
 bool MeasureNumberStateHandler::isFirstActualMeasure() const
       {
-      return (_irregularMeasureNo + _measureNo + _pickupMeasureNo) == 4;
+      return (_irregularMeasureNo + (_measureNo - _measureNoOffset) + _pickupMeasureNo) == 4;
       }
 
 //---------------------------------------------------------

--- a/mtest/musicxml/io/testMeasureNumberOffset.xml
+++ b/mtest/musicxml/io/testMeasureNumberOffset.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 4.0 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="4.0">
+  <work>
+    <work-title>Untitled score</work-title>
+    </work>
+  <identification>
+    <creator type="composer">Composer / arranger</creator>
+    <encoding>
+      <software>MuseScore 0.7.0</software>
+      <encoding-date>2007-09-10</encoding-date>
+      <supports element="accidental" type="yes"/>
+      <supports element="beam" type="yes"/>
+      <supports element="print" attribute="new-page" type="no"/>
+      <supports element="print" attribute="new-system" type="no"/>
+      <supports element="stem" type="yes"/>
+      </encoding>
+    </identification>
+  <part-list>
+    <score-part id="P1">
+      <part-name>Flute</part-name>
+      <part-abbreviation>Fl.</part-abbreviation>
+      <score-instrument id="P1-I1">
+        <instrument-name>Flute</instrument-name>
+        </score-instrument>
+      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-instrument id="P1-I1">
+        <midi-channel>1</midi-channel>
+        <midi-program>74</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    </part-list>
+  <part id="P1">
+    <measure number="6">
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>0</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        </attributes>
+      <note>
+        <pitch>
+          <step>B</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+        </note>
+      </measure>
+    <measure number="7">
+      <note>
+        <pitch>
+          <step>B</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  </score-partwise>

--- a/mtest/musicxml/io/tst_mxml_io.cpp
+++ b/mtest/musicxml/io/tst_mxml_io.cpp
@@ -186,6 +186,7 @@ private slots:
       void maxNumberLevel() { mxmlMscxExportTestRef("testMaxNumberLevel"); }
       void measureLength() { mxmlIoTestRef("testMeasureLength"); }
       void measureNumbers() { mxmlIoTest("testMeasureNumbers"); }
+      void measureNumberOffset() { mxmlIoTest("testMeasureNumberOffset"); }
       void measureStyleSlash() { mxmlImportTestRef("testMeasureStyleSlash"); }
       void midiPortExport() { mxmlMscxExportTestRef("testMidiPortExport"); }
       void multiInstrumentPart1() { mxmlIoTest("testMultiInstrumentPart1"); }


### PR DESCRIPTION
Backport of #20511

Resolves: #20490

Important score information which should be included in the first bar of the piece was not being written if the first measures's number is offset.
