### PR TITLE
Fix GH#21056: Don't add empty whole measure rests to second+ voices

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -1468,7 +1468,6 @@ void Score::changeCRlen(ChordRest* cr, const Fraction& dstF, bool fillWithRest)
             if (m1 == 0)
                   break;
             Segment* s = m1->first(SegmentType::ChordRest);
-            expandVoice(s, track);
             cr1 = toChordRest(s->element(track));
             }
       connectTies();


### PR DESCRIPTION
Backport of #21447

Resolves: #21056