### PR TITLE
Fixes for LayoutMode::FLOAT

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -1984,7 +1984,9 @@ void LayoutContext::layoutPage(Page* page, qreal restHeight, qreal footerPadding
 
       if (sList.empty() || MScore::noVerticalStretch || score->enableVerticalSpread() || score->layoutMode() == LayoutMode::SYSTEM) {
             if (score->layoutMode() == LayoutMode::FLOAT) {
-                  qreal y = restHeight * .5;
+                  qreal y = 0.0;
+                  if (gaps > 0)
+                      y = restHeight * .5;
                   for (System* system : page->systems())
                         system->move(QPointF(0.0, y));
                   }

--- a/libmscore/page.cpp
+++ b/libmscore/page.cpp
@@ -94,7 +94,8 @@ void Page::appendSystem(System* s)
 
 void Page::draw(QPainter* painter) const
       {
-      if (score()->layoutMode() != LayoutMode::PAGE)
+      bool shouldDraw = score()->pageMode() || score()->floatMode();
+      if (!shouldDraw)
             return;
       //
       // draw header/footer
@@ -213,7 +214,8 @@ Text* Page::layoutHeaderFooter(int area, const QString& ss) const
 
 qreal Page::headerExtension() const
       {
-      if (!score()->pageMode())
+      bool shouldLayoutHeader = score()->pageMode() || score()->floatMode();
+      if (!shouldLayoutHeader)
             return 0.0;
 
       int n = no() + 1 + score()->pageNumberOffset();
@@ -256,7 +258,8 @@ qreal Page::headerExtension() const
 
 qreal Page::footerExtension() const
       {
-      if (!score()->pageMode())
+      bool shouldLayoutFooter = score()->pageMode() || score()->floatMode();
+      if (!shouldLayoutFooter)
             return 0.0;
 
       int n = no() + 1 + score()->pageNumberOffset();

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -132,7 +132,7 @@ enum class Pad : char {
 //   LayoutMode
 //    PAGE   The normal page view, honors page and line breaks.
 //    LINE   The panoramic view, one long system
-//    FLOAT  The "reflow" mode, ignore page and line breaks
+//    FLOAT  The "reflow" mode, ignore page and line breaks, stave spacer up, fixed and down
 //    SYSTEM The "never ending page", page break are turned into line break
 //---------------------------------------------------------
 

--- a/libmscore/scorefile.cpp
+++ b/libmscore/scorefile.cpp
@@ -891,12 +891,10 @@ Score::FileError MasterScore::loadCompressedMsc(QIODevice* io, bool ignoreVersio
                   masterScore()->setLayoutMode(LayoutMode::LINE);
             else if ( viewMode == "continuous_h")
                   masterScore()->setLayoutMode(LayoutMode::SYSTEM);
-#if 0
-            else if (viewMode == "page") // not neeed, is the default anyhow
+            else if (viewMode == "page") // not really neeed, is the default anyhow
                   masterScore()->setLayoutMode(LayoutMode::PAGE);
-            else // should never happen!
+            else // may never happen
                   masterScore()->setLayoutMode(LayoutMode::FLOAT);
-#endif
             }
 
 #ifdef OMR

--- a/libmscore/system.cpp
+++ b/libmscore/system.cpp
@@ -1420,6 +1420,13 @@ qreal System::minDistance(System* s2) const
       dist = qMax(dist, score()->staff(firstStaff)->userDist());
       fixedDownDistance = false;
 
+      const SysStaff* sysStaff = staff(lastStaff);
+      qreal sld = sysStaff ? sysStaff->skyline().minDistance(s2->staff(firstStaff)->skyline()) : 0;
+      sld -= sysStaff ? sysStaff->bbox().height() - minVerticalDistance : 0;
+
+      if (score()->floatMode())
+            return qMax(dist, sld);
+
       for (MeasureBase* mb1 : ml) {
             if (mb1->isMeasure()) {
                   Measure* m = toMeasure(mb1);
@@ -1444,10 +1451,7 @@ qreal System::minDistance(System* s2) const
                               dist = qMax(dist, sp->gap());
                         }
                   }
-            qreal sld = staff(lastStaff)->skyline().minDistance(s2->staff(firstStaff)->skyline());
-            sld -=  staff(lastStaff)->bbox().height() - minVerticalDistance;
             dist = qMax(dist, sld);
-//            dist = dist - staff(lastStaff)->bbox().height() + minVerticalDistance;
             }
       return dist;
       }

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -1008,6 +1008,10 @@ void MuseScore::populateFileOperations()
       viewModeCombo->addItem(tr("Page View"), int(LayoutMode::PAGE));
       viewModeCombo->addItem(tr("Continuous View"), int(LayoutMode::LINE));
       viewModeCombo->addItem(tr("Single Page"), int(LayoutMode::SYSTEM));
+#ifdef NDEBUG
+      if (enableExperimental)
+#endif
+            viewModeCombo->addItem(tr("Floating"), int(LayoutMode::FLOAT));
 
       // Restore the saved view-mode combobox index, if any.
       if (viewModeComboIndex != -1)
@@ -2133,6 +2137,10 @@ void MuseScore::retranslate()
       viewModeCombo->setItemText(viewModeCombo->findData(int(LayoutMode::PAGE)), tr("Page View"));
       viewModeCombo->setItemText(viewModeCombo->findData(int(LayoutMode::LINE)), tr("Continuous View"));
       viewModeCombo->setItemText(viewModeCombo->findData(int(LayoutMode::SYSTEM)), tr("Single Page"));
+#ifdef NDEBUG
+      if (enableExperimental)
+#endif
+            viewModeCombo->setItemText(viewModeCombo->findData(int(LayoutMode::FLOAT)), tr("Floating"));
 
       showMidiImportButton->setText(tr("Show MIDI import panel"));
 
@@ -2831,7 +2839,6 @@ void MuseScore::updateViewModeCombo()
       int idx;
       switch (cs->layoutMode()) {
             case LayoutMode::PAGE:
-            case LayoutMode::FLOAT:
                   idx = 0;
                   break;
             case LayoutMode::LINE:
@@ -2839,6 +2846,9 @@ void MuseScore::updateViewModeCombo()
                   break;
             case LayoutMode::SYSTEM:
                   idx = 2;
+                  break;
+            case LayoutMode::FLOAT:
+                  idx = 3;
                   break;
             default:
                   idx = 0;


### PR DESCRIPTION
Backports of #21599, #21689 and#21812. Also #21699

Pretty limited use, as AFAIK so far it is used only on musescore.com and/or in the mobile apps.
Shouldn't harm much either...
And maybe there is some use, with my commit that enables Floating mode on Debug builds or when using the -x commandline option to enable experimental features