### PR TITLE
Improve Mu1 import

### DIFF
--- a/mtest/libmscore/compat114/clefs-ref.mscx
+++ b/mtest/libmscore/compat114/clefs-ref.mscx
@@ -68,10 +68,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <leftMargin>5</leftMargin>
-        <rightMargin>5</rightMargin>
-        <topMargin>5</topMargin>
-        <bottomMargin>5</bottomMargin>
         <boxAutoSize>0</boxAutoSize>
         <Text>
           <style>Title</style>

--- a/mtest/libmscore/compat114/fingering-ref.mscx
+++ b/mtest/libmscore/compat114/fingering-ref.mscx
@@ -76,10 +76,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <leftMargin>5</leftMargin>
-        <rightMargin>5</rightMargin>
-        <topMargin>5</topMargin>
-        <bottomMargin>5</bottomMargin>
         <boxAutoSize>0</boxAutoSize>
         <Text>
           <style>Title</style>

--- a/mtest/libmscore/compat114/hairpin-ref.mscx
+++ b/mtest/libmscore/compat114/hairpin-ref.mscx
@@ -72,10 +72,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <leftMargin>5</leftMargin>
-        <rightMargin>5</rightMargin>
-        <topMargin>5</topMargin>
-        <bottomMargin>5</bottomMargin>
         <boxAutoSize>0</boxAutoSize>
         <Text>
           <style>Title</style>

--- a/mtest/libmscore/compat114/hor_frame_and_mmrest-ref.mscx
+++ b/mtest/libmscore/compat114/hor_frame_and_mmrest-ref.mscx
@@ -68,10 +68,6 @@
     <Staff id="1">
       <HBox>
         <width>5</width>
-        <leftMargin>5</leftMargin>
-        <rightMargin>5</rightMargin>
-        <topMargin>5</topMargin>
-        <bottomMargin>5</bottomMargin>
         <boxAutoSize>0</boxAutoSize>
         </HBox>
       <Measure>

--- a/mtest/libmscore/compat114/keysig-ref.mscx
+++ b/mtest/libmscore/compat114/keysig-ref.mscx
@@ -67,10 +67,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <leftMargin>5</leftMargin>
-        <rightMargin>5</rightMargin>
-        <topMargin>5</topMargin>
-        <bottomMargin>5</bottomMargin>
         <boxAutoSize>0</boxAutoSize>
         <Text>
           <style>Title</style>

--- a/mtest/libmscore/compat114/notes-ref.mscx
+++ b/mtest/libmscore/compat114/notes-ref.mscx
@@ -67,10 +67,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <leftMargin>5</leftMargin>
-        <rightMargin>5</rightMargin>
-        <topMargin>5</topMargin>
-        <bottomMargin>5</bottomMargin>
         <boxAutoSize>0</boxAutoSize>
         <Text>
           <style>Title</style>

--- a/mtest/libmscore/compat114/text_scaling-ref.mscx
+++ b/mtest/libmscore/compat114/text_scaling-ref.mscx
@@ -72,10 +72,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <leftMargin>5</leftMargin>
-        <rightMargin>5</rightMargin>
-        <topMargin>5</topMargin>
-        <bottomMargin>5</bottomMargin>
         <boxAutoSize>0</boxAutoSize>
         <Text>
           <style>Title</style>

--- a/mtest/libmscore/compat114/textstyles-ref.mscx
+++ b/mtest/libmscore/compat114/textstyles-ref.mscx
@@ -1655,10 +1655,6 @@
     <Staff id="1">
       <VBox>
         <height>6.36254</height>
-        <leftMargin>5</leftMargin>
-        <rightMargin>5</rightMargin>
-        <topMargin>5</topMargin>
-        <bottomMargin>5</bottomMargin>
         <boxAutoSize>0</boxAutoSize>
         <Text>
           <style>Title</style>

--- a/mtest/libmscore/compat114/title-ref.mscx
+++ b/mtest/libmscore/compat114/title-ref.mscx
@@ -72,10 +72,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <leftMargin>5</leftMargin>
-        <rightMargin>5</rightMargin>
-        <topMargin>5</topMargin>
-        <bottomMargin>5</bottomMargin>
         <boxAutoSize>0</boxAutoSize>
         <Text>
           <style>Title</style>

--- a/mtest/libmscore/compat114/tuplets-ref.mscx
+++ b/mtest/libmscore/compat114/tuplets-ref.mscx
@@ -65,10 +65,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <leftMargin>5</leftMargin>
-        <rightMargin>5</rightMargin>
-        <topMargin>5</topMargin>
-        <bottomMargin>5</bottomMargin>
         <boxAutoSize>0</boxAutoSize>
         <Text>
           <style>Title</style>

--- a/mtest/libmscore/compat114/tuplets_1-ref.mscx
+++ b/mtest/libmscore/compat114/tuplets_1-ref.mscx
@@ -65,10 +65,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <leftMargin>5</leftMargin>
-        <rightMargin>5</rightMargin>
-        <topMargin>5</topMargin>
-        <bottomMargin>5</bottomMargin>
         <boxAutoSize>0</boxAutoSize>
         <Text>
           <style>Title</style>

--- a/mtest/libmscore/compat114/tuplets_2-ref.mscx
+++ b/mtest/libmscore/compat114/tuplets_2-ref.mscx
@@ -65,10 +65,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <leftMargin>5</leftMargin>
-        <rightMargin>5</rightMargin>
-        <topMargin>5</topMargin>
-        <bottomMargin>5</bottomMargin>
         <boxAutoSize>0</boxAutoSize>
         <Text>
           <style>Title</style>

--- a/mtest/libmscore/compat206/frame_text2-ref.mscx
+++ b/mtest/libmscore/compat206/frame_text2-ref.mscx
@@ -233,7 +233,6 @@
     <Staff id="1">
       <VBox>
         <height>25.5926</height>
-        <bottomGap>0</bottomGap>
         <topMargin>3</topMargin>
         <boxAutoSize>0</boxAutoSize>
         <Text>
@@ -249,7 +248,6 @@
       <VBox>
         <height>47.762</height>
         <topGap>10</topGap>
-        <bottomGap>0</bottomGap>
         <boxAutoSize>0</boxAutoSize>
         <Text>
           <style>Frame</style>


### PR DESCRIPTION
here esp. the vertical and horizontal frames and their margins, by syncing read114.cpp's `readBox()` with what read206.cpp's `readBox()` does.

Examples, Mu3 (and Mu4):
![Screenshot 2024-07-18 190249](https://github.com/user-attachments/assets/072d7da9-03f7-4a31-8a79-ca4547499653)

Mu1 (and Mu2 and with this PR):
![image](https://github.com/user-attachments/assets/7c11393d-8b42-499b-84b2-9b1b4ba744c4)

Importing Mu1 and Mu2 scores marked BOTTOM_GAP of a vertical frame to not be the default setting even if it was, so I fixed that too, in the passing

Highly annoying to have to reset these 5 setting to default on every single score, I really should have done this PR back in 2019 when I switched to Mu3 and migrated loads of my old M1 and Mu2 scores. All done now, so too late for me ... (except for some 400 scores on the back burner, awaiting a properly working album feature)

'Backport' of #23648 (actually this one here existed first)