### PR TITLE
Fix GH#21479: Accidentals follow note visibility when repitching

### DIFF
--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -2239,6 +2239,7 @@ void Note::updateAccidental(AccidentalState* as)
                         Accidental* a = new Accidental(score());
                         a->setParent(this);
                         a->setAccidentalType(acci);
+                        a->setVisible(visible());
                         score()->undoAddElement(a);
                         }
                   else if (_accidental->accidentalType() != acci) {


### PR DESCRIPTION
Backport of #21858

Resolves: [#21479](https://www.github.com/musescore/MuseScore/issues/21479)