### PR TITLE
Fix GH#16396: Tie, Slur, Glissando invisibility/color crossing system breaks

### DIFF
--- a/libmscore/glissando.cpp
+++ b/libmscore/glissando.cpp
@@ -82,7 +82,7 @@ void GlissandoSegment::draw(QPainter* painter) const
       painter->save();
       qreal _spatium = spatium();
 
-      QPen pen(curColor(visible(), glissando()->lineColor()));
+      QPen pen(curColor(getProperty(Pid::VISIBLE).toBool(), getProperty(Pid::COLOR).value<QColor>()));
       pen.setWidthF(glissando()->lineWidth());
       pen.setCapStyle(Qt::FlatCap);
       painter->setPen(pen);

--- a/libmscore/slur.cpp
+++ b/libmscore/slur.cpp
@@ -30,7 +30,7 @@ namespace Ms {
 
 void SlurSegment::draw(QPainter* painter) const
       {
-      QPen pen(curColor());
+      QPen pen(curColor(getProperty(Pid::VISIBLE).toBool(), getProperty(Pid::COLOR).value<QColor>()));
       qreal mag = staff() ? staff()->mag(slur()->tick()) : 1.0;
 
       //Replace generic Qt dash patterns with improved equivalents to show true dots (keep in sync with tie.cpp)

--- a/libmscore/tie.cpp
+++ b/libmscore/tie.cpp
@@ -36,7 +36,7 @@ void TieSegment::draw(QPainter* painter) const
       if (tie()->endNote() && tie()->endNote()->chord()->crossMeasure() == CrossMeasure::SECOND)
             return;
 
-      QPen pen(curColor());
+      QPen pen(curColor(getProperty(Pid::VISIBLE).toBool(), getProperty(Pid::COLOR).value<QColor>()));
       qreal mag = staff() ? staff()->mag(tie()->tick()) : 1.0;
 
       //Replace generic Qt dash patterns with improved equivalents to show true dots (keep in sync with slur.cpp)


### PR DESCRIPTION
Backport of #21347

Resolves: [musescore#16396](https://www.github.com/musescore/MuseScore/issues/16396)