### PR TITLE
Fix GH#21175: Include fret diagram harmony symbols in range selections

### DIFF
--- a/libmscore/select.cpp
+++ b/libmscore/select.cpp
@@ -583,6 +583,11 @@ void Selection::updateSelectedElements()
                   for (Element* e : s->annotations()) {
                         if (e->track() != st)
                               continue;
+                        if (e->isFretDiagram()) {
+                              FretDiagram* fd = toFretDiagram(e);
+                              if (Harmony* harm = fd->harmony())
+                                    appendFiltered(harm);
+                              }
                         appendFiltered(e);
                         }
                   Element* e = s->element(st);


### PR DESCRIPTION
(partial) backport of #21280 (the harmony part)

Resolves: #21175 (the harmony part, bends don't seem to be an issue in Mu3)