### PR TITLE
Fix GH#443: Importing Mu4 scores looses key sig of transposing instruments

### DIFF
--- a/libmscore/keysig.cpp
+++ b/libmscore/keysig.cpp
@@ -443,7 +443,7 @@ void KeySig::read(XmlReader& e)
                   _showCourtesy = e.readInt();
             else if (tag == "showNaturals")           // obsolete
                   e.readInt();
-            else if (tag == "accidental" || tag == "concertKey") // + 4.x compat
+            else if (tag == "accidental" || tag == "actualKey" || tag == "concertKey") // + 4.x compat, order matters!
                   _sig.setKey(Key(e.readInt()));
             else if (tag == "natural")                // obsolete
                   e.readInt();

--- a/libmscore/read302.cpp
+++ b/libmscore/read302.cpp
@@ -107,6 +107,8 @@ bool Score::read(XmlReader& e)
                   _showFrames = e.readInt();
             else if (tag == "showMargins")
                   _showPageborders = e.readInt();
+            else if (tag == "open") // + Mu4 compat
+                  e.skipCurrentElement(); // irgnore, even in Mu4 it doesn't seem to have any usefull meaning
             else if (tag == "markIrregularMeasures")
                   _markIrregularMeasures = e.readInt();
             else if (tag == "Style") {


### PR DESCRIPTION
also ignore the Mu4 tag `<open>` (which even there doesn't seem to do anything usefull

Resolves: #443