### PR TITLE
Fix GH#21672: Prevent crash when realizing chords over multi-measure rests

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -3586,6 +3586,11 @@ Segment* Score::setChord(Segment* segment, int track, Chord* chordTemplate, Frac
                   qDebug("reached end of score");
                   break;
                   }
+
+            //it is possible that the next measure's ticks have not been computed yet. compute them now
+            if (nseg->ticks().isZero())
+                  nseg->measure()->computeTicks();
+
             segment = nseg;
 
             cr = toChordRest(segment->element(track));

--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -4660,7 +4660,7 @@ void Measure::computeMinWidth(Segment* s, qreal x, bool isSystemHeader)
             Segment* seg = findSegmentR(SegmentType::ChordRest, Fraction(0,1));
             const int nstaves = score()->nstaves();
             for (int st = 0; st < nstaves; ++st) {
-                  Rest* mmRest = toRest(seg->element(staff2track(st)));
+                  Rest* mmRest = seg->element(staff2track(st))->isRest() ? toRest(seg->element(staff2track(st))) : nullptr;
                   if (mmRest) {
                         mmRest->rxpos() = 0;
                         mmRest->layoutMMRest(score()->styleP(Sid::minMMRestWidth) * mag());


### PR DESCRIPTION
Backport of #21975

Mu3 didn't crash in that particular scenario (but does when there's no note in the measure with the chord symbol, hence the 2nd commit), but now does render the realized chord symbols differently and better, before:
![image](https://github.com/Jojo-Schmitz/MuseScore/assets/1786669/a5c82f78-e9bc-451b-be13-d295978abb23)
after (when realizing chord symbols via right-click on the C):
![image](https://github.com/Jojo-Schmitz/MuseScore/assets/1786669/dd9e9098-39e2-451b-af68-4f9c7b5a3be9)

Resolves: [musescore#21672](https://www.github.com/musescore/MuseScore/issues/21672)