### PR TITLE
Fix GH#288: Fix Instrument change from palette

### DIFF
--- a/libmscore/chordrest.cpp
+++ b/libmscore/chordrest.cpp
@@ -563,10 +563,8 @@ Element* ChordRest::drop(EditData& data)
                         InstrumentChange* ic = toInstrumentChange(e);
                         ic->setParent(segment());
                         ic->setTrack((track() / VOICES) * VOICES);
-                        Instrument* instr = ic->instrument();
-                        Instrument* prevInstr = part()->instrument(tick());
-                        if (instr && instr->isDifferentInstrument(*prevInstr))
-                              ic->setupInstrument(instr);
+                        Instrument* instr = part()->instrument(tick());
+                        ic->setInstrument(instr);
                         score()->undoAddElement(ic);
                         return e;
                         }

--- a/libmscore/chordrest.cpp
+++ b/libmscore/chordrest.cpp
@@ -563,8 +563,14 @@ Element* ChordRest::drop(EditData& data)
                         InstrumentChange* ic = toInstrumentChange(e);
                         ic->setParent(segment());
                         ic->setTrack((track() / VOICES) * VOICES);
-                        Instrument* instr = part()->instrument(tick());
-                        ic->setInstrument(instr);
+
+                        const Instrument* instr = part()->instrument(tick());
+                        if (!instr) {
+                            delete e;
+                            return 0;
+                        }
+
+                        ic->setInstrument(*instr);
                         score()->undoAddElement(ic);
                         return e;
                         }


### PR DESCRIPTION
Fix GH#14722, part 1: fix Instrument change from palette
Backport of #14802
Resolves: #14722, part 1

Fix GH#14722: Fixed a crash after adding an instrument change element and undoing it (via ctrl + z)
Backport of #14804, 2nd commit
Resolves: #14845

Resolves: #288