### PR TITLE
Fix GH#21953: Crash on regroup rhythms in some scores

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -4156,7 +4156,7 @@ static Chord* findLinkedChord(Chord* c, Staff* nstaff)
       if (!ns)
             return 0;
       Element* ne = ns->element(dtrack);
-      if (!ne->isChord())
+      if (!ne || !ne->isChord())
             return 0;
       Chord* nc = toChord(ne);
       if (c->isGrace()) {


### PR DESCRIPTION
Backport of #22314

Seems to build upon an backport of #10654, which got closed in favor of #13183

Resolves: [musescore#21953](https://www.github.com/musescore/MuseScore/issues/21953)