### PR TITLE
Fix GH#20718: Prevent crash when adding time signature before instrument change

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -1098,7 +1098,7 @@ Fraction Score::makeGap(Segment* segment, int track, const Fraction& _sd, Tuplet
             typedef SelectionFilterType Sel;
             // chord symbols can exist without chord/rest so they should not be removed
             constexpr Sel filter = static_cast<Sel>(int(Sel::ALL) & ~int(Sel::CHORD_SYMBOL));
-            deleteAnnotationsFromRange(s1, s2, track, track + 1, filter);
+            deleteAnnotationsFromRange(s1, s2, track, track + 1, filter, false);
             deleteSpannersFromRange(t1, t2, track, track + 1, filter);
             }
 
@@ -1138,7 +1138,7 @@ bool Score::makeGap1(const Fraction& baseTick, int staffIdx, const Fraction& len
                   typedef SelectionFilterType Sel;
                   // chord symbols can exist without chord/rest so they should not be removed
                   constexpr Sel filter = static_cast<Sel>(int(Sel::ALL) & ~int(Sel::CHORD_SYMBOL));
-                  deleteAnnotationsFromRange(tick2rightSegment(tick), tick2rightSegment(endTick), track, track + 1, filter);
+                  deleteAnnotationsFromRange(tick2rightSegment(tick), tick2rightSegment(endTick), track, track + 1, filter, false);
                   deleteSpannersFromRange(tick, endTick, track, track + 1, filter);
                   }
 

--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -2321,7 +2321,7 @@ void Score::deleteSpannersFromRange(const Fraction& t1, const Fraction& t2, int 
 ///   given selection filter.
 //---------------------------------------------------------
 
-void Score::deleteAnnotationsFromRange(Segment* s1, Segment* s2, int track1, int track2, const SelectionFilter& filter)
+void Score::deleteAnnotationsFromRange(Segment* s1, Segment* s2, int track1, int track2, const SelectionFilter& filter, bool deleteInstrumentChanges)
       {
       if (!s1)
             return;
@@ -2337,8 +2337,11 @@ void Score::deleteAnnotationsFromRange(Segment* s1, Segment* s2, int track1, int
                         // skip if not included in selection (eg, filter)
                         if (!filter.canSelect(annotation))
                               continue;
-                        if (!annotation->systemFlag() && annotation->track() == track)
+                        if (!annotation->systemFlag() && annotation->track() == track) {
+                              if (annotation->isInstrumentChange() && !deleteInstrumentChanges)
+                                    continue;
                               deleteItem(annotation);
+                              }
                         }
                   }
             }
@@ -2389,7 +2392,7 @@ std::vector<ChordRest*> Score::deleteRange(Segment* s1, Segment* s2, int track1,
                               continue;
                               }
                         // delete annotations just from this segment and track
-                        deleteAnnotationsFromRange(s, s->next1(), track, track + 1, filter);
+                        deleteAnnotationsFromRange(s, s->next1(), track, track + 1, filter, true);
 
                         Element* e = s->element(track);
                         if (!e)

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -552,7 +552,7 @@ class Score : public QObject, public ScoreElement {
       void resetTempoRange(const Fraction& tick1, const Fraction& tick2);
 
       void deleteSpannersFromRange(const Fraction& t1, const Fraction& t2, int trackStart, int trackEnd, const SelectionFilter& filter);
-      void deleteAnnotationsFromRange(Segment* segStart, Segment* segEnd, int trackStart, int trackEnd, const SelectionFilter& filter);
+      void deleteAnnotationsFromRange(Segment* segStart, Segment* segEnd, int trackStart, int trackEnd, const SelectionFilter& filter, bool deleteInstrumentChanges);
       std::vector<ChordRest*> deleteRange(Segment* segStart, Segment* segEnd, int trackStart, int trackEnd,
                                           const SelectionFilter& filter);
 


### PR DESCRIPTION
Backport of #21845

Resolves: [#20718](https://www.github.com/musescore/MuseScore/issues/20718), which may not really apply to Mu3