### PR TITLE
LayoutContext: Fix indexing of empty array

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -2173,7 +2173,8 @@ void LayoutContext::getNextPage()
       else {
             page = score->pages()[curPage];
             QList<System*>& systems = page->systems();
-            pageOldMeasure = systems.isEmpty() ? nullptr : systems.back()->measures().back();
+            pageOldMeasure = systems.isEmpty() || systems.back()->measures().empty() ?
+                  nullptr : systems.back()->measures().back();
             const int i = systems.indexOf(curSystem);
             if (i > 0 && systems[i-1]->page() == page) {
                   // Current and previous systems are on the current page.


### PR DESCRIPTION
  #4  0x00007a53720dd3b2 in std::__glibcxx_assert_fail (... condition=condition@entry=0x60abeae61604 "!this->empty()")
  #5  0x000060abeac23e90 in std::vector<Ms::MeasureBase*, std::allocator<Ms::MeasureBase*> >::back
  #6  std::vector<Ms::MeasureBase*, std::allocator<Ms::MeasureBase*> >::back
  #7  Ms::LayoutContext::getNextPage
