### PR TITLE
Fix GH#21020: Check hook is valid before getting width, part #2

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -549,7 +549,8 @@ void Score::layoutChords1(Segment* segment, int staffIdx)
                                     // we will need more space to avoid collision with hook
                                     // but we won't need as much dot adjustment
                                     if (ledgerOverlapBelow) {
-                                          double hookWidth = topDownNote->chord()->hook()->width();
+                                          Hook* hook = topDownNote->chord()->hook();
+                                          double hookWidth = hook ? hook->width() : 0.0;
                                           upOffset = hookWidth + ledgerLen + ledgerGap;
                                           }
                                     // we will need more space to avoid collision with hook


### PR DESCRIPTION
Backport of the 3rd commit of #21063 resp. the 2nd part of #21050

Resolves: #21020