### PR TITLE
[Fix] Pasting repeat barline (probably other things also potentially)

### DIFF
--- a/libmscore/paste.cpp
+++ b/libmscore/paste.cpp
@@ -1080,7 +1080,7 @@ void Score::cmdPaste(const QMimeData* ms, MuseScoreView* view, Fraction scale)
                   ddata.dropElement = el.get();
                   if (target->acceptDrop(ddata)) {
                         if (!el->isNote() || (target = prepareTarget(target, toNote(el.get()), duration))) {
-                              ddata.dropElement = nel = el->clone();
+                              ddata.dropElement = el->clone();
                               Element* dropped = target->drop(ddata);
                               if (dropped)
                                     nel = dropped;


### PR DESCRIPTION
Resolves:  #420

Should be good to go

The culprit was: https://github.com/musescore/MuseScore/pull/8825 and its being backported. Apparently the "nel" was prematurely being set before finalizing the drop target information. Hell I don't know, but I can't crash on copy/pasting a repeat barline with this fix 