### PR TITLE
Fix superfluous clefs after every system break on Capella import

### DIFF
--- a/libmscore/chord.cpp
+++ b/libmscore/chord.cpp
@@ -1131,7 +1131,7 @@ bool Chord::readProperties(XmlReader& e)
             _arpeggio->read(e);
             _arpeggio->setParent(this);
             }
-      else if (tag == "Tremolo" || tag == "TremoloSingleChord") { // Mu4.3+ compatibility
+      else if (tag == "Tremolo" || tag == "TremoloSingleChord") { // Mu4.4+ compatibility
             _tremolo = new Tremolo(score());
             _tremolo->setTrack(track());
             _tremolo->read(e);

--- a/mtest/capella/io/test1.cap-ref.mscx
+++ b/mtest/capella/io/test1.cap-ref.mscx
@@ -48,10 +48,6 @@
         </VBox>
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <TimeSig>
             <sigN>4</sigN>
             <sigD>4</sigD>
@@ -155,10 +151,6 @@
         </Measure>
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <Chord>
             <durationType>quarter</durationType>
             <Note>

--- a/mtest/capella/io/test1.capx-ref.mscx
+++ b/mtest/capella/io/test1.capx-ref.mscx
@@ -48,10 +48,6 @@
         </VBox>
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <Chord>
             <durationType>quarter</durationType>
             <Note>
@@ -151,10 +147,6 @@
         </Measure>
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <Chord>
             <durationType>quarter</durationType>
             <Note>

--- a/mtest/capella/io/test3.cap-ref.mscx
+++ b/mtest/capella/io/test3.cap-ref.mscx
@@ -48,10 +48,6 @@
         </VBox>
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>-1</accidental>
             </KeySig>
@@ -161,10 +157,6 @@
         </Measure>
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <Chord>
             <durationType>quarter</durationType>
             <Note>

--- a/mtest/capella/io/test3.capx-ref.mscx
+++ b/mtest/capella/io/test3.capx-ref.mscx
@@ -48,10 +48,6 @@
         </VBox>
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>-1</accidental>
             </KeySig>
@@ -161,10 +157,6 @@
         </Measure>
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <Chord>
             <durationType>quarter</durationType>
             <Note>

--- a/mtest/capella/io/test4.cap-ref.mscx
+++ b/mtest/capella/io/test4.cap-ref.mscx
@@ -48,10 +48,6 @@
         </VBox>
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <TimeSig>
             <sigN>4</sigN>
             <sigD>4</sigD>

--- a/mtest/capella/io/test4.capx-ref.mscx
+++ b/mtest/capella/io/test4.capx-ref.mscx
@@ -48,10 +48,6 @@
         </VBox>
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <TimeSig>
             <sigN>4</sigN>
             <sigD>4</sigD>

--- a/mtest/capella/io/test5.cap-ref.mscx
+++ b/mtest/capella/io/test5.cap-ref.mscx
@@ -48,10 +48,6 @@
         </VBox>
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>1</accidental>
             </KeySig>
@@ -164,10 +160,6 @@
         </Measure>
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <Chord>
             <durationType>quarter</durationType>
             <Note>

--- a/mtest/capella/io/test5.capx-ref.mscx
+++ b/mtest/capella/io/test5.capx-ref.mscx
@@ -48,10 +48,6 @@
         </VBox>
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>1</accidental>
             </KeySig>
@@ -164,10 +160,6 @@
         </Measure>
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <Chord>
             <durationType>quarter</durationType>
             <Note>

--- a/mtest/capella/io/test6.cap-ref.mscx
+++ b/mtest/capella/io/test6.cap-ref.mscx
@@ -48,10 +48,6 @@
         </VBox>
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>2</accidental>
             </KeySig>
@@ -170,10 +166,6 @@
         </Measure>
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <Chord>
             <durationType>quarter</durationType>
             <Note>

--- a/mtest/capella/io/test6.capx-ref.mscx
+++ b/mtest/capella/io/test6.capx-ref.mscx
@@ -48,10 +48,6 @@
         </VBox>
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>2</accidental>
             </KeySig>
@@ -170,10 +166,6 @@
         </Measure>
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <Chord>
             <durationType>quarter</durationType>
             <Note>

--- a/mtest/capella/io/test7.cap-ref.mscx
+++ b/mtest/capella/io/test7.cap-ref.mscx
@@ -48,10 +48,6 @@
         </VBox>
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>3</accidental>
             </KeySig>
@@ -201,10 +197,6 @@
         </Measure>
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>5</accidental>
             </KeySig>
@@ -350,10 +342,6 @@
         </Measure>
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>7</accidental>
             </KeySig>
@@ -499,10 +487,6 @@
         </Measure>
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>-3</accidental>
             </KeySig>
@@ -648,10 +632,6 @@
         </Measure>
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>-5</accidental>
             </KeySig>
@@ -800,10 +780,6 @@
           <subtype>line</subtype>
           </LayoutBreak>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>-7</accidental>
             </KeySig>

--- a/mtest/capella/io/test7.capx-ref.mscx
+++ b/mtest/capella/io/test7.capx-ref.mscx
@@ -51,10 +51,6 @@
           <subtype>line</subtype>
           </LayoutBreak>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>3</accidental>
             </KeySig>

--- a/mtest/capella/io/test8.cap-ref.mscx
+++ b/mtest/capella/io/test8.cap-ref.mscx
@@ -48,10 +48,6 @@
         </VBox>
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <TimeSig>
             <sigN>4</sigN>
             <sigD>4</sigD>
@@ -207,10 +203,6 @@
         </Measure>
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <Chord>
             <durationType>quarter</durationType>
             <Note>

--- a/mtest/capella/io/testBarline.capx-ref.mscx
+++ b/mtest/capella/io/testBarline.capx-ref.mscx
@@ -47,12 +47,8 @@
       <VBox>
         <height>5</height>
         </VBox>
-      <Measure len="4/4">
+      <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <TimeSig>
             <sigN>4</sigN>
             <sigD>4</sigD>

--- a/mtest/capella/io/testEmptyStaff1.capx-ref.mscx
+++ b/mtest/capella/io/testEmptyStaff1.capx-ref.mscx
@@ -76,10 +76,6 @@
           <subtype>line</subtype>
           </LayoutBreak>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <Chord>
             <durationType>whole</durationType>
             <Note>
@@ -94,10 +90,6 @@
           <subtype>line</subtype>
           </LayoutBreak>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <Chord>
             <durationType>whole</durationType>
             <Note>
@@ -111,10 +103,6 @@
     <Staff id="2">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <Chord>
             <durationType>whole</durationType>
             <Note>
@@ -126,10 +114,6 @@
         </Measure>
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <Chord>
             <durationType>whole</durationType>
             <Note>
@@ -141,10 +125,6 @@
         </Measure>
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <Chord>
             <durationType>whole</durationType>
             <Note>

--- a/mtest/capella/io/testEmptyStaff2.capx-ref.mscx
+++ b/mtest/capella/io/testEmptyStaff2.capx-ref.mscx
@@ -80,10 +80,6 @@
           <subtype>line</subtype>
           </LayoutBreak>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <Chord>
             <dots>1</dots>
             <durationType>half</durationType>
@@ -98,10 +94,6 @@
     <Staff id="2">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <TimeSig>
             <sigN>3</sigN>
             <sigD>4</sigD>
@@ -118,10 +110,6 @@
         </Measure>
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <Chord>
             <dots>1</dots>
             <durationType>half</durationType>

--- a/mtest/capella/io/testPianoG4G5.capx-ref.mscx
+++ b/mtest/capella/io/testPianoG4G5.capx-ref.mscx
@@ -65,10 +65,6 @@
           <subtype>line</subtype>
           </LayoutBreak>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <Chord>
             <durationType>quarter</durationType>
             <Note>

--- a/mtest/capella/io/testScaleC4C5.capx-ref.mscx
+++ b/mtest/capella/io/testScaleC4C5.capx-ref.mscx
@@ -48,10 +48,6 @@
         </VBox>
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <Chord>
             <durationType>quarter</durationType>
             <Note>

--- a/mtest/capella/io/testSlurTie.capx-ref.mscx
+++ b/mtest/capella/io/testSlurTie.capx-ref.mscx
@@ -51,10 +51,6 @@
           <subtype>line</subtype>
           </LayoutBreak>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <TimeSig>
             <sigN>4</sigN>
             <sigD>4</sigD>

--- a/mtest/capella/io/testText1.capx-ref.mscx
+++ b/mtest/capella/io/testText1.capx-ref.mscx
@@ -48,10 +48,6 @@
         </VBox>
       <Measure len="2/4">
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <TimeSig>
             <sigN>4</sigN>
             <sigD>4</sigD>

--- a/mtest/capella/io/testTuplet1.capx-ref.mscx
+++ b/mtest/capella/io/testTuplet1.capx-ref.mscx
@@ -48,10 +48,6 @@
         </VBox>
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <Chord>
             <durationType>quarter</durationType>
             <Note>

--- a/mtest/capella/io/testTuplet2.cap-ref.mscx
+++ b/mtest/capella/io/testTuplet2.cap-ref.mscx
@@ -51,10 +51,6 @@
           <subtype>line</subtype>
           </LayoutBreak>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <TimeSig>
             <sigN>4</sigN>
             <sigD>4</sigD>
@@ -122,10 +118,6 @@
           <subtype>line</subtype>
           </LayoutBreak>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <Chord>
             <durationType>quarter</durationType>
             <Note>
@@ -196,10 +188,6 @@
           <subtype>line</subtype>
           </LayoutBreak>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <Chord>
             <durationType>quarter</durationType>
             <Note>
@@ -291,10 +279,6 @@
           <subtype>line</subtype>
           </LayoutBreak>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <Chord>
             <durationType>quarter</durationType>
             <Note>
@@ -393,10 +377,6 @@
           <subtype>line</subtype>
           </LayoutBreak>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <Chord>
             <durationType>quarter</durationType>
             <Note>
@@ -476,15 +456,11 @@
             </Chord>
           </voice>
         </Measure>
-      <Measure len="12/8">
+      <Measure>
         <LayoutBreak>
           <subtype>line</subtype>
           </LayoutBreak>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <TimeSig>
             <sigN>12</sigN>
             <sigD>8</sigD>
@@ -554,10 +530,6 @@
           <subtype>line</subtype>
           </LayoutBreak>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <Tuplet>
             <normalNotes>3</normalNotes>
             <actualNotes>4</actualNotes>
@@ -645,10 +617,6 @@
           <subtype>line</subtype>
           </LayoutBreak>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <Tuplet>
             <normalNotes>6</normalNotes>
             <actualNotes>8</actualNotes>
@@ -750,10 +718,6 @@
           <subtype>line</subtype>
           </LayoutBreak>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <Tuplet>
             <normalNotes>6</normalNotes>
             <actualNotes>10</actualNotes>
@@ -869,10 +833,6 @@
           <subtype>line</subtype>
           </LayoutBreak>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <Tuplet>
             <normalNotes>12</normalNotes>
             <actualNotes>14</actualNotes>
@@ -1041,15 +1001,11 @@
             </Chord>
           </voice>
         </Measure>
-      <Measure len="4/4">
+      <Measure>
         <LayoutBreak>
           <subtype>line</subtype>
           </LayoutBreak>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <TimeSig>
             <sigN>4</sigN>
             <sigD>4</sigD>
@@ -1173,10 +1129,6 @@
           <subtype>line</subtype>
           </LayoutBreak>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <Tuplet>
             <normalNotes>8</normalNotes>
             <actualNotes>12</actualNotes>
@@ -1300,10 +1252,6 @@
           <subtype>line</subtype>
           </LayoutBreak>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <Tuplet>
             <normalNotes>8</normalNotes>
             <actualNotes>13</actualNotes>
@@ -1448,10 +1396,6 @@
           <subtype>line</subtype>
           </LayoutBreak>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <Tuplet>
             <normalNotes>8</normalNotes>
             <actualNotes>15</actualNotes>

--- a/mtest/capella/io/testTuplet2.capx-ref.mscx
+++ b/mtest/capella/io/testTuplet2.capx-ref.mscx
@@ -51,10 +51,6 @@
           <subtype>line</subtype>
           </LayoutBreak>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <TimeSig>
             <sigN>4</sigN>
             <sigD>4</sigD>
@@ -122,10 +118,6 @@
           <subtype>line</subtype>
           </LayoutBreak>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <Chord>
             <durationType>quarter</durationType>
             <Note>
@@ -196,10 +188,6 @@
           <subtype>line</subtype>
           </LayoutBreak>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <Chord>
             <durationType>quarter</durationType>
             <Note>
@@ -291,10 +279,6 @@
           <subtype>line</subtype>
           </LayoutBreak>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <Chord>
             <durationType>quarter</durationType>
             <Note>
@@ -393,10 +377,6 @@
           <subtype>line</subtype>
           </LayoutBreak>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <Chord>
             <durationType>quarter</durationType>
             <Note>
@@ -476,15 +456,11 @@
             </Chord>
           </voice>
         </Measure>
-      <Measure len="12/8">
+      <Measure>
         <LayoutBreak>
           <subtype>line</subtype>
           </LayoutBreak>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <TimeSig>
             <sigN>12</sigN>
             <sigD>8</sigD>
@@ -554,10 +530,6 @@
           <subtype>line</subtype>
           </LayoutBreak>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <Tuplet>
             <normalNotes>3</normalNotes>
             <actualNotes>4</actualNotes>
@@ -645,10 +617,6 @@
           <subtype>line</subtype>
           </LayoutBreak>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <Tuplet>
             <normalNotes>6</normalNotes>
             <actualNotes>8</actualNotes>
@@ -750,10 +718,6 @@
           <subtype>line</subtype>
           </LayoutBreak>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <Tuplet>
             <normalNotes>6</normalNotes>
             <actualNotes>10</actualNotes>
@@ -869,10 +833,6 @@
           <subtype>line</subtype>
           </LayoutBreak>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <Tuplet>
             <normalNotes>12</normalNotes>
             <actualNotes>14</actualNotes>
@@ -1041,15 +1001,11 @@
             </Chord>
           </voice>
         </Measure>
-      <Measure len="4/4">
+      <Measure>
         <LayoutBreak>
           <subtype>line</subtype>
           </LayoutBreak>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <TimeSig>
             <sigN>4</sigN>
             <sigD>4</sigD>
@@ -1173,10 +1129,6 @@
           <subtype>line</subtype>
           </LayoutBreak>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <Tuplet>
             <normalNotes>8</normalNotes>
             <actualNotes>12</actualNotes>
@@ -1300,10 +1252,6 @@
           <subtype>line</subtype>
           </LayoutBreak>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <Tuplet>
             <normalNotes>8</normalNotes>
             <actualNotes>13</actualNotes>
@@ -1448,10 +1396,6 @@
           <subtype>line</subtype>
           </LayoutBreak>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <Tuplet>
             <normalNotes>8</normalNotes>
             <actualNotes>15</actualNotes>


### PR DESCRIPTION
For some strange reason that also fixes superfluous key signatures.

Resolves: https://musescore.org/de/node/363553

Capella apparently repeats clef, key- and time signature on every start of a system.
If you then remove the system break(s), and that results in the systems to automatically break at a different spot, at the first measure after the previous system break there will be a clef and a key signature, even if it is the same as already active.

This bug annoyed me quite a bit back in the Mu1 days, but it took me until today to get to the bottom of it.