### PR TITLE
Remove hanging ties on XML import

### DIFF
--- a/importexport/musicxml/importmxmlpass2.h
+++ b/importexport/musicxml/importmxmlpass2.h
@@ -142,8 +142,8 @@ private:
       void readElision(QString& formattedText);
       const LyricNumberHandler _lyricNumberHandler;
       QXmlStreamReader& _e;
-      Score* const _score;                      // the score
-      MxmlLogger* _logger;                      ///< Error logger
+      Score* const _score = nullptr;      // the score
+      MxmlLogger* _logger = nullptr;      ///< Error logger
       QMap<int, Lyrics*> _numberedLyrics; // lyrics with valid number
       QSet<Lyrics*> _extendedLyrics;      // lyrics with the extend flag set
       };
@@ -218,7 +218,7 @@ public:
 
 class MusicXMLParserNotations {
 public:
-      MusicXMLParserNotations(QXmlStreamReader& e, Score* score, MxmlLogger* logger);
+      MusicXMLParserNotations(QXmlStreamReader& e, Score* score, MxmlLogger* logger, MusicXMLParserPass1& pass1);
       void parse();
       void addToScore(ChordRest* const cr, Note* const note, const int tick, SlurStack& slurs,
                       Glissando* glissandi[MAX_NUMBER_LEVEL][2], MusicXmlSpannerMap& spanners, TrillStack& trills,
@@ -246,6 +246,7 @@ private:
       void tuplet();
       void otherNotation();
       QXmlStreamReader& _e;
+      MusicXMLParserPass1& _pass1;
       Score* const _score;                      // the score
       MxmlLogger* _logger;                      // the error logger
       QString _errors;                          // errors to present to the user

--- a/mtest/musicxml/io/testBackupRoundingError_ref.mscx
+++ b/mtest/musicxml/io/testBackupRoundingError_ref.mscx
@@ -921,11 +921,6 @@
           <Chord>
             <BeamMode>begin</BeamMode>
             <durationType>eighth</durationType>
-            <Articulation>
-              <subtype>articLaissezVibrerBelow</subtype>
-              <autoplace>0</autoplace>
-              <offset x="1.06594" y="-8.45219"/>
-              </Articulation>
             <Note>
               <pitch>69</pitch>
               <tpc>17</tpc>
@@ -942,11 +937,6 @@
           <Chord>
             <BeamMode>mid</BeamMode>
             <durationType>eighth</durationType>
-            <Articulation>
-              <subtype>articLaissezVibrerBelow</subtype>
-              <autoplace>0</autoplace>
-              <offset x="1.06594" y="-6.11334"/>
-              </Articulation>
             <Note>
               <Accidental>
                 <subtype>accidentalSharp</subtype>
@@ -958,11 +948,6 @@
           <Chord>
             <BeamMode>mid</BeamMode>
             <durationType>eighth</durationType>
-            <Articulation>
-              <subtype>articLaissezVibrerBelow</subtype>
-              <autoplace>0</autoplace>
-              <offset x="1.06594" y="-2.95219"/>
-              </Articulation>
             <Note>
               <Accidental>
                 <subtype>accidentalNatural</subtype>
@@ -1072,11 +1057,6 @@
             </Spanner>
           <Chord>
             <durationType>whole</durationType>
-            <Articulation>
-              <subtype>articLaissezVibrerAbove</subtype>
-              <autoplace>0</autoplace>
-              <offset x="1.14594" y="0.202187"/>
-              </Articulation>
             <Note>
               <Accidental>
                 <subtype>accidentalNatural</subtype>
@@ -1743,11 +1723,6 @@
         <voice>
           <Chord>
             <durationType>half</durationType>
-            <Articulation>
-              <subtype>articLaissezVibrerAbove</subtype>
-              <autoplace>0</autoplace>
-              <offset x="1.14594" y="0.222187"/>
-              </Articulation>
             <StemDirection>down</StemDirection>
             <Note>
               <Accidental>


### PR DESCRIPTION
Backport of #22455, which in turn is a port of #8556 (which got ported to 3.7 earlier), but doesn't replace hanging ties with l.v. articulations, opting instead to simply delete them pending a proper feature.