### PR TITLE
Fix GH#21621: Use triggerLayoutAll() when updating the measure number property of section breaks

### DIFF
--- a/libmscore/element.cpp
+++ b/libmscore/element.cpp
@@ -1927,6 +1927,11 @@ void Element::triggerLayoutAll() const
             score()->setLayoutAll(staffIdx(), this);
       }
 
+void Element::triggerLayoutToEnd() const
+      {
+      score()->setLayout(tick(), score()->endTick(), staffIdx(), staffIdx(), this);
+      }
+
 //---------------------------------------------------------
 //   control
 //---------------------------------------------------------

--- a/libmscore/element.h
+++ b/libmscore/element.h
@@ -513,6 +513,7 @@ class Element : public ScoreElement {
 
       virtual void triggerLayout() const;
       virtual void triggerLayoutAll() const;
+      virtual void triggerLayoutToEnd() const;
       virtual void drawEditMode(QPainter*, EditData&);
 
       void autoplaceSegmentElement(bool above, bool add);        // helper functions

--- a/libmscore/layoutbreak.cpp
+++ b/libmscore/layoutbreak.cpp
@@ -291,9 +291,15 @@ bool LayoutBreak::setProperty(Pid propertyId, const QVariant& v)
                         return false;
                   break;
             }
-      triggerLayout();
-      if (parent() && measure()->next())
-            measure()->next()->triggerLayout();
+
+      if (propertyId == Pid::START_WITH_MEASURE_ONE)
+            triggerLayoutToEnd();
+      else {
+            triggerLayout();
+            if (parent() && measure()->next())
+                  measure()->next()->triggerLayout();
+            }
+
       setGenerated(false);
       return true;
       }

--- a/libmscore/measurebase.cpp
+++ b/libmscore/measurebase.cpp
@@ -137,6 +137,8 @@ void MeasureBase::add(Element* e)
                         setLineBreak(true);
                         setSectionBreak(false);
                         setNoBreak(false);
+                        if (b->startWithMeasureOne())
+                              triggerLayoutToEnd();
                         break;
                   case LayoutBreak::SECTION:
                         setLineBreak(false);
@@ -176,7 +178,8 @@ void MeasureBase::remove(Element* el)
                   case LayoutBreak::SECTION:
                         setSectionBreak(false);
                         score()->setPause(endTick(), 0);
-                        triggerLayout();
+                        if (lb->startWithMeasureOne())
+                              triggerLayoutToEnd();
                         break;
                   case LayoutBreak::NOBREAK:
                         setNoBreak(false);


### PR DESCRIPTION
Backport of #21730

Resolves: [musescore#21621](https://www.github.com/musescore/MuseScore/issues/21621)