### PR TITLE
Fix GH#23652: Possible buffer overflow in `Capella::readString()`

### DIFF
--- a/importexport/capella/capella.h
+++ b/importexport/capella/capella.h
@@ -630,7 +630,7 @@ struct CapBracket {
 
 class Capella {
       static const char* errmsg[];
-      int curPos;
+      qint64 curPos;
 
       QFile* f;
       char* author;

--- a/importexport/capella/capella.h
+++ b/importexport/capella/capella.h
@@ -682,7 +682,7 @@ class Capella {
 
    public:
       enum class Error : char { CAP_NO_ERROR, BAD_SIG, CAP_EOF, BAD_VOICE_SIG,
-            BAD_STAFF_SIG, BAD_SYSTEM_SIG
+            BAD_STAFF_SIG, BAD_SYSTEM_SIG, BAD_FORMAT,
             };
 
       Capella();


### PR DESCRIPTION
Resolves: [musescore#23652](https://www.github.com/musescore/MuseScore/issues/23652)

'Backport' of #23654 (actually this one here existed first)
Backport of #23696