### PR TITLE
Fix GH#23241: Header/footer special symbols tooltip closes too quickly

### DIFF
--- a/mscore/editstyle.cpp
+++ b/mscore/editstyle.cpp
@@ -907,9 +907,9 @@ void EditStyle::setHeaderFooterToolTip() {
             }
       toolTipHeaderFooter += QString("</table></body></html>");
       showHeader->setToolTip(toolTipHeaderFooter);
-      showHeader->setToolTipDuration(5000); // leaving the default value of -1 calculates the duration automatically and it takes too long
+      showHeader->setToolTipDuration(10000); // leaving the default value of -1 calculates the duration automatically and it takes too long
       showFooter->setToolTip(toolTipHeaderFooter);
-      showFooter->setToolTipDuration(5000);
+      showFooter->setToolTipDuration(10000);
       }
 
 //---------------------------------------------------------

--- a/mscore/editstyle.ui
+++ b/mscore/editstyle.ui
@@ -2702,6 +2702,9 @@
                  </item>
                  <item>
                   <widget class="QCheckBox" name="footerInsideMargins">
+                   <property name="toolTip">
+                    <string>Inside margins</string>
+                   </property>
                    <property name="text">
                     <string>Inside margins</string>
                    </property>


### PR DESCRIPTION
'Backport' of #23246 (actually this here existed first)

Resolves: [musescore#23241](https://www.github.com/musescore/MuseScore/issues/23241)