### PR TITLE
Check whether string is empty before calling .back()

### DIFF
--- a/importexport/musicxml/importmxmlpass2.cpp
+++ b/importexport/musicxml/importmxmlpass2.cpp
@@ -3328,7 +3328,7 @@ void MusicXMLParserDirection::direction(const QString& partId,
                         QString rawWordsText = _wordsText;
                         static const QRegularExpression re("(<.*?>)");
                         rawWordsText.remove(re);
-                        QString sep = !_metroText.isEmpty() && !_wordsText.isEmpty()
+                        QString sep = !_metroText.isEmpty() && !rawWordsText.isEmpty()
 #if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
                                     && rawWordsText.back()
 #else


### PR DESCRIPTION
Actually it should be `!m_wordsText.empty() && !rawWordsText.empty()`, but `!rawWordsText.empty()` implies `!m_wordsText.empty()`, so checking only `!rawWordsText.empty()` suffices.

Bacport of #23339, commit 1