### PR TITLE
Remove newlines in status bar (esp found in multi lined fingering text)

### DIFF
--- a/mscore/scoreaccessibility.cpp
+++ b/mscore/scoreaccessibility.cpp
@@ -281,6 +281,7 @@ void ScoreAccessibility::currentInfoChanged()
 
             QString staff = "";
             QString optimizedStaff = "";
+
             if (e->staffIdx() + 1) {
                   _oldStaff = e->staffIdx();
                   staff = tr("Staff: %1").arg(QString::number(e->staffIdx() + 1));
@@ -292,13 +293,13 @@ void ScoreAccessibility::currentInfoChanged()
                         rez = QString("%1; %2").arg(rez).arg(staff);
                         }
                   else {
-                        rez = QString("%1; %2 (%3)").arg(rez).arg(staff).arg(staffName.replace('\n', ' ')); // no newlines in the status bar
+                        rez = QString("%1; %2 (%3)").arg(rez).arg(staff).arg(staffName);
                         }
                   if (e->staffIdx() != oldStaff)
                         optimizedStaff = QString("%1 (%2)").arg(staff).arg(staffName);
                   }
 
-            statusBarLabel->setText(rez);
+            statusBarLabel->setText(rez.simplified()); // no linebreaks in statusbar
 
             if (scoreView->mscoreState() & STATE_ALLTEXTUAL_EDIT) {
                   // Don't say element name during text editing.


### PR DESCRIPTION
Didn't make an issue, but check:

Make a fingering text and add manual line breaks instead of using space bar to insert multiple numbers... then click on the text

Status bar will put the line breaks in there. Mu4 doesn't do this, so somewhere they fixed it. This should also fix the same problem and who knows whatever else by replacing \n with a space for separation