### PR TITLE
[Advanced Preference] Disable mouse-based note entry, and instead sel…

### DIFF
--- a/global/settings/types/preferencekeys.h
+++ b/global/settings/types/preferencekeys.h
@@ -119,6 +119,7 @@
 #define PREF_SCORE_NOTE_PLAYONCLICK                         "score/note/playOnClick"
 #define PREF_SCORE_NOTE_DEFAULTPLAYDURATION                 "score/note/defaultPlayDuration"
 #define PREF_SCORE_NOTE_WARNPITCHRANGE                      "score/note/warnPitchRange"
+#define PREF_SCORE_NOTE_INPUT_DISABLE_MOUSE_INPUT           "ui/score/noteEntry/disableMouseEntry"
 #define PREF_SCORE_STYLE_DEFAULTSTYLEFILE                   "score/style/defaultStyleFile"
 #define PREF_SCORE_STYLE_PARTSTYLEFILE                      "score/style/partStyleFile"
 #define PREF_UI_CANVAS_BG_USECOLOR                          "ui/canvas/background/useColor"

--- a/libmscore/mscore.cpp
+++ b/libmscore/mscore.cpp
@@ -95,6 +95,7 @@ QColor  MScore::frameMarginColor;
 QColor  MScore::bgColor;
 QColor  MScore::dropColor;
 bool    MScore::warnPitchRange;
+bool    MScore::disableMouseEntry;
 int     MScore::pedalEventsMinTicks;
 
 bool    MScore::harmonyPlayDisableCompatibility;

--- a/libmscore/mscore.h
+++ b/libmscore/mscore.h
@@ -341,6 +341,7 @@ class MScore {
       static QColor frameMarginColor;
       static QColor bgColor;
       static bool warnPitchRange;
+      static bool disableMouseEntry;
       static int pedalEventsMinTicks;
 
       static bool harmonyPlayDisableCompatibility;

--- a/libmscore/shadownote.cpp
+++ b/libmscore/shadownote.cpp
@@ -115,7 +115,7 @@ bool ShadowNote::computeUp() const
 
 void ShadowNote::draw(QPainter* painter) const
       {
-      if (!visible() || !isValid())
+      if (!visible() || !isValid() || MScore::disableMouseEntry)
             return;
 
       QPointF ap(pagePos());

--- a/mscore/events.cpp
+++ b/mscore/events.cpp
@@ -572,7 +572,19 @@ void ScoreView::mousePressEvent(QMouseEvent* ev)
                   bool restMode = _score->inputState().rest();
                   if (ev->button() == Qt::RightButton)
                         _score->inputState().setRest(!restMode);
-                  _score->putNote(editData.startMove, ev->modifiers() & Qt::ShiftModifier, ev->modifiers() & Qt::ControlModifier);
+                  if (MScore::disableMouseEntry) {
+                        if (auto el = elementAt(editData.pos)) {
+                              if (!el->isStaffLines()) {
+                                    _score->select(el);
+                                    if (el->isNote() || el->isRest())
+                                          _score->inputState().moveInputPos(el);
+                                    else changeState(ViewState::NORMAL);
+                                    //adjustCanvasPosition(el, true);
+                                    }
+                              }
+                        }
+                  else _score->putNote(editData.startMove, ev->modifiers() & Qt::ShiftModifier, ev->modifiers() & Qt::ControlModifier);
+
                   if (ev->button() == Qt::RightButton)
                         _score->inputState().setRest(restMode);
                   _score->endCmd();

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -432,6 +432,7 @@ void updateExternalValuesFromPreferences() {
       MScore::playRepeats = preferences.getBool(PREF_APP_PLAYBACK_PLAYREPEATS);
       MScore::playbackSpeedIncrement = preferences.getInt(PREF_APP_PLAYBACK_SPEEDINCREMENT);
       MScore::warnPitchRange = preferences.getBool(PREF_SCORE_NOTE_WARNPITCHRANGE);
+      MScore::disableMouseEntry = preferences.getBool(PREF_SCORE_NOTE_INPUT_DISABLE_MOUSE_INPUT);
       MScore::pedalEventsMinTicks = preferences.getInt(PREF_IO_MIDI_PEDAL_EVENTS_MIN_TICKS);
       MScore::layoutBreakColor = preferences.getColor(PREF_UI_SCORE_LAYOUTBREAKCOLOR);
       MScore::frameMarginColor = preferences.getColor(PREF_UI_SCORE_FRAMEMARGINCOLOR);

--- a/mscore/preferences.cpp
+++ b/mscore/preferences.cpp
@@ -220,6 +220,7 @@ void Preferences::init(bool storeInMemoryOnly)
             {PREF_SCORE_NOTE_PLAYONCLICK,                          new BoolPreference(true, false)},
             {PREF_SCORE_NOTE_DEFAULTPLAYDURATION,                  new IntPreference(300 /* ms */, false)},
             {PREF_SCORE_NOTE_WARNPITCHRANGE,                       new BoolPreference(true, false)},
+            {PREF_SCORE_NOTE_INPUT_DISABLE_MOUSE_INPUT,            new BoolPreference(false, true)},
             {PREF_SCORE_STYLE_DEFAULTSTYLEFILE,                    new StringPreference("", false)},
             {PREF_SCORE_STYLE_PARTSTYLEFILE,                       new StringPreference("", false)},
             {PREF_UI_CANVAS_BG_USECOLOR,                           new BoolPreference(true, false)},

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -1021,7 +1021,6 @@ void ScoreView::setShadowNote(const QPointF& p)
       qreal mag     = score()->staff(pos.staffIdx)->mag(Fraction(0,1));
       qreal relX    = pos.pos.x() - pos.segment->measure()->canvasPos().x();
       pos.pos.rx() -= qMin(relX - score()->styleP(Sid::barNoteDistance) * mag, 0.0);
-
       shadowNote->setVisible(true);
       Staff* staff = score()->staff(pos.staffIdx);
       shadowNote->setMag(staff->mag(Fraction(0,1)));
@@ -3206,7 +3205,8 @@ void ScoreView::startNoteEntry()
 
       getAction("pad-rest")->setChecked(false);
       setMouseTracking(true);
-      shadowNote->setVisible(true);
+      if (!MScore::disableMouseEntry)
+            shadowNote->setVisible(true);
       _score->setUpdateAll();
       _score->update();
 


### PR DESCRIPTION
This is in relation to the https://github.com/musescore/MuseScore/issues/21399 and https://musescore.org/en/node/360642 topics

I figured I'd at least provide an advanced option for 3.x and request it over to you if you want to try it out. Does no harm, as it's an advanced option under the title: `"ui/score/noteEntry/disableMouseEntry"`

Would've done it for 4.x but don't know how advanced preferences work over there just yet since I don't really use it much. Anyways, when enabled, it will allow the user to select a note or a rest without placing anything there, and the note entry position will be updated to that element. If a staff-line is selected, nothing will happen, and if anything else is selected, note entry will exit and that element will be selected (clef/barline/staff text/etc)

Hopefully it may be of some use to someone to be tested or what have you.