### PR TITLE
Fix GH#20856: Fix ignored color on trill after opening score

### DIFF
--- a/libmscore/trill.cpp
+++ b/libmscore/trill.cpp
@@ -344,7 +344,7 @@ LineSegment* Trill::createLineSegment()
       {
       TrillSegment* seg = new TrillSegment(this, score());
       seg->setTrack(track());
-      seg->setColor(color());
+      seg->setColor(lineColor());
       seg->initElementStyle(&trillSegmentStyle);
       return seg;
       }


### PR DESCRIPTION
Backport of #22852

Resolves: [musescore#20856](https://www.github.com/musescore/MuseScore/issues/20856)