### PR TITLE
Fix GH#21621 (MS4): Section break not properly laying out measure numbers

### DIFF
--- a/libmscore/layoutbreak.cpp
+++ b/libmscore/layoutbreak.cpp
@@ -291,9 +291,10 @@ bool LayoutBreak::setProperty(Pid propertyId, const QVariant& v)
                         return false;
                   break;
             }
-      triggerLayout();
-      if (parent() && measure()->next())
-            measure()->next()->triggerLayout();
+      if (auto s = score()) {
+            auto lastTick = s->measures()->last() ? s->measures()->last()->endTick() : tick();
+            score()->setLayout(tick(), lastTick, 0, 0);
+            }
       setGenerated(false);
       return true;
       }


### PR DESCRIPTION
Layout from layout-break to the end of score to make sure measure numbers are up to date when changes are made....