### PR TITLE
Fix GH#21786: Prevent crash when pasting list selection including hairpins

### DIFF
--- a/libmscore/paste.cpp
+++ b/libmscore/paste.cpp
@@ -821,6 +821,11 @@ void Score::pasteSymbols(XmlReader& e, ChordRest* dst)
                               undoAddElement(d);
                               }
                         else if (tag == "HairPin") {
+                              if (destTrack >= maxTrack) {
+                                    qDebug("PasteSymbols: no track for %s", tag.toLocal8Bit().data());
+                                    e.skipCurrentElement();
+                                    continue;
+                                    }
                               Hairpin* h = new Hairpin(this);
                               h->setTrack(destTrack);
                               h->read(e);


### PR DESCRIPTION
Backport of #21990

Resolves: [musescore#21786](https://www.github.com/musescore/MuseScore/issues/21786)