### PR TITLE
Fix GH#17600: Select tuplet when calling next-element prev-element actions

### DIFF
--- a/libmscore/chord.cpp
+++ b/libmscore/chord.cpp
@@ -3793,4 +3793,18 @@ void Chord::setNoteEventLists(QList<NoteEventList>& ell)
 
       }
 
+//---------------------------------
+// firstGraceOrNote
+//---------------------------------
+Note* Chord::firstGraceOrNote()
+      {
+      QVector<Chord*> graceNotesBefore = this->graceNotesBefore();
+      if (!graceNotesBefore.empty()) {
+            if (Chord* graceNotesBeforeFirstChord = graceNotesBefore.front())
+                  return graceNotesBeforeFirstChord->notes().front();
+            }
+
+      return this->notes().back();
+      }
+
 }

--- a/libmscore/chord.h
+++ b/libmscore/chord.h
@@ -229,6 +229,8 @@ class Chord final : public ChordRest {
       Element* prevSegmentElement() override;
       QString accessibleExtraInfo() const override;
 
+      Note* firstGraceOrNote();
+
       Shape shape() const override;
       };
 

--- a/libmscore/chordrest.cpp
+++ b/libmscore/chordrest.cpp
@@ -1141,6 +1141,11 @@ Element* ChordRest::prevElement()
                   break;
                   }
             }
+
+      Tuplet* tuplet = this->tuplet();
+      if (tuplet && this == tuplet->elements().front())
+            return tuplet;
+
       int staffId = e->staffIdx();
       return segment()->prevElement(staffId);
       }

--- a/libmscore/navigate.cpp
+++ b/libmscore/navigate.cpp
@@ -536,7 +536,8 @@ Element* Score::nextElement()
             switch (e->type()) {
                   case ElementType::NOTE:
                   case ElementType::REST:
-                  case ElementType::CHORD: {
+                  case ElementType::CHORD:
+                  case ElementType::TUPLET: {
                         Element* next = e->nextElement();
                         if (next)
                               return next;
@@ -664,7 +665,8 @@ Element* Score::prevElement()
             switch (e->type()) {
                   case ElementType::NOTE:
                   case ElementType::REST:
-                  case ElementType::CHORD: {
+                  case ElementType::CHORD:
+                  case ElementType::TUPLET: {
                         Element* prev = e->prevElement();
                         if (prev)
                               return prev;

--- a/libmscore/segment.cpp
+++ b/libmscore/segment.cpp
@@ -1395,8 +1395,16 @@ Element* Segment::firstElementOfSegment(Segment* s, int activeStaff)
       {
       for (auto i: s->elist()) {
             if (i && i->staffIdx() == activeStaff) {
-                  if (i->type() == ElementType::CHORD)
-                        return toChord(i)->notes().back();
+                  if (i->isDurationElement()) {
+                        DurationElement* de = toDurationElement(i);
+                        Tuplet* tuplet = de->tuplet();
+                        if (tuplet && de == tuplet->elements().front())
+                              return tuplet;
+                        }
+                  if (i->type() == ElementType::CHORD) {
+                        Chord* chord = toChord(i);
+                        return chord->firstGraceOrNote();
+                        }
                   else
                         return i;
                   }
@@ -1659,7 +1667,8 @@ Element* Segment::nextElement(int activeStaff)
             case ElementType::FIGURED_BASS:
             case ElementType::STAFF_STATE:
             case ElementType::INSTRUMENT_CHANGE:
-            case ElementType::STICKING: {
+            case ElementType::STICKING:
+            case ElementType::TUPLET:{
                   Element* next = nullptr;
                   if (e->parent() == this)
                         next = nextAnnotation(e);

--- a/libmscore/tuplet.cpp
+++ b/libmscore/tuplet.cpp
@@ -1381,5 +1381,23 @@ void Tuplet::addMissingElements()
       if (!missingElementsDuration.isZero())
             qDebug("Tuplet::addMissingElements(): still missing duration of %d/%d", missingElementsDuration.numerator(), missingElementsDuration.denominator());
       }
+
+Element* Tuplet::nextElement()
+      {
+      ChordRest* firstElement = toChordRest(elements().front());
+      if (firstElement->type() == ElementType::CHORD) {
+            Chord* chord = toChord(firstElement);
+            return chord->firstGraceOrNote();
+            }
+      return firstElement;
+      }
+
+Element* Tuplet::prevElement()
+      {
+      ChordRest* firstElement = toChordRest(elements().front());
+      int staffId = firstElement->staffIdx();
+      Element* prevItem = firstElement->segment()->prevElement(staffId);
+      return prevItem;
+      }
 }  // namespace Ms
 

--- a/libmscore/tuplet.h
+++ b/libmscore/tuplet.h
@@ -145,6 +145,9 @@ class Tuplet final : public DurationElement {
 
       void sanitizeTuplet();
       void addMissingElements();
+
+      Element* nextElement() override;
+      Element* prevElement() override;
       };
 
 


### PR DESCRIPTION
Backport of #23082

Resolves: [musescore#17600](https://www.github.com/musescore/MuseScore/issues/17600)