### PR TITLE
3.x piano roll editor fix note placement

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -2497,6 +2497,31 @@ void Score::cmdDeleteSelection()
             // so we need a local copy:
             QList<Element*> el = selection().elements();
 
+            QList<Note*> notesToDelete;
+
+            for (Element* e : el) {
+                  if (!e->isNote())
+                        continue;
+
+                  Note* noteStart = toNote(e);
+                  while (noteStart->tieBack()) {
+                        noteStart = noteStart->tieBack()->startNote();
+                        }
+                  
+                  notesToDelete.append(noteStart);
+                  for (Note* note = noteStart; note->tieFor() != nullptr; note = note->tieFor()->endNote()) {
+                        int j = 9;
+
+                        notesToDelete.append(note->tieFor()->endNote());
+                        }                  
+                  }
+
+            for (Note* note: notesToDelete)
+                  deleteItem(note);
+            /////////////////////////////////
+
+
+            /*
             // keep track of linked elements that are deleted implicitly
             // so we don't try to delete them twice if they are also in selection
             QList<ScoreElement*> deletedElements;
@@ -2566,19 +2591,20 @@ void Score::cmdDeleteSelection()
                   for (ScoreElement* se : qAsConst(links))
                         deletedElements.append(se);
                   }
-
+*/
             }
 
-      deselectAll();
-      // make new selection if appropriate
-      if (noteEntryMode())
-            cr = _is.cr();
-      if (cr) {
-            if (cr->isChord())
-                  select(toChord(cr)->upNote(), SelectType::SINGLE);
-            else
-                  select(cr, SelectType::SINGLE);
-            }
+      //deselectAll();
+      //// make new selection if appropriate
+      //if (noteEntryMode())
+      //      cr = _is.cr();
+
+      //if (cr) {
+      //      if (cr->isChord())
+      //            select(toChord(cr)->upNote(), SelectType::SINGLE);
+      //      else
+      //            select(cr, SelectType::SINGLE);
+      //      }
       }
 
 //---------------------------------------------------------

--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -2497,31 +2497,6 @@ void Score::cmdDeleteSelection()
             // so we need a local copy:
             QList<Element*> el = selection().elements();
 
-            QList<Note*> notesToDelete;
-
-            for (Element* e : el) {
-                  if (!e->isNote())
-                        continue;
-
-                  Note* noteStart = toNote(e);
-                  while (noteStart->tieBack()) {
-                        noteStart = noteStart->tieBack()->startNote();
-                        }
-                  
-                  notesToDelete.append(noteStart);
-                  for (Note* note = noteStart; note->tieFor() != nullptr; note = note->tieFor()->endNote()) {
-                        int j = 9;
-
-                        notesToDelete.append(note->tieFor()->endNote());
-                        }                  
-                  }
-
-            for (Note* note: notesToDelete)
-                  deleteItem(note);
-            /////////////////////////////////
-
-
-            /*
             // keep track of linked elements that are deleted implicitly
             // so we don't try to delete them twice if they are also in selection
             QList<ScoreElement*> deletedElements;
@@ -2591,20 +2566,19 @@ void Score::cmdDeleteSelection()
                   for (ScoreElement* se : qAsConst(links))
                         deletedElements.append(se);
                   }
-*/
+
             }
 
-      //deselectAll();
-      //// make new selection if appropriate
-      //if (noteEntryMode())
-      //      cr = _is.cr();
-
-      //if (cr) {
-      //      if (cr->isChord())
-      //            select(toChord(cr)->upNote(), SelectType::SINGLE);
-      //      else
-      //            select(cr, SelectType::SINGLE);
-      //      }
+      deselectAll();
+      // make new selection if appropriate
+      if (noteEntryMode())
+            cr = _is.cr();
+      if (cr) {
+            if (cr->isChord())
+                  select(toChord(cr)->upNote(), SelectType::SINGLE);
+            else
+                  select(cr, SelectType::SINGLE);
+            }
       }
 
 //---------------------------------------------------------

--- a/mscore/pianoroll/pianoview.cpp
+++ b/mscore/pianoroll/pianoview.cpp
@@ -1261,14 +1261,15 @@ QVector<Note*> PianoView::addNote(Fraction startTick, Fraction duration, int pit
                               addedNotes.append(getSegmentNotes(newSeg, track));
                         }
 
+                  startTick += curDur;
+                  duration -= curDur;
+
                   Segment* seg = curChordRest->nextSegmentAfterCR(SegmentType::ChordRest);
                   if (!seg)
                         break;
                   curChordRest = seg->cr(track);
                   curStartTick = curChordRest->tick();
                   curDur = curChordRest->ticks();
-                  startTick += curChordRest->ticks();
-                  duration -= curChordRest->ticks();
                   }
 
             if (duration > Fraction(0, 1)) {

--- a/mscore/pianoroll/pianoview.cpp
+++ b/mscore/pianoroll/pianoview.cpp
@@ -2008,8 +2008,7 @@ void PianoView::updateNotes()
                         addChord(toChord(e), voice);
                   }
             }
-      for (int i = 0; i < 3; ++i)
-            moveLocator(i);
+
       scene()->blockSignals(false);
 
       scene()->update(sceneRect());

--- a/mscore/pianoroll/pianoview.cpp
+++ b/mscore/pianoroll/pianoview.cpp
@@ -32,8 +32,6 @@
 #include "libmscore/undo.h"
 #include "libmscore/utils.h"
 
-#pragma optimize("", off)
-
 namespace Ms {
 
 extern MuseScore* mscore;

--- a/mscore/pianoroll/pianoview.cpp
+++ b/mscore/pianoroll/pianoview.cpp
@@ -1255,8 +1255,9 @@ QVector<Note*> PianoView::addNote(Fraction startTick, Fraction duration, int pit
             ChordRest* curChordRest = nullptr;
 
             //Cut first chord if new note starts inside of it
-            if (startTick > curCr->tick())
+            if (startTick > curCr->tick()) {
                   cutChordRest(curCr, track, startTick, cr0, curChordRest);  //Cut at the start of existing chord rest
+                  }
             else
                   curChordRest = curCr;  //We are inserting at start of chordrest
 
@@ -1761,14 +1762,17 @@ bool PianoView::cutChordRest(ChordRest* targetCr, int track, Fraction cutTick, C
             Chord* ch1 = toChord(nextCR);
 
             for (Note* n: ch1->notes()) {
-                  NoteVal nx = n->noteVal();
+                  NoteVal notePitch = n->noteVal();
                   if (!ch0) {
                         ChordRest* cr = score->findCR(startTick, track);
-                        score->setNoteRest(cr->segment(), track, nx, cr->ticks());
+                        score->setNoteRest(cr->segment(), track, notePitch, cr->ticks());
                         ch0 = toChord(score->findCR(startTick, track));
+                        Note* note = ch0->notes()[0];
+                        toggleTie(note);
                         }
                   else {
-                        score->addNote(ch0, nx);
+                        Note* note = score->addNote(ch0, notePitch);
+                        toggleTie(note);
                         }
                   }
             cr0 = ch0;

--- a/mscore/pianoroll/pianoview.cpp
+++ b/mscore/pianoroll/pianoview.cpp
@@ -2312,6 +2312,30 @@ void PianoView::compactMeasures(QList<Measure*> measures)
                               Segment* newSeg = score->setNoteRest(cr->segment(), track, NoteVal(-1), crTicks + crNextTicks);
                               cr = newSeg->cr(track);
                               }
+                        else if (cr->isChord() && crNext->isChord()) {
+                              Chord* chord = toChord(cr);
+
+                              bool allAreTied = true;
+                              QList<NoteVal> pitchList;
+
+                              for (Note* n : chord->notes()) {
+                                    if (!n->tieFor()) {
+                                          allAreTied = false;
+                                          break;
+                                          }
+                                    pitchList.append(n->noteVal());
+                                    }
+
+                              if (allAreTied) {
+                                    Segment* newSeg = score->setNoteRest(cr->segment(), track, NoteVal(pitchList.at(0)), crTicks + crNextTicks);
+                                    cr = newSeg->cr(track);
+
+                                    for (int i = 1; i < pitchList.size(); ++i)
+                                          score->addNote(toChord(cr), pitchList.at(i));
+                                    }
+                              else
+                                    cr = crNext;
+                              }
                         else
                               cr = crNext;
                         }

--- a/mscore/pianoroll/pianoview.cpp
+++ b/mscore/pianoroll/pianoview.cpp
@@ -1253,7 +1253,8 @@ QVector<Note*> PianoView::addNote(Fraction startTick, Fraction duration, int pit
             while (startTick + duration >= curStartTick + curDur) {
                   if (curChordRest->isChord()) {
                         Chord* ch = toChord(curChordRest);
-                        addedNotes.append(score->addNote(ch, added_note_pitch));
+                        if (!std::any_of(ch->notes().begin(), ch->notes().end(), [pitch](Note* n) { return n->pitch() == pitch; }))
+                              addedNotes.append(score->addNote(ch, added_note_pitch));
                         }
                   else {
                         Segment* newSeg = score->setNoteRest(curChordRest->segment(), track, added_note_pitch, curDur);
@@ -1279,7 +1280,8 @@ QVector<Note*> PianoView::addNote(Fraction startTick, Fraction duration, int pit
                   cutChordRest(curChordRest, track, startTick + duration, crMid, crEnd);
                   if (crMid->isChord()) {
                         Chord* ch = toChord(crMid);
-                        addedNotes.append(score->addNote(ch, added_note_pitch));
+                        if (!std::any_of(ch->notes().begin(), ch->notes().end(), [pitch](Note* n) { return n->pitch() == pitch; }))
+                              addedNotes.append(score->addNote(ch, added_note_pitch));
                         }
                   else {
                         Segment* newSeg = score->setNoteRest(crMid->segment(), track, added_note_pitch, duration);
@@ -1291,9 +1293,7 @@ QVector<Note*> PianoView::addNote(Fraction startTick, Fraction duration, int pit
 
       for (auto it = addedNotes.begin(); it != std::prev(addedNotes.end()); it++)
             toggleTie(*it);
-      //for (Note* note: addedNotes) {
-      //      toggleTie(note);
-      //      }
+
       return addedNotes;
       }
 

--- a/mscore/pianoroll/pianoview.cpp
+++ b/mscore/pianoroll/pianoview.cpp
@@ -2258,7 +2258,8 @@ void PianoView::cutNotes()
       Score* score = _staff->score();
       score->startCmd();
 
-      score->cmdDeleteSelection();
+      //score->cmdDeleteSelection();
+      deleteSeletedNotes();
 
       score->endCmd();
       }
@@ -2276,6 +2277,57 @@ void PianoView::copyNotes()
       QMimeData* mimeData = new QMimeData;
       mimeData->setData(PIANO_NOTE_MIME_TYPE, copiedNotes.toUtf8());
       QApplication::clipboard()->setMimeData(mimeData);
+      }
+
+
+//---------------------------------------------------------
+//   compactMeasures
+//---------------------------------------------------------
+
+void PianoView::compactMeasures()
+{
+}
+
+//---------------------------------------------------------
+//   pasteNotesAtCursor
+//---------------------------------------------------------
+
+void PianoView::deleteSeletedNotes()
+      {
+      ChordRest* cr = 0;            // select something after deleting notes
+
+      Score* score = _staff->score();
+
+      // deleteItem modifies selection().elements() list,
+      // so we need a local copy:
+      QList<Element*> el = score->selection().elements();
+
+      QList<Note*> notesToDelete;
+
+      for (Element* e : el) {
+            if (!e->isNote())
+                  continue;
+
+            Note* noteStart = toNote(e);
+            while (noteStart->tieBack()) {
+                  noteStart = noteStart->tieBack()->startNote();
+            }
+
+            notesToDelete.append(noteStart);
+            for (Note* note = noteStart; note->tieFor() != nullptr; note = note->tieFor()->endNote()) {
+                  int j = 9;
+
+                  notesToDelete.append(note->tieFor()->endNote());
+                  }
+            }
+            
+
+      for (Note* note : notesToDelete)
+            score->deleteItem(note);
+
+
+      compactMeasures();
+
       }
 
 //---------------------------------------------------------
@@ -2356,7 +2408,8 @@ void PianoView::finishNoteGroupDrag(QMouseEvent* event) {
       score->startCmd();
 
       if (!(event->modifiers() & Qt::ShiftModifier)) {
-            score->cmdDeleteSelection();
+            //score->cmdDeleteSelection();
+            deleteSeletedNotes();
             }
       QVector<Note*> notes = pasteNotes(_dragNoteCache, pasteTickOffset, pasteLengthOffset, pitchOffset, true);
 

--- a/mscore/pianoroll/pianoview.cpp
+++ b/mscore/pianoroll/pianoview.cpp
@@ -32,6 +32,8 @@
 #include "libmscore/undo.h"
 #include "libmscore/utils.h"
 
+#pragma optimize("", off)
+
 namespace Ms {
 
 extern MuseScore* mscore;
@@ -302,7 +304,6 @@ PianoView::PianoView()
       setResizeAnchor(QGraphicsView::AnchorUnderMouse);
       setMouseTracking(true);
       _timeType   = TType::TICKS;
-      _playEventsView = true;
       _staff      = nullptr;
       _chord      = nullptr;
       _locator    = nullptr;

--- a/mscore/pianoroll/pianoview.cpp
+++ b/mscore/pianoroll/pianoview.cpp
@@ -32,6 +32,8 @@
 #include "libmscore/undo.h"
 #include "libmscore/utils.h"
 
+#pragma optimize("", off)
+
 namespace Ms {
 
 extern MuseScore* mscore;

--- a/mscore/pianoroll/pianoview.cpp
+++ b/mscore/pianoroll/pianoview.cpp
@@ -552,9 +552,8 @@ void PianoView::drawNoteBlock(QPainter* p, PianoItem* block)
                   }
             }
 
-      if (note->selected()) {
+      if (note->selected())
             noteColor = _colorNoteSel;
-            }
 
       //if (block->staffIdx != m_activeStaff) {
       //    noteColor = noteColor.lighter(150);
@@ -582,6 +581,19 @@ void PianoView::drawNoteBlock(QPainter* p, PianoItem* block)
 
                   p->setPen(QPen(noteColor.darker(180)));
                   p->drawText(textRect, Qt::AlignLeft | Qt::AlignTop, name);
+                  }
+            }
+
+      if (_editNoteTool != PianoRollEditTool::EVENT_ADJUST) {
+            p->setPen(QPen(_colorTie));
+            for (Tie* note_tie = note->tieFor(); note_tie != nullptr; note_tie = note_tie->endNote()->tieFor()) {
+                  Fraction tieTime = note_tie->endNote()->tick();
+                  float xpos = tickToPixelX(tieTime.ticks());
+                  int pitch = note_tie->endNote()->pitch();
+                  int y0 = pitchToPixelY(pitch + 1);
+                  int y1 = pitchToPixelY(pitch);
+
+                  p->drawLine(xpos, y0, xpos, y1);
                   }
             }
       }

--- a/mscore/pianoroll/pianoview.h
+++ b/mscore/pianoroll/pianoview.h
@@ -106,7 +106,6 @@ private:
       int _subdiv;  //Beat subdivisions
       int _barPattern;
 
-      bool _playEventsView;
       bool _mouseDown;
       bool _dragStarted;
       QString _dragNoteCache;
@@ -253,7 +252,7 @@ private:
       
       void zoomView(int step, bool horizontal, int centerX, int centerY);
 
-      bool playEventsView() { return _playEventsView; }
+      bool playEventsView() { return _editNoteTool == PianoRollEditTool::EVENT_ADJUST; }
       };
 
 

--- a/mscore/pianoroll/pianoview.h
+++ b/mscore/pianoroll/pianoview.h
@@ -23,6 +23,7 @@ class Staff;
 class Chord;
 class ChordRest;
 class Segment;
+class Measure;
 class Note;
 class NoteEvent;
 class PianoView;
@@ -168,7 +169,7 @@ private:
       void cutChord(const QPointF& pos);
       void toggleTie(const QPointF& pos);
       void toggleTie(Note*);
-      void compactMeasures();
+      void compactMeasures(QList<Measure*> measures);
       void deleteSeletedNotes();
       void dragSelectionNoteGroup();
       void finishNoteGroupDrag(QMouseEvent* event);

--- a/mscore/pianoroll/pianoview.h
+++ b/mscore/pianoroll/pianoview.h
@@ -168,6 +168,8 @@ private:
       void cutChord(const QPointF& pos);
       void toggleTie(const QPointF& pos);
       void toggleTie(Note*);
+      void compactMeasures();
+      void deleteSeletedNotes();
       void dragSelectionNoteGroup();
       void finishNoteGroupDrag(QMouseEvent* event);
       void finishNoteEventAdjustDrag();


### PR DESCRIPTION
A lot of bugfixes for when blocks are being moved around in the PRE.  Should avoid a lot of the problems with notes disappearing.
