### PR TITLE
Some optimizations for invisible staves: not laying spanners nor computing horizontal spacing

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -4540,6 +4540,8 @@ void Score::layoutSystemElements(System* system, LayoutContext& lc)
       std::vector<Spanner*> spanner;
       for (auto interval : spanners) {
             Spanner* sp = interval.value;
+            if (sp->staff() && !sp->staff()->show())
+                continue;
             sp->computeStartElement();
             sp->computeEndElement();
             lc.processedSpanners.insert(sp);
@@ -4619,6 +4621,8 @@ void Score::layoutSystemElements(System* system, LayoutContext& lc)
 
       for (auto interval : spanners) {
             Spanner* sp = interval.value;
+            if (sp->staff() && !sp->staff()->show())
+                continue;
             if (sp->tick() < etick && sp->tick2() > stick) {
                   if (sp->isOttava())
                         ottavas.push_back(sp);

--- a/libmscore/segment.cpp
+++ b/libmscore/segment.cpp
@@ -2196,6 +2196,8 @@ qreal Segment::minHorizontalCollidingDistance(Segment* ns) const
       {
       qreal w = 0.0;
       for (unsigned staffIdx = 0; staffIdx < _shapes.size(); ++staffIdx) {
+            if (score()->staff(staffIdx) && !score()->staff(staffIdx)->show())
+                  continue;
             qreal d = staffShape(staffIdx).minHorizontalDistance(ns->staffShape(staffIdx));
             w       = qMax(w, d);
             }
@@ -2212,6 +2214,8 @@ qreal Segment::minHorizontalDistance(Segment* ns, bool systemHeaderGap) const
 
       qreal ww = -1000000.0;        // can remain negative
       for (unsigned staffIdx = 0; staffIdx < _shapes.size(); ++staffIdx) {
+            if (score()->staff(staffIdx) && !score()->staff(staffIdx)->show())
+                  continue;
             qreal d = ns ? staffShape(staffIdx).minHorizontalDistance(ns->staffShape(staffIdx)) : 0.0;
             // first chordrest of a staff should clear the widest header for any staff
             // so make sure segment is as wide as it needs to be


### PR DESCRIPTION
* Not layouting spanners on hidden staves, backport of #20798
* Avoid computing horizontal spacing for hidden staves, backport of #20876

Possible todo: Skip computing spacing for hidden elements, backport #20799, 