### PR TITLE
Fix GH#359: Crash on Voice2-4 expanding into new measure

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -1384,8 +1384,17 @@ void Score::changeCRlen(ChordRest* cr, const Fraction& dstF, bool fillWithRest)
       Chord* oc      = 0;
 
       bool first = true;
+      Fraction totalLen = cr->rtick() + f;
       for (Fraction f2 : qAsConst(flist)) {
             f  -= f2;
+            if (totalLen.reduced() > Fraction(1, 1)) {
+                  if (auto nm = cr1->measure()->nextMeasure()) {
+                        if (auto seg = nm->first(SegmentType::ChordRest)) {
+                              expandVoice(seg, track);
+                              totalLen.setNumerator(totalLen.numerator() - totalLen.denominator());
+                              }
+                        }
+                  }
             makeGap(cr1->segment(), cr1->track(), f2, tuplet, first);
 
             if (cr->isRest()) {
@@ -1462,10 +1471,12 @@ void Score::changeCRlen(ChordRest* cr, const Fraction& dstF, bool fillWithRest)
                   }
             Measure* m  = cr1->measure();
             Measure* m1 = m->nextMeasure();
-            if (m1 == 0)
+            if (!m1)
                   break;
             Segment* s = m1->first(SegmentType::ChordRest);
             cr1 = toChordRest(s->element(track));
+            if (!cr1)
+                  break;
             }
       connectTies();
       }


### PR DESCRIPTION
Resolves: #359 
Instead of only reverting the change, I tried to get the same "intention" as the 4.x branch by way of seeing if the resulting "total fraction" was going to spill over into the next measure. If so, then perform the expand function (it was crashing because 3.x apparently needs to expand there when extending past current measure). Putting it back in how it was would cause unnecessary rests though every time. Test please if you're willing... 

I have a screen cast showing how it doesn't make a voice-2 rest for no reason and also that it doesn't crash on my side over here if it "spills over".



https://github.com/Jojo-Schmitz/MuseScore/assets/7139517/20f3013e-a1df-439c-8844-c8fc97051ad1


