### PR TITLE
Fix crash on opening a foreign generated score

### DIFF
--- a/libmscore/scorefile.cpp
+++ b/libmscore/scorefile.cpp
@@ -1054,7 +1054,7 @@ Score::FileError MasterScore::read1(XmlReader& e, bool ignoreVersionError)
             if (e.name() == "museScore") {
                   const QString& version = e.attribute("version");
                   QStringList sl = version.split('.');
-                  setMscVersion(sl[0].toInt() * 100 + sl[1].toInt());
+                  setMscVersion(sl[0].toInt() * 100 + (sl.size() > 1 ? sl[1].toInt() : 0));
 
                   if (!ignoreVersionError) {
                         if (mscVersion() > MSCVERSION)


### PR DESCRIPTION
with an 'invalid' mscVersion (integer number rather than decimal fraction)

Resolves: https://musescore.org/en/node/357459