### PR TITLE
Fix #445 - Horizontal View not resetting view on rewind

### DIFF
--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -3853,13 +3853,16 @@ void ScoreView::adjustCanvasPosition(const Element* el, bool playBack, int staff
       if (oldX == x && oldY == y)
             return;
 
-      int cx = 0, cy = 0;
-      constraintCanvas(&cx, &cy);
       x *= -physicalZoomLevel();
       y *= -physicalZoomLevel();
-      cx = (x < 0) ? x : cx + _matrix.dx();
-
-      setOffset(cx, y);
+      int cx = x;
+      int cy = y;
+      bool constrain = MScore::verticalOrientation() && preferences.getBool(PREF_UI_CANVAS_SCROLL_LIMITSCROLLAREA);
+      if (constrain) {
+            constraintCanvas(&cx, &cy);
+            cx = (x < 0) ? x : cx + _matrix.dx();
+            }
+      setOffset(cx, cy);
       update();
       }
 


### PR DESCRIPTION
Resolves: #445 

There probably is a more fundamental fix somewhere to be performed, but for now this should give appropriate rewinding in horizontal/vertical and also constrain for vertical as with #377 

Plz test ;)