### PR TITLE
[Attempt] Fix reset of harmony texts during edit/move

### DIFF
--- a/libmscore/segment.cpp
+++ b/libmscore/segment.cpp
@@ -2119,7 +2119,9 @@ void Segment::createShape(int staffIdx)
 
             if (e->isHarmony()) {
                   // use same spacing calculation as for chordrest
-                  toHarmony(e)->layout1();
+                  auto h = toHarmony(e);
+                  if (h->bbox().isEmpty())
+                        h->layout1();
                   const qreal margin = styleP(Sid::minHarmonyDistance) * 0.5;
                   qreal x1 = e->bbox().x() - margin + e->pos().x();
                   qreal x2 = e->bbox().x() + e->bbox().width() + margin + e->pos().x();


### PR DESCRIPTION
Attempt to resolves: #344

Mu4 also performs the harmony layout again (again in the sense that measure base already performs a layout here, so this isn't in accord with Mu4, but please test this out to see if it does something wrong if you've the time. A quick test on my side shows no problem with the v-alignment and also with no "dropping" on the next system

The point is that harmony texts already get "laid out" when doing a measurebase layout and also wh