### PR TITLE
Backporting changes to the piano roll made for MuseScore 4 PR #9109

### DIFF
--- a/libmscore/fraction.h
+++ b/libmscore/fraction.h
@@ -221,6 +221,7 @@ class Fraction {
       Fraction operator/(const Fraction& v) const { return Fraction(*this) /= v; }
       Fraction operator/(int v)             const { return Fraction(*this) /= v; }
 
+      double toDouble() { return (double)_numerator / _denominator; }
 
       //---------------------------------------------------------
       //   fromTicks

--- a/mscore/pianoroll/pianoroll.cpp
+++ b/mscore/pianoroll/pianoroll.cpp
@@ -117,7 +117,7 @@ PianorollEditor::PianorollEditor(QWidget* parent)
             PianoRollEditTool _tool;
             QString _tooltip;
             bool _selected;
-      };
+            };
       ToolIconData _iconDataTool[] = {
             { QStringLiteral(":/data/icons/preEdit-select.svg"), PianoRollEditTool::SELECT, tr("Select Notes"), true },
             { QStringLiteral(":/data/icons/preEdit-insertNote.svg"), PianoRollEditTool::ADD, tr("Insert Note"), false },
@@ -127,7 +127,7 @@ PianorollEditor::PianorollEditor(QWidget* parent)
             { QStringLiteral(":/data/icons/preEdit-changeLength.svg"), PianoRollEditTool::EVENT_ADJUST, tr("Change Chord Length"), false },
             { QStringLiteral(":/data/icons/preEdit-tie.svg"), PianoRollEditTool::TIE, tr("Toggle Tie"), false },
             { "", PianoRollEditTool::LAST, "", false },
-      };
+            };
 
       for (ToolIconData* p = _iconDataTool; p->_tool != PianoRollEditTool::LAST; ++p) {
             QToolButton* bn = new QToolButton();

--- a/mscore/pianoroll/pianoroll.cpp
+++ b/mscore/pianoroll/pianoroll.cpp
@@ -113,10 +113,10 @@ PianorollEditor::PianorollEditor(QWidget* parent)
 
       struct ToolIconData
       {
-          QString _icon;
-          PianoRollEditTool _tool;
-          QString _tooltip;
-          bool _selected;
+            QString _icon;
+            PianoRollEditTool _tool;
+            QString _tooltip;
+            bool _selected;
       };
       ToolIconData _iconDataTool[] = {
             { QStringLiteral(":/data/icons/preEdit-select.svg"), PianoRollEditTool::SELECT, tr("Select Notes"), true },
@@ -196,9 +196,9 @@ PianorollEditor::PianorollEditor(QWidget* parent)
 
       struct DotIconData
       {
-          QString _icon;
-          int _len;
-          bool _selected;
+            QString _icon;
+            int _len;
+            bool _selected;
       };
       DotIconData _iconDotData[] = {
             { QStringLiteral(":/data/icons/note-dot.svg"), 1, false },
@@ -233,10 +233,10 @@ PianorollEditor::PianorollEditor(QWidget* parent)
 
       struct VoiceIconData
       {
-          QString _icon;
-          int _voice;
-          QString _tooltip;
-          bool _selected;
+            QString _icon;
+            int _voice;
+            QString _tooltip;
+            bool _selected;
       };
       VoiceIconData _iconDataVoice[] = {
             { QStringLiteral(":/data/icons/voice-1.svg"), 0, tr("Voice 1"), true },
@@ -349,7 +349,7 @@ PianorollEditor::PianorollEditor(QWidget* parent)
 
       hsb = new QScrollBar(Qt::Horizontal);
       connect(pianoView->horizontalScrollBar(), SIGNAL(rangeChanged(int,int)),
-         SLOT(rangeChanged(int,int)));
+            SLOT(rangeChanged(int,int)));
 
       QWidget* noteAreaWidget = new QWidget;
 

--- a/mscore/pianoroll/pianoroll.cpp
+++ b/mscore/pianoroll/pianoroll.cpp
@@ -130,28 +130,28 @@ PianorollEditor::PianorollEditor(QWidget* parent)
       };
 
       for (ToolIconData* p = _iconDataTool; p->_tool != PianoRollEditTool::LAST; ++p) {
-          QToolButton* bn = new QToolButton();
-          QIcon icon;
-          icon.addFile(p->_icon, QSize(), QIcon::Normal, QIcon::Off);
-          bn->setIcon(icon);
-          bn->setCheckable(true);
-          bn->setToolTip(p->_tooltip);
-          PianoRollEditTool tool = p->_tool;
-          connect(bn, &QToolButton::clicked, this, [=]() {this->setEditNoteTool(tool); });
+            QToolButton* bn = new QToolButton();
+            QIcon icon;
+            icon.addFile(p->_icon, QSize(), QIcon::Normal, QIcon::Off);
+            bn->setIcon(icon);
+            bn->setCheckable(true);
+            bn->setToolTip(p->_tooltip);
+            PianoRollEditTool tool = p->_tool;
+            connect(bn, &QToolButton::clicked, this, [=]() {this->setEditNoteTool(tool); });
 
-          if (p->_selected)
-              bn->setChecked(true);
-          bngrpActionBns->addButton(bn);
-          tbTool->addWidget(bn);
-      }
+            if (p->_selected)
+                  bn->setChecked(true);
+            bngrpActionBns->addButton(bn);
+            tbTool->addWidget(bn);
+            }
 
       //----
 
       struct LenIconData
       {
-          QString _icon;
-          int _measureFrac;  //Note length is 2^n of a measure
-          bool _selected;
+            QString _icon;
+            int _measureFrac;  //Note length is 2^n of a measure
+            bool _selected;
       };
 
       LenIconData _iconData[] = {

--- a/mscore/pianoroll/pianoroll.cpp
+++ b/mscore/pianoroll/pianoroll.cpp
@@ -102,7 +102,50 @@ PianorollEditor::PianorollEditor(QWidget* parent)
       tbMain->addWidget(partLabel);
 
       // --------------------------------------------------
-      // empty area for spacing
+      // toolbars
+
+
+      //----
+
+      QToolBar* tbTool = addToolBar("Action Buttons");
+      QButtonGroup* bngrpActionBns = new QButtonGroup();
+
+
+      struct ToolIconData
+      {
+          QString _icon;
+          PianoRollEditTool _tool;
+          QString _tooltip;
+          bool _selected;
+      };
+      ToolIconData _iconDataTool[] = {
+            { QStringLiteral(":/data/icons/preEdit-select.svg"), PianoRollEditTool::SELECT, tr("Select Notes"), true },
+            { QStringLiteral(":/data/icons/preEdit-insertNote.svg"), PianoRollEditTool::ADD, tr("Insert Note"), false },
+            //{ QStringLiteral(":/data/icons/preEdit-appendChord.svg"), PianoRollEditTool::APPEND_NOTE, tr("Append Note to Chord"), false },
+            { QStringLiteral(":/data/icons/preEdit-cutNote.svg"), PianoRollEditTool::CUT, tr("Cut Chord"), false },
+            { QStringLiteral(":/data/icons/preEdit-eraseNote.svg"), PianoRollEditTool::ERASE, tr("Erase Note"), false },
+            { QStringLiteral(":/data/icons/preEdit-changeLength.svg"), PianoRollEditTool::EVENT_ADJUST, tr("Change Chord Length"), false },
+            { QStringLiteral(":/data/icons/preEdit-tie.svg"), PianoRollEditTool::TIE, tr("Toggle Tie"), false },
+            { "", PianoRollEditTool::LAST, "", false },
+      };
+
+      for (ToolIconData* p = _iconDataTool; p->_tool != PianoRollEditTool::LAST; ++p) {
+          QToolButton* bn = new QToolButton();
+          QIcon icon;
+          icon.addFile(p->_icon, QSize(), QIcon::Normal, QIcon::Off);
+          bn->setIcon(icon);
+          bn->setCheckable(true);
+          bn->setToolTip(p->_tooltip);
+          PianoRollEditTool tool = p->_tool;
+          connect(bn, &QToolButton::clicked, this, [=]() {this->setEditNoteTool(tool); });
+
+          if (p->_selected)
+              bn->setChecked(true);
+          bngrpActionBns->addButton(bn);
+          tbTool->addWidget(bn);
+      }
+
+      //----
 
       struct LenIconData
       {
@@ -110,6 +153,7 @@ PianorollEditor::PianorollEditor(QWidget* parent)
           int _measureFrac;  //Note length is 2^n of a measure
           bool _selected;
       };
+
       LenIconData _iconData[] = {
             { QStringLiteral(":/data/icons/note-longa.svg"), 2, false },
             { QStringLiteral(":/data/icons/note-breve.svg"), 1, false },
@@ -180,50 +224,12 @@ PianorollEditor::PianorollEditor(QWidget* parent)
             tbDots->addWidget(bn);
             }
 
-      //----
-
-      QToolBar* tbTool = addToolBar("Toolbar Edit Tool");
-      bngrpNoteLen = new QButtonGroup();
-
-      struct ToolIconData
-      {
-          QString _icon;
-          PianoRollEditTool _tool;
-          QString _tooltip;
-          bool _selected;
-      };
-      ToolIconData _iconDataTool[] = {
-            { QStringLiteral(":/data/icons/preEdit-select.svg"), PianoRollEditTool::SELECT, tr("Select Notes"), true },
-            { QStringLiteral(":/data/icons/preEdit-insertNote.svg"), PianoRollEditTool::INSERT_NOTE, tr("Insert Note"), false },
-            { QStringLiteral(":/data/icons/preEdit-appendChord.svg"), PianoRollEditTool::APPEND_NOTE, tr("Append Note to Chord"), false },
-            { QStringLiteral(":/data/icons/preEdit-cutNote.svg"), PianoRollEditTool::CUT_CHORD, tr("Cut Chord"), false },
-            { QStringLiteral(":/data/icons/preEdit-eraseNote.svg"), PianoRollEditTool::ERASE, tr("Erase Note"), false },
-            { QStringLiteral(":/data/icons/preEdit-changeLength.svg"), PianoRollEditTool::CHANGE_LENGTH, tr("Change Chord Length"), false },
-            { QStringLiteral(":/data/icons/preEdit-tie.svg"), PianoRollEditTool::TIE, tr("Toggle Tie"), false },
-            { "", PianoRollEditTool::LAST, "", false },
-            };
-
-      for (ToolIconData* p = _iconDataTool; p->_tool != PianoRollEditTool::LAST; ++p) {
-            QToolButton* bn = new QToolButton();
-            QIcon icon;
-            icon.addFile(p->_icon, QSize(), QIcon::Normal, QIcon::Off);
-            bn->setIcon(icon);
-            bn->setCheckable(true);
-            bn->setToolTip(p->_tooltip);
-            PianoRollEditTool tool = p->_tool;
-            connect(bn, &QToolButton::clicked, this, [=](){this->setEditNoteTool(tool);});
-
-            if (p->_selected)
-                  bn->setChecked(true);
-            bngrpNoteLen->addButton(bn);
-            tbTool->addWidget(bn);
-            }
-
 
       //----
 
       QToolBar* tbVoices = addToolBar("Toolbar Voices");
-      bngrpNoteLen = new QButtonGroup();
+      QButtonGroup* bngrpVoices = new QButtonGroup();
+      //bngrpNoteLen = new QButtonGroup();
 
       struct VoiceIconData
       {
@@ -252,7 +258,7 @@ PianorollEditor::PianorollEditor(QWidget* parent)
 
             if (p->_selected)
                   bn->setChecked(true);
-            bngrpNoteLen->addButton(bn);
+            bngrpVoices->addButton(bn);
             tbVoices->addWidget(bn);
             }
 
@@ -476,9 +482,9 @@ PianorollEditor::~PianorollEditor()
 //   setEditNoteLength
 //---------------------------------------------------------
 
-void PianorollEditor:: setEditNoteLength(int len)
+void PianorollEditor::setEditNoteLength(int len)
       {
-            pianoView->setEditNoteLength(len);
+            pianoView->setEditNoteLength(Fraction::fromTicks(pow(2, len + 2) * MScore::division));
       }
 
 //---------------------------------------------------------

--- a/mscore/pianoroll/pianorolledittool.h
+++ b/mscore/pianoroll/pianorolledittool.h
@@ -17,15 +17,15 @@ namespace Ms {
 
 enum PianoRollEditTool
 {
-    SELECT,
-    ADD,
-    CUT,
-    ERASE,
-    EVENT_ADJUST,
-    TIE, //deprecated
-    APPEND_NOTE, //deprecated
+      SELECT,
+      ADD,
+      CUT,
+      ERASE,
+      EVENT_ADJUST,
+      TIE, //deprecated
+      APPEND_NOTE, //deprecated
 
-    LAST  //Marker for end of list - not a tool
+      LAST  //Marker for end of list - not a tool
 };
 
 } // namespace Ms

--- a/mscore/pianoroll/pianorolledittool.h
+++ b/mscore/pianoroll/pianorolledittool.h
@@ -18,12 +18,12 @@ namespace Ms {
 enum PianoRollEditTool
 {
     SELECT,
-    INSERT_NOTE,
-    APPEND_NOTE,
-    CUT_CHORD,
-    CHANGE_LENGTH,
+    ADD,
+    CUT,
     ERASE,
-    TIE,
+    EVENT_ADJUST,
+    TIE, //deprecated
+    APPEND_NOTE, //deprecated
 
     LAST  //Marker for end of list - not a tool
 };

--- a/mscore/pianoroll/pianorolledittool.h
+++ b/mscore/pianoroll/pianorolledittool.h
@@ -26,7 +26,7 @@ enum PianoRollEditTool
       APPEND_NOTE, //deprecated
 
       LAST  //Marker for end of list - not a tool
-};
+      };
 
 } // namespace Ms
 

--- a/mscore/pianoroll/pianoview.cpp
+++ b/mscore/pianoroll/pianoview.cpp
@@ -525,7 +525,7 @@ void PianoView::drawBackground(QPainter* p, const QRectF& r)
 //---------------------------------------------------------
 
 void PianoView::drawNoteBlock(QPainter* p, PianoItem* block)
-{
+      {
       Note* note = block->note();
       if (note->tieBack()) {
             return;

--- a/mscore/pianoroll/pianoview.cpp
+++ b/mscore/pianoroll/pianoview.cpp
@@ -33,6 +33,8 @@
 #include "libmscore/undo.h"
 #include "libmscore/utils.h"
 
+#pragma optimize("", off)
+
 namespace Ms {
 
 extern MuseScore* mscore;
@@ -478,11 +480,21 @@ void PianoView::drawBackground(QPainter* p, const QRectF& r)
             p->drawLine(x, y1, x, y2);
             }
 
+      //----------------------------
       //Draw notes
-      for (int i = 0; i < _noteList.size(); ++i)
-            _noteList[i]->paint(p);
+      //p->setRenderHints(QPainter::Antialiasing | QPainter::SmoothPixmapTransform | QPainter::TextAntialiasing);
+      //for (int i = 0; i < _noteList.size(); ++i)
+      //      _noteList[i]->paint(p);
 
-      if (_dragStyle == DragStyle::NOTES)
+      p->setRenderHints(QPainter::Antialiasing | QPainter::SmoothPixmapTransform | QPainter::TextAntialiasing);
+      for (PianoItem* block : _noteList) {
+          drawNoteBlock(p, block);
+      }
+
+      if (_dragStyle == DragStyle::NOTE_POSITION || _dragStyle == DragStyle::NOTE_LENGTH_END
+            || _dragStyle == DragStyle::NOTE_LENGTH_START || _dragStyle == DragStyle::DRAW_NOTE
+            || _dragStyle == DragStyle::EVENT_LENGTH || _dragStyle == DragStyle::EVENT_MOVE
+            || _dragStyle == DragStyle::EVENT_ONTIME)
             drawDraggedNotes(p);
 
       //Draw locators
@@ -509,6 +521,117 @@ void PianoView::drawBackground(QPainter* p, const QRectF& r)
             }
       }
 
+
+//---------------------------------------------------------
+//   drawNoteBlock
+//---------------------------------------------------------
+
+void PianoView::drawNoteBlock(QPainter* p, PianoItem* block)
+{
+      Note* note = block->note();
+      if (note->tieBack()) {
+            return;
+            }
+
+      QColor noteColor;
+      if (_editNoteTool == PianoRollEditTool::EVENT_ADJUST) {
+            noteColor = _colorTweaks;
+            }
+      else {
+            switch (note->voice()) {
+            case 0:
+                  noteColor = _colorNoteVoice1;
+                  break;
+            case 1:
+                  noteColor = _colorNoteVoice2;
+                  break;
+            case 2:
+                  noteColor = _colorNoteVoice3;
+                  break;
+            case 3:
+                  noteColor = _colorNoteVoice4;
+                  break;
+                  }
+            }
+
+      if (note->selected()) {
+            noteColor = _colorNoteSel;
+            }
+
+    //if (block->staffIdx != m_activeStaff) {
+    //    noteColor = noteColor.lighter(150);
+    //}
+
+      p->setBrush(noteColor);
+      p->setPen(QPen(noteColor.darker(250)));
+
+      for (NoteEvent& e : note->playEvents()) {
+            QRect bounds = boundingRect(note, &e, _editNoteTool == PianoRollEditTool::EVENT_ADJUST);
+            p->drawRoundedRect(bounds, _noteRectRoundedRadius, _noteRectRoundedRadius);
+
+            //Pitch name
+            if (bounds.width() >= 20 && bounds.height() >= 12) {
+                  QRectF textRect(bounds.x() + 2, bounds.y(), bounds.width() - 6, bounds.height() + 1);
+                  QRectF textHiliteRect(bounds.x() + 3, bounds.y() + 1, bounds.width() - 6, bounds.height());
+
+                  QFont f("FreeSans", 8);
+                  p->setFont(f);
+
+                  //Note name
+                  QString name = note->tpcUserName();
+                  p->setPen(QPen(noteColor.lighter(130)));
+                  p->drawText(textHiliteRect, Qt::AlignLeft | Qt::AlignTop, name);
+
+                  p->setPen(QPen(noteColor.darker(180)));
+                  p->drawText(textRect, Qt::AlignLeft | Qt::AlignTop, name);
+                  }
+            }
+}
+
+
+QRect PianoView::boundingRect(Note* note, bool applyEvents)
+      {
+      for (NoteEvent& e : note->playEvents()) {
+            QRect bounds = boundingRect(note, &e, applyEvents);
+            return bounds;
+            }
+      return QRect();
+      }
+
+
+QRect PianoView::boundingRect(Note* note, NoteEvent* evt, bool applyEvents)
+      {
+      Chord* chord = note->chord();
+      int pitch = note->pitch() + (evt ? evt->pitch() : 0);
+
+      Fraction ticks = chord->ticks();
+      Tuplet* tup = chord->tuplet();
+      if (tup) {
+            Fraction frac = tup->ratio();
+            ticks = ticks * frac.inverse();
+            }
+      Fraction tieLen = note->playTicksFraction() - ticks;
+
+      Fraction start;
+      Fraction len;
+      if (evt && applyEvents) {
+            start = note->chord()->tick() + ticks * evt->ontime() / 1000;
+            len = ticks * evt->len() / 1000 + tieLen;
+            }
+      else {
+            start = note->chord()->tick();
+            len = ticks + tieLen;
+            }
+
+      int x0 = tickToPixelX(start.ticks());
+      int y0 = pitchToPixelY(pitch + 1);
+      int x1 = tickToPixelX((start + len).ticks());
+      int y1 = pitchToPixelY(pitch);
+
+      QRect rect;
+      rect.setRect(x0, y0, x1 - x0, y1 - y0);
+      return rect;
+      }
 
 //---------------------------------------------------------
 //   moveLocator
@@ -545,8 +668,8 @@ int PianoView::tickToPixelX(int tick)
 //---------------------------------------------------------
 
 void PianoView::zoomView(int step, bool horizontal, int centerX, int centerY)
-    {
-    if (horizontal) {
+      {
+      if (horizontal) {
             //Horizontal zoom
             QRectF viewRect = mapToScene(viewport()->geometry()).boundingRect();
 
@@ -608,6 +731,8 @@ void PianoView::wheelEvent(QWheelEvent* event)
             zoomView(step, true, event->x(), event->y());
             }
       }
+
+
 
 //---------------------------------------------------------
 //   showPopupMenu
@@ -678,7 +803,7 @@ void PianoView::contextMenuEvent(QContextMenuEvent *event)
 //---------------------------------------------------------
 
 void PianoView::keyReleaseEvent(QKeyEvent* event) {
-      if (_dragStyle == DragStyle::NOTES || _dragStyle == DragStyle::SELECTION_RECT) {
+      if (_dragStyle == DragStyle::NOTE_POSITION || _dragStyle == DragStyle::SELECTION_RECT) {
             if (event->key() == Qt::Key_Escape) {
                   //Cancel drag
                   _dragStyle = DragStyle::CANCELLED;
@@ -699,6 +824,7 @@ void PianoView::mousePressEvent(QMouseEvent* event)
       bool rightBn = event->button() == Qt::RightButton;
       if (!rightBn) {
             _mouseDown = true;
+            _mouseDownScreenPos = event->pos();
             _mouseDownPos = mapToScene(event->pos());
             _lastMousePos = _mouseDownPos;
             scene()->update();
@@ -742,50 +868,84 @@ void PianoView::mouseReleaseEvent(QMouseEvent* event)
 
                   int startTick = pixelXToTick((int)minX);
                   int endTick = pixelXToTick((int)maxX);
-                  int lowPitch = (int)floor(128 - maxY / noteHeight());
-                  int highPitch = (int)ceil(128 - minY / noteHeight());
+                  int lowPitch = pixelYToPitch(maxY);
+                  int highPitch = pixelYToPitch(minY);
 
                   selectNotes(startTick, endTick, lowPitch, highPitch, selType);
                   }
-            else if (_dragStyle == DragStyle::NOTES) {
-                  if (toolCanDragNotes()) {
-                        finishNoteGroupDrag();
+            else if (_dragStyle == DragStyle::NOTE_POSITION || _dragStyle == DragStyle::NOTE_LENGTH_START
+                  || _dragStyle == DragStyle::NOTE_LENGTH_END) {
+                  if (_editNoteTool == PianoRollEditTool::SELECT || _editNoteTool == PianoRollEditTool::ADD) {
+                        finishNoteGroupDrag(event);
 
                         //Keep last note drag event, if any
                         if (_inProgressUndoEvent)
                               _inProgressUndoEvent = false;
                         }
                   }
+            else if (_dragStyle == DragStyle::EVENT_ONTIME || _dragStyle == DragStyle::EVENT_MOVE
+                  || _dragStyle == DragStyle::EVENT_LENGTH) {
+                  finishNoteEventAdjustDrag();
+                  }
+            else if (_dragStyle == DragStyle::DRAW_NOTE) {
+                  double startTick = pixelXToTick(_mouseDownPos.x());
+                  double endTick = pixelXToTick(_lastMousePos.x());
+                  if (startTick > endTick) {
+                        std::swap(startTick, endTick);
+                        }
 
-            _dragStarted = false;
+                  Fraction startTickFrac = roundToStartBeat(startTick);
+                   Fraction endTickFrac = roundToStartBeat(endTick, false);
+
+                   if (endTickFrac != startTickFrac) {
+                        double pitch = pixelYToPitch(_mouseDownPos.y());
+
+                        Score* curScore = _staff->score();
+
+                        int voice = _editNoteVoice;
+                        int track = (int)_staff->idx() * VOICES + voice;
+
+                        Fraction duration = endTickFrac - startTickFrac;
+
+                        //Store duration as new length for future single-click note add events
+                        _editNoteLength = duration;
+
+                        //Do command
+                        curScore->startCmd();
+                        addNote(startTickFrac, duration, (int)pitch, track);
+                        curScore->endCmd();
+
+                        updateNotes();
+                        }
+                  }
+
+                  _dragStarted = false;
             }
       else {
             //This was just a click, not a drag
             switch (_editNoteTool) {
             case SELECT:
+            case EVENT_ADJUST:
                   handleSelectionClick();
-                  break;
-            case CHANGE_LENGTH:
-                  changeChordLength(_mouseDownPos);
                   break;
             case ERASE:
                   eraseNote(_mouseDownPos);
                   break;
-            case INSERT_NOTE:
+            case ADD:
                   insertNote(modifiers);
                   break;
             case APPEND_NOTE:
                   appendNoteToChord(_mouseDownPos);
                   break;
-            case CUT_CHORD:
+            case CUT:
                   cutChord(_mouseDownPos);
                   break;
             case TIE:
                   toggleTie(_mouseDownPos);
                   break;
             default:
-                break;
-                }
+                  break;
+                  }
 
             }
 
@@ -796,17 +956,115 @@ void PianoView::mouseReleaseEvent(QMouseEvent* event)
       }
 
 
+//---------------------------------------------------------
+//   finishNoteEventAdjustDrag
+//---------------------------------------------------------
+
+void PianoView::finishNoteEventAdjustDrag()
+{
+      Score* curScore = _staff->score();
+      Fraction dx = Fraction::fromTicks(pixelXToTick(_lastMousePos.x()) - pixelXToTick(_mouseDownPos.x()));
+
+      for (int i = 0; i < _noteList.size(); ++i) {
+            PianoItem* pi = _noteList[i];
+            if (pi->note()->selected()) {
+                  for (NoteEvent& e : pi->note()->playEvents()) {
+                        Chord* chord = pi->note()->chord();
+                        Fraction ticks = chord->ticks();
+                        Tuplet* tup = chord->tuplet();
+                        if (tup) {
+                              Fraction frac = tup->ratio();
+                              ticks = ticks * frac.inverse();
+                              }
+
+                        Fraction start = pi->note()->chord()->tick();
+                        Fraction len = ticks;
+                        Fraction startAdj = start + ticks * e.ontime() / 1000;
+                        Fraction lenAdj = ticks * e.len() / 1000;
+
+                        //Calc start, duration of where we dragged to
+                        Fraction startNew;
+                        Fraction lenNew;
+                        switch (_dragStyle) {
+                        case DragStyle::EVENT_ONTIME:
+                              startNew = startAdj + dx;
+                              lenNew = lenAdj - dx;
+                              break;
+                        case DragStyle::EVENT_MOVE:
+                              startNew = startAdj + dx;
+                              lenNew = lenAdj;
+                              break;
+                        default:
+                        case DragStyle::EVENT_LENGTH:
+                              startNew = startAdj;
+                              lenNew = lenAdj + dx;
+                              break;
+                              }
+
+                        int evtOntimeNew = int(((startNew - start) / ticks).toDouble() * 1000);
+                        int evtLenNew = int((lenNew / ticks).toDouble() * 1000);
+                        if (evtLenNew < 1) {
+                              evtLenNew = 1;
+                              }
+
+                        NoteEvent ne = e;
+                        ne.setOntime(evtOntimeNew);
+                        ne.setLen(evtLenNew);
+
+                        curScore->startCmd();
+                        curScore->undo(new ChangeNoteEvent(pi->note(), &e, ne));
+                        curScore->endCmd();
+                        }
+                  }
+            }
+
+      update();
+}
+
+
+//---------------------------------------------------------
+//   hoverMoveEvent
+//---------------------------------------------------------
+
+void PianoView::updateCursor()
+{
+      if (_editNoteTool == PianoRollEditTool::SELECT
+            || _editNoteTool == PianoRollEditTool::ADD
+            || _editNoteTool == PianoRollEditTool::EVENT_ADJUST) {
+
+            QPointF pos = _lastMousePos;
+            int tick = pixelXToTick(pos.x());
+            int pitch = pixelYToPitch(pos.y());
+            PianoItem* pi = pickNote(tick, pitch);
+
+            if (pi) {
+                  QRect bounds = boundingRect(pi->note(), _editNoteTool == PianoRollEditTool::EVENT_ADJUST);
+                  if (bounds.contains(pos.x(), pos.y())) {
+                        if (pos.x() <= bounds.x() + _dragNoteLengthMargin
+                              || pos.x() >= bounds.x() + bounds.width() - _dragNoteLengthMargin) {
+                              setCursor(Qt::SizeHorCursor);
+                              return;
+                              }
+                        }
+                  }
+            }
+
+      setCursor(Qt::ArrowCursor);
+}
 
 //---------------------------------------------------------
 //   mouseMoveEvent
 //---------------------------------------------------------
 
 void PianoView::mouseMoveEvent(QMouseEvent* event)
-      {
+{
       if (_dragStyle == DragStyle::CANCELLED)
             return;
 
+      _lastMouseScreenPos = event->pos();
       _lastMousePos = mapToScene(event->pos());
+
+      updateCursor();
 
       if (_mouseDown && !_dragStarted) {
             qreal dx = _lastMousePos.x() - _mouseDownPos.x();
@@ -816,43 +1074,98 @@ void PianoView::mouseMoveEvent(QMouseEvent* event)
                   //Start dragging
                   _dragStarted = true;
 
-                  //Check for move note
-                  int tick = pixelXToTick(_mouseDownPos.x());
-                  int mouseDownPitch = pixelYToPitch(_mouseDownPos.y());
-                  PianoItem* pi = pickNote(tick, mouseDownPitch);
-                  if (pi && toolCanDragNotes()) {
-                        if (!pi->note()->selected()) {
-                              selectNotes(tick, tick, mouseDownPitch, mouseDownPitch, NoteSelectType::REPLACE);
-                              }
-                        _dragStyle = DragStyle::NOTES;
-                        _dragStartPitch = mouseDownPitch;
-                        _dragNoteCache = serializeSelectedNotes();
+                  if (event->buttons() & Qt::MiddleButton) {
+                        _dragStyle = DragStyle::MOVE_VIEWPORT;
+
+                        QRectF rect = mapToScene(viewport()->geometry()).boundingRect();
+                        _viewportFocus = rect.center();
                         }
-                  else if (!pi && _editNoteTool == PianoRollEditTool::SELECT)
-                        _dragStyle = DragStyle::SELECTION_RECT;
-                  else
-                        _dragStyle = DragStyle::NONE;
+                  else {
+                        //Check for move note
+                        int tick = pixelXToTick(_mouseDownPos.x());
+                        int mouseDownPitch = pixelYToPitch(_mouseDownPos.y());
+
+                        PianoItem* pi = pickNote(tick, mouseDownPitch);
+                        if (pi && (_editNoteTool == PianoRollEditTool::SELECT || _editNoteTool == PianoRollEditTool::ADD)) {
+                              if (!pi->note()->selected()) {
+                                    selectNotes(tick, tick, mouseDownPitch, mouseDownPitch, NoteSelectType::REPLACE);
+                                    }
+
+                              //QRect bounds = boundingRect(pi->note, false);
+                              QRect bounds = pi->boundingRect();
+                              if (_mouseDownPos.x() <= bounds.x() + _dragNoteLengthMargin) {
+                                    _dragStyle = DragStyle::NOTE_LENGTH_START;
+                                    }
+                              else if (_mouseDownPos.x() >= bounds.x() + bounds.width() - _dragNoteLengthMargin) {
+                                    _dragStyle = DragStyle::NOTE_LENGTH_END;
+                              }
+                              else {
+                                    _dragStyle = DragStyle::NOTE_POSITION;
+                              }
+
+                              _dragStartPitch = mouseDownPitch;
+                              _dragStartTick = pi->note()->tick();
+                              _dragEndTick = _dragStartTick + pi->note()->chord()->ticks();
+                              _dragNoteCache = serializeSelectedNotes();
+                        }
+                        else if (pi && _editNoteTool == PianoRollEditTool::EVENT_ADJUST) {
+                              if (!pi->note()->selected()) {
+                                    selectNotes(tick, tick, mouseDownPitch, mouseDownPitch, NoteSelectType::REPLACE);
+                                    }
+
+                              QRect bounds = boundingRect(pi->note(), true);
+                              //QRect bounds = pi->boundingRect();
+                              if (_mouseDownPos.x() <= bounds.x() + _dragNoteLengthMargin) {
+                                    _dragStyle = DragStyle::EVENT_ONTIME;
+                                    }
+                              else if (_mouseDownPos.x() >= bounds.x() + bounds.width() - _dragNoteLengthMargin) {
+                                    _dragStyle = DragStyle::EVENT_LENGTH;
+                                    }
+                              else {
+                                    _dragStyle = DragStyle::EVENT_MOVE;
+                                    }
+                        }
+                        else if (!pi && _editNoteTool == PianoRollEditTool::SELECT) {
+                              _dragStyle = DragStyle::SELECTION_RECT;
+                              }
+                        else if (!pi && _editNoteTool == PianoRollEditTool::ADD) {
+                              _dragStyle = DragStyle::DRAW_NOTE;
+                              }
+                        else
+                              _dragStyle = DragStyle::NONE;
                   }
             }
+      }
 
       if (_dragStarted) {
-          switch (_editNoteTool) {
-          case SELECT:
-          case INSERT_NOTE:
-          case APPEND_NOTE:
-          case CUT_CHORD:
-          case TIE:
-                scene()->update();
-                break;
-          case CHANGE_LENGTH:
-                changeChordLength(_lastMousePos);
-                break;
-          case ERASE:
-                eraseNote(_lastMousePos);
-                break;
-          default:
-                break;
-                }
+            if (_dragStyle == DragStyle::MOVE_VIEWPORT) {
+                  qreal dx = _lastMouseScreenPos.x() - _mouseDownScreenPos.x();
+                  qreal dy = _lastMouseScreenPos.y() - _mouseDownScreenPos.y();
+
+                  QRectF rect = mapToScene(viewport()->geometry()).boundingRect();
+                  qreal px = _viewportFocus.x() - dx;
+                  qreal py = _viewportFocus.y() - dy;
+                  horizontalScrollBar()->setValue(qMax(px - rect.width() / 2, 0.0));
+                  verticalScrollBar()->setValue(qMax(py - rect.height() / 2, 0.0));
+                  }
+            else {
+                  switch (_editNoteTool) {
+                  case SELECT:
+                  case ADD:
+                  case EVENT_ADJUST:
+                  case APPEND_NOTE:
+                  case CUT:
+                  case TIE:
+                        scene()->update();
+                        break;
+                  case ERASE:
+                        eraseNote(_lastMousePos);
+                        scene()->update();
+                        break;
+                  default:
+                        break;
+                        }
+                  }
             }
 
 
@@ -864,13 +1177,13 @@ void PianoView::mouseMoveEvent(QMouseEvent* event)
       int tick = pixelXToTick(p.x());
       if (tick < 0) {
             tick = 0;
-            trackingPos.setTick(tick);
-            trackingPos.setInvalid();
+            _trackingPos.setTick(tick);
+            _trackingPos.setInvalid();
             }
       else
-            trackingPos.setTick(tick);
-      emit trackingPosChanged(trackingPos);
-      }
+            _trackingPos.setTick(tick);
+      emit trackingPosChanged(_trackingPos);
+}
 
 
 //---------------------------------------------------------
@@ -894,8 +1207,8 @@ void PianoView::dragSelectionNoteGroup() {
             _inProgressUndoEvent = true;
             _dragStartPitch = curPitch;
             }
-      scene()->update();
 
+      scene()->update();
       }
 
 
@@ -1041,7 +1354,7 @@ void PianoView::changeChordLength(const QPointF& pos) {
 //   roundToStartBeat
 //---------------------------------------------------------
 
-Fraction PianoView::roundToStartBeat(int tick)  const
+Fraction PianoView::roundToStartBeat(int tick, bool down)  const
       {
       Score* _score = _staff->score();
       Pos barPos(_score->tempomap(), _score->sigmap(), tick, TType::TICKS);
@@ -1054,7 +1367,8 @@ Fraction PianoView::roundToStartBeat(int tick)  const
 
       //Round down to nearest division
       Fraction pickFrac = Fraction::fromTicks(tick);
-      int numDiv = (int)floor((pickFrac.numerator() * divisions / (double)pickFrac.denominator()));
+      double frac = (pickFrac.numerator() * divisions / (double)pickFrac.denominator());
+      int numDiv = (int)(down ? floor(frac) : ceil(frac));
       return Fraction(numDiv, divisions);
       }
 
@@ -1065,15 +1379,7 @@ Fraction PianoView::roundToStartBeat(int tick)  const
 
 Fraction PianoView::noteEditLength() const
       {
-      //Find n, d such that n/d = 2^_editNoteLength
-      int n = _editNoteLength > 0 ? (1 << _editNoteLength) : 1;
-      int d = _editNoteLength < 0 ? (1 << -_editNoteLength) : 1;
-
-      //dots multiplier is (2^(n + 1) - 1)/(2^n) where n is the number of dots
-      int dotN = (1 << (_editNoteDots + 1)) - 1;
-      int dotD = 1 << _editNoteDots;
-
-      return Fraction(n * dotN, d * dotD);
+      return _editNoteLength;
       }
 
 
@@ -1541,8 +1847,8 @@ void PianoView::selectNotes(int startTick, int endTick, int lowPitch, int highPi
 void PianoView::leaveEvent(QEvent* event)
       {
       emit pitchChanged(-1);
-      trackingPos.setInvalid();
-      emit trackingPosChanged(trackingPos);
+      _trackingPos.setInvalid();
+      emit trackingPosChanged(_trackingPos);
       QGraphicsView::leaveEvent(event);
       }
 
@@ -1595,7 +1901,7 @@ void PianoView::setStaff(Staff* s, Pos* l)
             return;
             }
 
-      trackingPos.setContext(_staff->score()->tempomap(), _staff->score()->sigmap());
+      _trackingPos.setContext(_staff->score()->tempomap(), _staff->score()->sigmap());
       updateBoundingSize();
 
       updateNotes();
@@ -1985,7 +2291,7 @@ void PianoView::pasteNotesAtCursor()
             QByteArray copiedNotes = ms->data(PIANO_NOTE_MIME_TYPE);
 
             score->startCmd();
-            pasteNotes(copiedNotes, pasteStartTick, 0);
+            pasteNotes(copiedNotes, pasteStartTick, Fraction(0, 1), 0);
             score->endCmd();
             }
 
@@ -1996,44 +2302,80 @@ void PianoView::pasteNotesAtCursor()
 //   finishNoteGroupDrag
 //---------------------------------------------------------
 
-void PianoView::finishNoteGroupDrag() {
+void PianoView::finishNoteGroupDrag(QMouseEvent* event) {
       Score* score = _staff->score();
 
-      Pos barPos(score->tempomap(), score->sigmap(), pixelXToTick(_lastMousePos.x()), TType::TICKS);
+      Fraction pos = Fraction::fromTicks(pixelXToTick(_lastMousePos.x()));
+      Measure* m = score->tick2measure(pos);
 
-      int beatsInBar = barPos.timesig().timesig().numerator();
+      Fraction timeSig = m->timesig();
+      int noteWithBeat = timeSig.denominator();
 
       //Number of smaller pieces the beat is divided into
       int subbeats = _tuplet * (1 << _subdiv);
-      int divisions = beatsInBar * subbeats;
+      int divisions = noteWithBeat * subbeats;
 
       //Round down to nearest division
-      QPointF offset = _lastMousePos - _mouseDownPos;
+      double dragToTick = pixelXToTick(_lastMousePos.x());
+      double startTick = pixelXToTick(_mouseDownPos.x());
+      Fraction dragOffsetTicks = Fraction::fromTicks(dragToTick - startTick);
 
-      Fraction tickOffset = Fraction::fromTicks(offset.x() / _xZoom);
-      //Round down to nearest division
-      int numDiv = (int)floor((tickOffset.numerator() * divisions / (double)tickOffset.denominator()));
-      Fraction pasteTickOffset(numDiv, divisions);
+      //Adjust offset so that note under cursor is aligned to note divistion
+      Fraction pasteTickOffset(0, 1);
+      Fraction pasteLengthOffset(0, 1);
+      int pitchOffset = 0;
 
-      int pitchOffset = (int)(-offset.y() / _noteHeight);
+      int dragToPitch = pixelYToPitch(_lastMousePos.y());
+      int startPitch = pixelYToPitch(_mouseDownPos.y());
 
+      if (_dragStyle == DragStyle::NOTE_POSITION) {
+            Fraction noteStartDraggedTick = _dragStartTick + dragOffsetTicks;
+            Fraction noteStartDraggedAlignedTick = Fraction(noteStartDraggedTick.numerator() * divisions / noteStartDraggedTick.denominator(), divisions);
+            pasteTickOffset = noteStartDraggedAlignedTick - _dragStartTick;
+            pitchOffset = dragToPitch - startPitch;
+      }
+      else if (_dragStyle == DragStyle::NOTE_LENGTH_END) {
+            Fraction noteEndDraggedTick = _dragEndTick + dragOffsetTicks;
+            Fraction noteEndDraggedAlignedTick = Fraction(noteEndDraggedTick.numerator() * divisions / noteEndDraggedTick.denominator(), divisions);
+            pasteLengthOffset = noteEndDraggedAlignedTick - _dragEndTick;
+      }
+      else if (_dragStyle == DragStyle::NOTE_LENGTH_START) {
+            Fraction noteStartDraggedTick = _dragStartTick + dragOffsetTicks;
+            Fraction noteStartDraggedAlignedTick = Fraction(noteStartDraggedTick.numerator() * divisions / noteStartDraggedTick.denominator(), divisions);
+            pasteTickOffset = noteStartDraggedAlignedTick - _dragStartTick;
+            pasteLengthOffset = _dragStartTick - noteStartDraggedAlignedTick;
+      }
 
       //Do command
       score->startCmd();
 
-      score->cmdDeleteSelection();
-      pasteNotes(_dragNoteCache, pasteTickOffset, pitchOffset, true);
+      if (!(event->modifiers() & Qt::ShiftModifier)) {
+            score->cmdDeleteSelection();
+      }
+      QVector<Note*> notes = pasteNotes(_dragNoteCache, pasteTickOffset, pasteLengthOffset, pitchOffset, true);
+
+      //Select just pasted notes
+      Selection& selection = score->selection();
+      selection.deselectAll();
+      for (Note* note : notes) {
+            selection.add(note);
+            note->setSelected(true);
+      }
 
       score->endCmd();
 
       _dragNoteCache = QByteArray();
+
+      score->update();
+      updateNotes();
+      update();
       }
 
 //---------------------------------------------------------
 //   pasteNotes
 //---------------------------------------------------------
 
-void PianoView::pasteNotes(const QString& copiedNotes, Fraction pasteStartTick, int pitchOffset, bool xIsOffset)
+QVector<Note*> PianoView::pasteNotes(const QString& copiedNotes, Fraction pasteStartTick, Fraction lengthOffset, int pitchOffset, bool xIsOffset)
       {
 
       QXmlStreamReader xml(copiedNotes);
@@ -2056,6 +2398,10 @@ void PianoView::pasteNotes(const QString& copiedNotes, Fraction pasteStartTick, 
                         int tn = xml.attributes().value("lenN").toString().toInt();
                         int td = xml.attributes().value("lenD").toString().toInt();
                         Fraction tickLen = Fraction(tn, td);
+                        tickLen += lengthOffset;
+                        if (tickLen.numerator() <= 0) {
+                            continue;
+                        }
 
                         int pitch = xml.attributes().value("pitch").toString().toInt();
                         int voice = xml.attributes().value("voice").toString().toInt();
@@ -2091,6 +2437,8 @@ void PianoView::pasteNotes(const QString& copiedNotes, Fraction pasteStartTick, 
                         }
                   }
             }
+
+      return addedNotes;
       }
 
 
@@ -2109,26 +2457,122 @@ void PianoView::drawDraggedNotes(QPainter* painter)
                   break;
             }
 
-
       Score* score = _staff->score();
 
-      Pos barPos(score->tempomap(), score->sigmap(), pixelXToTick(_lastMousePos.x()), TType::TICKS);
+      if (_dragStyle == DragStyle::DRAW_NOTE) {
+          double startTick = pixelXToTick(_mouseDownPos.x());
+          double endTick = pixelXToTick(_lastMousePos.x());
+          if (startTick > endTick) {
+              std::swap(startTick, endTick);
+          }
 
-      int beatsInBar = barPos.timesig().timesig().numerator();
+          Fraction startTickFrac = roundToStartBeat(startTick);
+          Fraction endTickFrac = roundToStartBeat(endTick, false);
+
+          if (endTickFrac != startTickFrac) {
+              double pitch = pixelYToPitch(_mouseDownPos.y());
+              int track = (int)_staff->idx() * VOICES + _editNoteVoice;
+
+              drawDraggedNote(painter, startTickFrac, endTickFrac - startTickFrac, pitch, track, _colorNoteDrag);
+          }
+          return;
+      }
+
+      if (_dragStyle == DragStyle::EVENT_LENGTH || _dragStyle == DragStyle::EVENT_MOVE
+            || _dragStyle == DragStyle::EVENT_ONTIME) {
+          
+            Fraction dx = Fraction::fromTicks(pixelXToTick(_lastMousePos.x()) - pixelXToTick(_mouseDownPos.x()));
+
+            for (int i = 0; i < _noteList.size(); ++i) {
+                  PianoItem* pi = _noteList[i];
+                  if (pi->note()->selected()) {
+                        for (NoteEvent& e : pi->note()->playEvents()) {
+                              Chord* chord = pi->note()->chord();
+                              Fraction ticks = chord->ticks();
+                              Tuplet* tup = chord->tuplet();
+                              if (tup) {
+                                    Fraction frac = tup->ratio();
+                                    ticks = ticks * frac.inverse();
+                                    }
+
+                              Fraction start = pi->note()->chord()->tick();
+                              Fraction len = ticks;
+                              Fraction startAdj = start + ticks * e.ontime() / 1000;
+                              Fraction lenAdj = ticks * e.len() / 1000;
+
+                              //Calc start, duration of where we dragged to
+                              Fraction startNew;
+                              Fraction lenNew;
+                              switch (_dragStyle) {
+                              case DragStyle::EVENT_ONTIME:
+                                    startNew = startAdj + dx;
+                                    lenNew = lenAdj - dx;
+                                    break;
+                              case DragStyle::EVENT_MOVE:
+                                    startNew = startAdj + dx;
+                                    lenNew = lenAdj;
+                                    break;
+                              default:
+                              case DragStyle::EVENT_LENGTH:
+                                    startNew = startAdj;
+                                    lenNew = lenAdj + dx;
+                                    break;
+                                    }
+
+                              int pitch = pi->note()->pitch();
+                              int voice = pi->note()->voice();
+                              int track = (int)_staff->idx() * VOICES + voice;
+
+                              drawDraggedNote(painter, startNew, lenNew, pitch, track, _colorNoteDrag);
+                              }
+                        }
+                  }
+
+                  return;
+            }
+
+      Fraction pos = Fraction::fromTicks(pixelXToTick(_lastMousePos.x()));
+      Measure* m = score->tick2measure(pos);
+
+      int ticksPerWholeNote = MScore::division * 4;
+      Fraction timeSig = m->timesig();
+      int noteWithBeat = timeSig.denominator();
 
       //Number of smaller pieces the beat is divided into
       int subbeats = _tuplet * (1 << _subdiv);
-      int divisions = beatsInBar * subbeats;
+      int divisions = noteWithBeat * subbeats;
 
-      QPointF offset = _lastMousePos - _mouseDownPos;
-
-      Fraction tickOffset = Fraction::fromTicks(offset.x() / _xZoom);
       //Round down to nearest division
-      int numDiv = (int)floor((tickOffset.numerator() * divisions / (double)tickOffset.denominator()));
-      Fraction pasteTickOffset(numDiv, divisions);
+      double dragToTick = pixelXToTick(_lastMousePos.x());
+      double startTick = pixelXToTick(_mouseDownPos.x());
+      Fraction dragOffsetTicks = Fraction::fromTicks(dragToTick - startTick);
 
-      int pitchOffset = (int)(-offset.y() / _noteHeight);
+      //Adjust offset so that note under cursor is aligned to note divistion
+      Fraction pasteTickOffset(0, 1);
+      Fraction pasteLengthOffset(0, 1);
+      int pitchOffset = 0;
 
+      int dragToPitch = pixelYToPitch(_lastMousePos.y());
+      int startPitch = pixelYToPitch(_mouseDownPos.y());
+      
+      if (_dragStyle == DragStyle::NOTE_POSITION) {
+            Fraction noteStartDraggedTick = _dragStartTick + dragOffsetTicks;
+            Fraction noteStartDraggedAlignedTick = Fraction(noteStartDraggedTick.numerator() * divisions / noteStartDraggedTick.denominator(), divisions);
+            pasteTickOffset = noteStartDraggedAlignedTick - _dragStartTick;
+            pitchOffset = dragToPitch - startPitch;
+            }
+      else if (_dragStyle == DragStyle::NOTE_LENGTH_END) {
+            Fraction noteEndDraggedTick = _dragEndTick + dragOffsetTicks;
+            Fraction noteEndDraggedAlignedTick = Fraction(noteEndDraggedTick.numerator() * divisions / noteEndDraggedTick.denominator(), divisions);
+            pasteLengthOffset = noteEndDraggedAlignedTick - _dragEndTick;
+            }
+      else if (_dragStyle == DragStyle::NOTE_LENGTH_START) {
+            Fraction noteStartDraggedTick = _dragStartTick + dragOffsetTicks;
+            Fraction noteStartDraggedAlignedTick = Fraction(noteStartDraggedTick.numerator() * divisions / noteStartDraggedTick.denominator(), divisions);
+            pasteTickOffset = noteStartDraggedAlignedTick - _dragStartTick;
+            pasteLengthOffset = _dragStartTick - noteStartDraggedAlignedTick;
+            }
+      
       //Iterate thorugh note data
       QXmlStreamReader xml(_dragNoteCache);
       Fraction firstTick;
@@ -2149,6 +2593,10 @@ void PianoView::drawDraggedNotes(QPainter* painter)
                         int tn = xml.attributes().value("lenN").toString().toInt();
                         int td = xml.attributes().value("lenD").toString().toInt();
                         Fraction tickLen = Fraction(tn, td);
+                        tickLen += pasteLengthOffset;
+                        if (tickLen.numerator() <= 0) {
+                            continue;
+                        }
 
                         int pitch = xml.attributes().value("pitch").toString().toInt();
                         int voice = xml.attributes().value("voice").toString().toInt();

--- a/mscore/pianoroll/pianoview.cpp
+++ b/mscore/pianoroll/pianoview.cpp
@@ -33,8 +33,6 @@
 #include "libmscore/undo.h"
 #include "libmscore/utils.h"
 
-#pragma optimize("", off)
-
 namespace Ms {
 
 extern MuseScore* mscore;

--- a/mscore/pianoroll/pianoview.cpp
+++ b/mscore/pianoroll/pianoview.cpp
@@ -487,7 +487,7 @@ void PianoView::drawBackground(QPainter* p, const QRectF& r)
       p->setRenderHints(QPainter::Antialiasing | QPainter::SmoothPixmapTransform | QPainter::TextAntialiasing);
       for (PianoItem* block : _noteList) {
             drawNoteBlock(p, block);
-      }
+            }
 
       if (_dragStyle == DragStyle::NOTE_POSITION || _dragStyle == DragStyle::NOTE_LENGTH_END
             || _dragStyle == DragStyle::NOTE_LENGTH_START || _dragStyle == DragStyle::DRAW_NOTE
@@ -731,7 +731,6 @@ void PianoView::wheelEvent(QWheelEvent* event)
       }
 
 
-
 //---------------------------------------------------------
 //   showPopupMenu
 //---------------------------------------------------------
@@ -959,7 +958,7 @@ void PianoView::mouseReleaseEvent(QMouseEvent* event)
 //---------------------------------------------------------
 
 void PianoView::finishNoteEventAdjustDrag()
-{
+      {
       Score* curScore = _staff->score();
       Fraction dx = Fraction::fromTicks(pixelXToTick(_lastMousePos.x()) - pixelXToTick(_mouseDownPos.x()));
 
@@ -1017,7 +1016,7 @@ void PianoView::finishNoteEventAdjustDrag()
             }
 
       update();
-}
+      }
 
 
 //---------------------------------------------------------
@@ -1025,7 +1024,7 @@ void PianoView::finishNoteEventAdjustDrag()
 //---------------------------------------------------------
 
 void PianoView::updateCursor()
-{
+      {
       if (_editNoteTool == PianoRollEditTool::SELECT
             || _editNoteTool == PianoRollEditTool::ADD
             || _editNoteTool == PianoRollEditTool::EVENT_ADJUST) {
@@ -1048,14 +1047,14 @@ void PianoView::updateCursor()
             }
 
       setCursor(Qt::ArrowCursor);
-}
+      }
 
 //---------------------------------------------------------
 //   mouseMoveEvent
 //---------------------------------------------------------
 
 void PianoView::mouseMoveEvent(QMouseEvent* event)
-{
+      {
       if (_dragStyle == DragStyle::CANCELLED)
             return;
 
@@ -1096,16 +1095,16 @@ void PianoView::mouseMoveEvent(QMouseEvent* event)
                                     }
                               else if (_mouseDownPos.x() >= bounds.x() + bounds.width() - _dragNoteLengthMargin) {
                                     _dragStyle = DragStyle::NOTE_LENGTH_END;
-                              }
+                                    }
                               else {
                                     _dragStyle = DragStyle::NOTE_POSITION;
-                              }
+                                    }
 
                               _dragStartPitch = mouseDownPitch;
                               _dragStartTick = pi->note()->tick();
                               _dragEndTick = _dragStartTick + pi->note()->chord()->ticks();
                               _dragNoteCache = serializeSelectedNotes();
-                        }
+                              }
                         else if (pi && _editNoteTool == PianoRollEditTool::EVENT_ADJUST) {
                               if (!pi->note()->selected()) {
                                     selectNotes(tick, tick, mouseDownPitch, mouseDownPitch, NoteSelectType::REPLACE);
@@ -1950,9 +1949,9 @@ void PianoView::setStaff(Staff* s, Pos* l)
 
 void PianoView::addChord(Chord* chrd, int voice)
       {
-      for (Chord* c: chrd->graceNotes())
+      for (Chord* c : chrd->graceNotes())
             addChord(c, voice);
-      for (Note* note: chrd->notes()) {
+      for (Note* note : chrd->notes()) {
             if (note->tieBack())
                   continue;
             _noteList.append(new PianoItem(note, this));
@@ -2331,25 +2330,25 @@ void PianoView::finishNoteGroupDrag(QMouseEvent* event) {
             Fraction noteStartDraggedAlignedTick = Fraction(noteStartDraggedTick.numerator() * divisions / noteStartDraggedTick.denominator(), divisions);
             pasteTickOffset = noteStartDraggedAlignedTick - _dragStartTick;
             pitchOffset = dragToPitch - startPitch;
-      }
+            }
       else if (_dragStyle == DragStyle::NOTE_LENGTH_END) {
             Fraction noteEndDraggedTick = _dragEndTick + dragOffsetTicks;
             Fraction noteEndDraggedAlignedTick = Fraction(noteEndDraggedTick.numerator() * divisions / noteEndDraggedTick.denominator(), divisions);
             pasteLengthOffset = noteEndDraggedAlignedTick - _dragEndTick;
-      }
+            }
       else if (_dragStyle == DragStyle::NOTE_LENGTH_START) {
             Fraction noteStartDraggedTick = _dragStartTick + dragOffsetTicks;
             Fraction noteStartDraggedAlignedTick = Fraction(noteStartDraggedTick.numerator() * divisions / noteStartDraggedTick.denominator(), divisions);
             pasteTickOffset = noteStartDraggedAlignedTick - _dragStartTick;
             pasteLengthOffset = _dragStartTick - noteStartDraggedAlignedTick;
-      }
+            }
 
       //Do command
       score->startCmd();
 
       if (!(event->modifiers() & Qt::ShiftModifier)) {
             score->cmdDeleteSelection();
-      }
+            }
       QVector<Note*> notes = pasteNotes(_dragNoteCache, pasteTickOffset, pasteLengthOffset, pitchOffset, true);
 
       //Select just pasted notes
@@ -2358,7 +2357,7 @@ void PianoView::finishNoteGroupDrag(QMouseEvent* event) {
       for (Note* note : notes) {
             selection.add(note);
             note->setSelected(true);
-      }
+            }
 
       score->endCmd();
 
@@ -2399,7 +2398,7 @@ QVector<Note*> PianoView::pasteNotes(const QString& copiedNotes, Fraction pasteS
                         tickLen += lengthOffset;
                         if (tickLen.numerator() <= 0) {
                               continue;
-                        }
+                              }
 
                         int pitch = xml.attributes().value("pitch").toString().toInt();
                         int voice = xml.attributes().value("voice").toString().toInt();
@@ -2458,23 +2457,23 @@ void PianoView::drawDraggedNotes(QPainter* painter)
       Score* score = _staff->score();
 
       if (_dragStyle == DragStyle::DRAW_NOTE) {
-          double startTick = pixelXToTick(_mouseDownPos.x());
-          double endTick = pixelXToTick(_lastMousePos.x());
-          if (startTick > endTick) {
-                std::swap(startTick, endTick);
-          }
+            double startTick = pixelXToTick(_mouseDownPos.x());
+            double endTick = pixelXToTick(_lastMousePos.x());
+            if (startTick > endTick) {
+                  std::swap(startTick, endTick);
+            }
 
-          Fraction startTickFrac = roundToStartBeat(startTick);
-          Fraction endTickFrac = roundToStartBeat(endTick, false);
+            Fraction startTickFrac = roundToStartBeat(startTick);
+            Fraction endTickFrac = roundToStartBeat(endTick, false);
 
-          if (endTickFrac != startTickFrac) {
-                double pitch = pixelYToPitch(_mouseDownPos.y());
-                int track = (int)_staff->idx() * VOICES + _editNoteVoice;
+            if (endTickFrac != startTickFrac) {
+                  double pitch = pixelYToPitch(_mouseDownPos.y());
+                  int track = (int)_staff->idx() * VOICES + _editNoteVoice;
 
-                drawDraggedNote(painter, startTickFrac, endTickFrac - startTickFrac, pitch, track, _colorNoteDrag);
-          }
-          return;
-      }
+                  drawDraggedNote(painter, startTickFrac, endTickFrac - startTickFrac, pitch, track, _colorNoteDrag);
+                  }
+            return;
+            }
 
       if (_dragStyle == DragStyle::EVENT_LENGTH || _dragStyle == DragStyle::EVENT_MOVE
             || _dragStyle == DragStyle::EVENT_ONTIME) {
@@ -2593,8 +2592,8 @@ void PianoView::drawDraggedNotes(QPainter* painter)
                         Fraction tickLen = Fraction(tn, td);
                         tickLen += pasteLengthOffset;
                         if (tickLen.numerator() <= 0) {
-                            continue;
-                        }
+                              continue;
+                              }
 
                         int pitch = xml.attributes().value("pitch").toString().toInt();
                         int voice = xml.attributes().value("voice").toString().toInt();

--- a/mscore/pianoroll/pianoview.cpp
+++ b/mscore/pianoroll/pianoview.cpp
@@ -120,10 +120,10 @@ QRect PianoItem::boundingRectPixels(NoteEvent* evt)
       int noteHeight = _pianoView->noteHeight();
 
       rect.setRect(_pianoView->tickToPixelX(rect.x()),
-              (127 - rect.y()) * noteHeight,
-              rect.width() * tix2pix,
-              rect.height() * noteHeight
-              );
+            (127 - rect.y()) * noteHeight,
+            rect.width() * tix2pix,
+            rect.height() * noteHeight
+            );
 
       return rect;
       }
@@ -293,7 +293,7 @@ void PianoItem::paint(QPainter* painter)
 //---------------------------------------------------------
 
 PianoView::PianoView()
-   : QGraphicsView()
+    : QGraphicsView()
       {
       setFrameStyle(QFrame::NoFrame);
       setLineWidth(0);
@@ -486,7 +486,7 @@ void PianoView::drawBackground(QPainter* p, const QRectF& r)
 
       p->setRenderHints(QPainter::Antialiasing | QPainter::SmoothPixmapTransform | QPainter::TextAntialiasing);
       for (PianoItem* block : _noteList) {
-          drawNoteBlock(p, block);
+            drawNoteBlock(p, block);
       }
 
       if (_dragStyle == DragStyle::NOTE_POSITION || _dragStyle == DragStyle::NOTE_LENGTH_END
@@ -854,7 +854,7 @@ void PianoView::mouseReleaseEvent(QMouseEvent* event)
 
 
       NoteSelectType selType = bnShift ? (bnCtrl ? NoteSelectType::SUBTRACT : NoteSelectType::XOR)
-              : (bnCtrl ? NoteSelectType::ADD : NoteSelectType::REPLACE);
+            : (bnCtrl ? NoteSelectType::ADD : NoteSelectType::REPLACE);
 
       if (_dragStarted) {
             if (_dragStyle == DragStyle::SELECTION_RECT) {
@@ -893,9 +893,9 @@ void PianoView::mouseReleaseEvent(QMouseEvent* event)
                         }
 
                   Fraction startTickFrac = roundToStartBeat(startTick);
-                   Fraction endTickFrac = roundToStartBeat(endTick, false);
+                  Fraction endTickFrac = roundToStartBeat(endTick, false);
 
-                   if (endTickFrac != startTickFrac) {
+                  if (endTickFrac != startTickFrac) {
                         double pitch = pixelYToPitch(_mouseDownPos.y());
 
                         Score* curScore = _staff->score();
@@ -1562,7 +1562,7 @@ void PianoView::handleSelectionClick()
       bool bnShift = modifiers & Qt::ShiftModifier;
       bool bnCtrl = modifiers & Qt::ControlModifier;
       NoteSelectType selType = bnShift ? (bnCtrl ? NoteSelectType::SUBTRACT : NoteSelectType::XOR)
-              : (bnCtrl ? NoteSelectType::ADD : NoteSelectType::REPLACE);
+            : (bnCtrl ? NoteSelectType::ADD : NoteSelectType::REPLACE);
 
       Score* score = _staff->score();
 
@@ -1872,7 +1872,7 @@ void PianoView::ensureVisible(int tick)
 void PianoView::updateBoundingSize()
       {
       Measure* lm = _staff->score()->lastMeasure();
-      _ticks       = (lm->tick() + lm->ticks()).ticks();
+      _ticks = (lm->tick() + lm->ticks()).ticks();
       scene()->setSceneRect(0.0, 0.0,
               double((_ticks + MAP_OFFSET * 2) * _xZoom),
               _noteHeight * 128);
@@ -1889,7 +1889,7 @@ void PianoView::setStaff(Staff* s, Pos* l)
       if (_staff == s)
             return;
 
-      _staff    = s;
+      _staff = s;
       setEnabled(_staff != nullptr);
       if (!_staff) {
             scene()->blockSignals(true);  // block changeSelection()
@@ -1950,9 +1950,9 @@ void PianoView::setStaff(Staff* s, Pos* l)
 
 void PianoView::addChord(Chord* chrd, int voice)
       {
-      for (Chord* c : chrd->graceNotes())
+      for (Chord* c: chrd->graceNotes())
             addChord(c, voice);
-      for (Note* note : chrd->notes()) {
+      for (Note* note: chrd->notes()) {
             if (note->tieBack())
                   continue;
             _noteList.append(new PianoItem(note, this));
@@ -2251,7 +2251,7 @@ void PianoView::copyNotes()
       {
       QString copiedNotes = serializeSelectedNotes();
       if (copiedNotes.isEmpty())
-          return;
+            return;
 
       QMimeData* mimeData = new QMimeData;
       mimeData->setData(PIANO_NOTE_MIME_TYPE, copiedNotes.toUtf8());
@@ -2398,7 +2398,7 @@ QVector<Note*> PianoView::pasteNotes(const QString& copiedNotes, Fraction pasteS
                         Fraction tickLen = Fraction(tn, td);
                         tickLen += lengthOffset;
                         if (tickLen.numerator() <= 0) {
-                            continue;
+                              continue;
                         }
 
                         int pitch = xml.attributes().value("pitch").toString().toInt();
@@ -2461,17 +2461,17 @@ void PianoView::drawDraggedNotes(QPainter* painter)
           double startTick = pixelXToTick(_mouseDownPos.x());
           double endTick = pixelXToTick(_lastMousePos.x());
           if (startTick > endTick) {
-              std::swap(startTick, endTick);
+                std::swap(startTick, endTick);
           }
 
           Fraction startTickFrac = roundToStartBeat(startTick);
           Fraction endTickFrac = roundToStartBeat(endTick, false);
 
           if (endTickFrac != startTickFrac) {
-              double pitch = pixelYToPitch(_mouseDownPos.y());
-              int track = (int)_staff->idx() * VOICES + _editNoteVoice;
+                double pitch = pixelYToPitch(_mouseDownPos.y());
+                int track = (int)_staff->idx() * VOICES + _editNoteVoice;
 
-              drawDraggedNote(painter, startTickFrac, endTickFrac - startTickFrac, pitch, track, _colorNoteDrag);
+                drawDraggedNote(painter, startTickFrac, endTickFrac - startTickFrac, pitch, track, _colorNoteDrag);
           }
           return;
       }

--- a/mscore/pianoroll/pianoview.h
+++ b/mscore/pianoroll/pianoview.h
@@ -40,7 +40,14 @@ enum class DragStyle {
     NONE = 0,
     CANCELLED,
     SELECTION_RECT,
-    NOTES
+    NOTE_POSITION,
+    NOTE_LENGTH_START,
+    NOTE_LENGTH_END,
+    DRAW_NOTE,
+    EVENT_ONTIME,
+    EVENT_MOVE,
+    EVENT_LENGTH,
+    MOVE_VIEWPORT
       };
 
 struct BarPattern {
@@ -89,7 +96,7 @@ private:
       Staff* _staff;
       Chord* _chord;
       
-      Pos trackingPos;  //Track mouse position
+      Pos _trackingPos;  //Track mouse position
       Pos* _locator;
       int _ticks;
       TType _timeType;
@@ -105,14 +112,20 @@ private:
       QString _dragNoteCache;
       QPointF _mouseDownPos;
       QPointF _lastMousePos;
+      QPointF _mouseDownScreenPos;
+      QPointF _lastMouseScreenPos;
+      QPointF _viewportFocus;
       QPointF _popupMenuPos;
       DragStyle _dragStyle;
       int _dragStartPitch;
+      Fraction _dragStartTick;
+      Fraction _dragEndTick;
+      int _dragNoteLengthMargin = 4;
       bool _inProgressUndoEvent;
 
       //The length of the note we are using for editng purposes, expressed as a fraction of the measure.
       // Note length will be (2^_editNoteLength) of a measure
-      int _editNoteLength = 0;
+      Fraction _editNoteLength = Fraction(1, 4);
       int _editNoteDots = 0;
       int _editNoteVoice = 0;
       PianoRollEditTool _editNoteTool = PianoRollEditTool::SELECT;
@@ -120,7 +133,23 @@ private:
       QList<PianoItem*> _noteList;
       quint8 _pitchHighlight[128];
 
+      QColor _colorNoteSel = QColor(0xffff00);
+      QColor _colorNoteVoice1 = QColor(0x9bcdff);
+      QColor _colorNoteVoice2 = QColor(0x80d580);
+      QColor _colorNoteVoice3 = QColor(0xffac85);
+      QColor _colorNoteVoice4 = QColor(0xff94db);
+
+      QColor _colorTweaks = QColor(0xfd63fcc);
+      QColor _colorNoteDrag = QColor(0xffbb33);
+      QColor _colorText = QColor(0x111111);
+      QColor _colorTie = QColor(0xff0000);
+
+      float _noteRectRoundedRadius = 3;
+
       virtual void drawBackground(QPainter* painter, const QRectF& rect);
+      void drawNoteBlock(QPainter* p, PianoItem* block);
+      QRect boundingRect(Note* note, bool applyEvents);
+      QRect boundingRect(Note* note, NoteEvent* evt, bool applyEvents);
 
       void addChord(Chord* _chord, int voice);
       QVector<Note*> getSegmentNotes(Segment* seg, int track);
@@ -132,7 +161,7 @@ private:
       QVector<Note*> addNote(Fraction startTick, Fraction duration, int pitch, int track);
       void handleSelectionClick();
       void insertNote(int modifiers);
-      Fraction roundToStartBeat(int tick) const;
+      Fraction roundToStartBeat(int tick, bool down = true) const;
       Fraction noteEditLength() const;
       void changeChordLength(const QPointF& pos);
       void eraseNote(const QPointF& pos);
@@ -141,23 +170,25 @@ private:
       void toggleTie(const QPointF& pos);
       void toggleTie(Note*);
       void dragSelectionNoteGroup();
-      void finishNoteGroupDrag();
+      void finishNoteGroupDrag(QMouseEvent* event);
+      void finishNoteEventAdjustDrag();
       bool toolCanDragNotes() const {
-            return _editNoteTool == PianoRollEditTool::SELECT || _editNoteTool == PianoRollEditTool::INSERT_NOTE ||
-                  _editNoteTool == PianoRollEditTool::APPEND_NOTE || _editNoteTool == PianoRollEditTool::CUT_CHORD ||
+            return _editNoteTool == PianoRollEditTool::SELECT || _editNoteTool == PianoRollEditTool::ADD ||
+                  _editNoteTool == PianoRollEditTool::APPEND_NOTE || _editNoteTool == PianoRollEditTool::CUT ||
                   _editNoteTool == PianoRollEditTool::TIE;
             }
 
       QAction* getAction(const char* id);
+      void updateCursor();
 
    protected:
-      virtual void wheelEvent(QWheelEvent* event);
-      virtual void keyReleaseEvent(QKeyEvent* event);
-      virtual void mousePressEvent(QMouseEvent* event);
-      virtual void mouseReleaseEvent(QMouseEvent* event);
-      virtual void mouseMoveEvent(QMouseEvent* event);
-      virtual void leaveEvent(QEvent*);
-      virtual void contextMenuEvent(QContextMenuEvent *event);
+      void wheelEvent(QWheelEvent* event) override;
+      void keyReleaseEvent(QKeyEvent* event) override;
+      void mousePressEvent(QMouseEvent* event) override;
+      void mouseReleaseEvent(QMouseEvent* event) override;
+      void mouseMoveEvent(QMouseEvent* event) override;
+      void leaveEvent(QEvent*) override;
+      void contextMenuEvent(QContextMenuEvent *event) override;
 
    signals:
       void xZoomChanged(qreal);
@@ -182,7 +213,7 @@ private:
       void setNotesToVoice(int voice);
 
       QString serializeSelectedNotes();
-      void pasteNotes(const QString& copiedNotes, Fraction pasteStartTick, int pitchOffset, bool xIsOffset = false);
+      QVector<Note*> pasteNotes(const QString& copiedNotes, Fraction pasteStartTick, Fraction lengthOffset, int pitchOffset, bool xIsOffset = false);
       void drawDraggedNotes(QPainter* painter);
       void drawDraggedNote(QPainter* painter, Fraction startTick, Fraction frac, int pitch, int track, QColor color);
 
@@ -205,10 +236,10 @@ private:
       QList<QGraphicsItem*> items() { return scene()->selectedItems(); }
       int editNoteDots() const { return _editNoteDots; }
 
-      void setEditNoteLength(int len) { _editNoteLength = len; }
+      void setEditNoteLength(Fraction len) { _editNoteLength = len; }
       void setEditNoteVoice(int voice) { _editNoteVoice = voice; }
       void setEditNoteDots(int dot) { _editNoteDots = dot; }
-      void setEditNoteTool(PianoRollEditTool tool) { _editNoteTool = tool; }
+      void setEditNoteTool(PianoRollEditTool tool) { _editNoteTool = tool; updateNotes();  }
 
       int pixelXToTick(int pixX);
       int tickToPixelX(int tick);

--- a/mscore/pianoroll/pianoview.h
+++ b/mscore/pianoroll/pianoview.h
@@ -37,17 +37,17 @@ enum class NoteSelectType {
       };
 
 enum class DragStyle {
-    NONE = 0,
-    CANCELLED,
-    SELECTION_RECT,
-    NOTE_POSITION,
-    NOTE_LENGTH_START,
-    NOTE_LENGTH_END,
-    DRAW_NOTE,
-    EVENT_ONTIME,
-    EVENT_MOVE,
-    EVENT_LENGTH,
-    MOVE_VIEWPORT
+      NONE = 0,
+      CANCELLED,
+      SELECTION_RECT,
+      NOTE_POSITION,
+      NOTE_LENGTH_START,
+      NOTE_LENGTH_END,
+      DRAW_NOTE,
+      EVENT_ONTIME,
+      EVENT_MOVE,
+      EVENT_LENGTH,
+      MOVE_VIEWPORT
       };
 
 struct BarPattern {


### PR DESCRIPTION
This is a backport of this PR which has been sitting for a long time: #9109

This is a video I put together for the 4.0 PR.  It covers most of what's in this one: https://youtu.be/EwkUV_uXqqc

Basically I implemented a lot of changes requested in an early design document for  the Piano Roll editor.   So you can now:

* Middle click & drag to reposition the viewport

* Select tool:
   * resize the notes by clicking and dragging on their end points
   * will work on a group of notes too
* Add tool:
   * click and drag to draw in a new note
   * click without drag will repeat the length of the last note drawn
* Note length tool:
   * Since the functionality of these two are now handled by the select and add tool, it has been repurposed to change playback event times instead.  Adjusting note start and end times will now affect playback timing instead of their notation value

* Updated color scheme to separate individual voices.