### PR TITLE
Fix GH#489: Bad y-spacing of chord symbols

### DIFF
--- a/libmscore/harmony.cpp
+++ b/libmscore/harmony.cpp
@@ -1356,10 +1356,11 @@ void Harmony::layout1()
             createLayout();
       if (textBlockList().empty())
             textBlockList().append(TextBlock());
-      calculateBoundingRect();    // for normal symbols this is called in layout: computeMinWidth()
+      auto positionPoint = calculateBoundingRect();    // for normal symbols this is called in layout: computeMinWidth()
       if (hasFrame())
             layoutFrame();
       score()->addRefresh(canvasBoundingRect());
+      setPos(positionPoint);
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
Revert "Fix #344: Modifying an element makes a chord symbol move" This reverts commit e86e962e0866aadd1e6efaa2c66e06a9ffea2f14.

Resolves: #489