### PR TITLE
Fix GH#20650: Change mmrest default shortcut

### DIFF
--- a/mscore/data/shortcuts-Mac.xml
+++ b/mscore/data/shortcuts-Mac.xml
@@ -999,7 +999,7 @@
     </SC>
   <SC>
     <key>toggle-mmrest</key>
-    <seq>M</seq>
+    <seq>Ctrl+Shift+M</seq>
     </SC>
   <SC>
     <key>text-b</key>

--- a/mscore/data/shortcuts.xml
+++ b/mscore/data/shortcuts.xml
@@ -999,7 +999,7 @@
     </SC>
   <SC>
     <key>toggle-mmrest</key>
-    <seq>M</seq>
+    <seq>Ctrl+Shift+M</seq>
     </SC>
   <SC>
     <key>text-b</key>

--- a/mscore/data/shortcuts_AZERTY.xml
+++ b/mscore/data/shortcuts_AZERTY.xml
@@ -1035,7 +1035,7 @@
     </SC>
   <SC>
     <key>toggle-mmrest</key>
-    <seq>M</seq>
+    <seq>Ctrl+Shift+M</seq>
     </SC>
   <SC>
     <key>text-b</key>


### PR DESCRIPTION
Backport of #22694

Resolves: [musescore#20650](https://www.github.com/musescore/MuseScore/issues/20650)