### PR TITLE
Fix (potential) crash when opening special characters dialog

### DIFF
--- a/libmscore/tempotext.cpp
+++ b/libmscore/tempotext.cpp
@@ -11,15 +11,16 @@
 //=============================================================================
 
 #include <limits>
-#include "score.h"
-#include "tempotext.h"
-#include "tempo.h"
-#include "system.h"
+
 #include "measure.h"
-#include "staff.h"
-#include "xml.h"
-#include "undo.h"
 #include "musescoreCore.h"
+#include "score.h"
+#include "staff.h"
+#include "system.h"
+#include "tempo.h"
+#include "tempotext.h"
+#include "undo.h"
+#include "xml.h"
 
 namespace Ms {
 

--- a/libmscore/tempotext.h
+++ b/libmscore/tempotext.h
@@ -14,7 +14,7 @@
 #define __TEMPOTEXT_H__
 
 #include "durationtype.h"
-#include "text.h"
+#include "textbase.h"
 
 namespace Ms {
 

--- a/mscore/textpalette.cpp
+++ b/mscore/textpalette.cpp
@@ -17,17 +17,14 @@
 //  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 //=============================================================================
 
-#include "palette.h"
 #include "menus.h"
+#include "musescore.h"
+#include "palette.h"
 #include "textpalette.h"
-#include "icons.h"
-#include "libmscore/text.h"
+
+#include "libmscore/score.h"
 #include "libmscore/sym.h"
 #include "libmscore/symbol.h"
-#include "libmscore/style.h"
-#include "libmscore/clef.h"
-#include "libmscore/score.h"
-#include "musescore.h"
 
 namespace Ms {
 
@@ -430,7 +427,7 @@ TextPalette::TextPalette(QWidget* parent)
 //   populateCommon
 //---------------------------------------------------------
 
-int unicodeAccidentals[] = { //better size and alignment, so put these first
+static constexpr char32_t unicodeAccidentals[] = { //better size and alignment, so put these first
       0x266d,    // flat
       0x266e,    // natural
       0x266f     // sharp
@@ -439,7 +436,7 @@ int unicodeAccidentals[] = { //better size and alignment, so put these first
       // 0x1d12a    // double sharp
       };
 
-int commonTextSymbols[] = {
+static constexpr char32_t commonTextSymbols[] = {
       0x00a9,    // &copy;
 
       // upper case ligatures
@@ -582,24 +579,24 @@ void TextPalette::populateCommon()
       {
       pCommon->clear();
 
-      for (auto id : unicodeAccidentals) {
+      for (char32_t id : unicodeAccidentals) {
             FSymbol* fs = new FSymbol(gscore);
             fs->setCode(id);
             fs->setFont(_font);
-            pCommon->append(fs, QString(id));
+            pCommon->append(fs, QString::fromUcs4(&id, 1));
             }
 
-      for (auto id : Sym::commonScoreSymbols) {
+      for (SymId id : Sym::commonScoreSymbols) {
             Symbol* s = new Symbol(gscore);
             s->setSym(id, gscore->scoreFont());
             pCommon->append(s, Sym::id2userName(id));
             }
 
-      for (auto id : commonTextSymbols) {
+      for (char32_t id : commonTextSymbols) {
             FSymbol* fs = new FSymbol(gscore);
             fs->setCode(id);
             fs->setFont(_font);
-            pCommon->append(fs, QString(id));
+            pCommon->append(fs, QString::fromUcs4(&id, 1));
             }
       }
 


### PR DESCRIPTION
Backport of #23192

Seems to crash only when using Qt6, and even there only in Debug builds, but the code is wrong even before: implicitly converting `id` to a `QChar` regardless that this is just a 16 bit value, while  ìd` is a 32 bit one.

Plus some rather unrelated includes cleanup...