### PR TITLE
Make sure the MIDI pedal events start at the same tick as their starting note

### DIFF
--- a/libmscore/rendermidi.cpp
+++ b/libmscore/rendermidi.cpp
@@ -1101,7 +1101,7 @@ void MidiRenderer::renderSpanners(const Chunk& chunk, EventMap* events)
                               channelPedalEvents.at(channel).pop_back();
                               channelPedalEvents.at(channel).push_back(std::pair<int, std::pair<bool, int> >(st + tickOffset + (2 - MScore::pedalEventsMinTicks), std::pair<bool, int>(false, staff)));
                               }
-                        int a = st + tickOffset + 2;
+                        int a = st + tickOffset + (3 - MScore::pedalEventsMinTicks);
                         channelPedalEvents.at(channel).push_back(std::pair<int, std::pair<bool, int> >(a, std::pair<bool, int>(true, staff)));
                         }
                   if (s->tick2().ticks() >= tick1 && s->tick2().ticks() <= tick2) {


### PR DESCRIPTION
"Backport" of #21925 (actually this one here existed first)

Resolves https://musescore.org/en/node/361768

This images shows that 2 ticks offset before my change:
![20240313_133110](https://github.com/Jojo-Schmitz/MuseScore/assets/1786669/31c0416c-7628-4996-a37d-e312c50219d1)