### PR TITLE
[Tab Layout] Allow fingering string text to affect which tablature string is attempted to apply on a linked staff/tab staff

### DIFF
--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -2061,6 +2061,33 @@ void Note::layout()
                   if (chord()->measure() != tieBack()->startNote()->chord()->measure() || el().size() > 0)
                         paren = true;
                   }
+
+            auto scoreElement = links() ? links()->mainElement() : nullptr;
+            if (scoreElement && scoreElement->isNote()) {
+                  if (auto n = toNote(scoreElement)) {
+                        int updatedString = _string;
+                        int updatedFret = _fret;
+                        for (auto& e : n->el()) {
+                              if (e->isFingering()) {
+                                    if (auto fingering = toFingering(e)) {
+                                          if (fingering->tid() == Tid::STRING_NUMBER) {
+                                                auto stringData = staff()->part()->instrument(tick())->stringData();
+                                                int whichString = fingering->plainText().toInt();
+                                                int maxStrings = stringData->strings();
+                                                if (whichString <= maxStrings && whichString >= 0) {
+                                                      updatedString = whichString;  // E.g: 1-6
+                                                      updatedString -= 1;           // E.g: 0-5 (internal representation)
+                                                      updatedFret = stringData->fret(pitch(), updatedString, staff(), chord()->tick());
+                                                      }
+                                                }
+                                          }
+                                    }
+                              }
+                        _string = updatedString;
+                        _fret   = updatedFret;
+                        }
+                  }
+
             // not complete but we need systems to be layouted to add parenthesis
             if (fixed())
                   _fretString = "/";


### PR DESCRIPTION
Resolves: #402 

So far this little change allows the string fingering text to force the string. If it doesn't, it displays a ? question mark. Hoping Scorster will test it out and give some feedback or find some undesired behavior, etc.
 Seems to be okay from an initial testing stage:

https://github.com/Jojo-Schmitz/MuseScore/assets/7139517/b362223a-c77d-4bc1-98b5-60b06607446b
