### PR TITLE
Fix GH#20045: Do not check showUnprintable() when rendering irregular measures

### DIFF
--- a/libmscore/barline.cpp
+++ b/libmscore/barline.cpp
@@ -739,7 +739,7 @@ void BarLine::draw(QPainter* painter) const
                   break;
             }
       Segment* s = segment();
-      if (s && s->isEndBarLineType() && !score()->printing() && score()->showUnprintable()) {
+      if (s && s->isEndBarLineType() && !score()->printing()) {
             Measure* m = s->measure();
             if (m->isIrregular() && score()->markIrregularMeasures() && !m->isMMRest()) {
                   painter->setPen(MScore::layoutBreakColor);


### PR DESCRIPTION
Backport of #20443

Resolves: #20045