### PR TITLE
Don't skip gap rests when entering notes (GH#17931 & GH#21355)

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -2462,7 +2462,9 @@ Element* Score::move(const QString& cmd)
             // find next chordrest, which might be a grace note
             // this may override note input cursor
             el = nextChordRest(cr);
-            while (el && el->isRest() && toRest(el)->isGap())
+
+            // Skip gap rests if we're not in note entry mode...
+            while (!noteEntryMode() && el && el->isRest() && toRest(el)->isGap())
                   el = nextChordRest(toChordRest(el));
             if (el && noteEntryMode()) {
                   // do not use if not in original or new measure (don't skip measures)
@@ -2501,7 +2503,9 @@ Element* Score::move(const QString& cmd)
             // find previous chordrest, which might be a grace note
             // this may override note input cursor
             el = prevChordRest(cr);
-            while (el && el->isRest() && toRest(el)->isGap())
+
+            // Skip gap rests if we're not in note entry mode...
+            while (!noteEntryMode() && el && el->isRest() && toRest(el)->isGap())
                   el = prevChordRest(toChordRest(el));
             if (el && noteEntryMode()) {
                   // do not use if not in original or new measure (don't skip measures)

--- a/libmscore/input.cpp
+++ b/libmscore/input.cpp
@@ -235,15 +235,10 @@ Segment* InputState::nextInputPos() const
       {
       Measure* m = _segment->measure();
       Segment* s = _segment->next1(SegmentType::ChordRest);
-      for (; s; s = s->next1(SegmentType::ChordRest)) {
-            if (s->element(_track)) {
-                  if (s->element(_track)->isRest() && toRest(s->element(_track))->isGap())
-                        m = s->measure();
-                  else
-                        return s;
-                  }
-            else if (s->measure() != m)
+      while (s) {
+            if (s->element(_track) || s->measure() != m)
                   return s;
+            s = s->next1(SegmentType::ChordRest);
             }
       return 0;
       }


### PR DESCRIPTION
Backport of #23911

Resolves: [musescore#17931](https://www.github.com/musescore/MuseScore/issues/17931) & [musescore#21355](https://www.github.com/musescore/MuseScore/issues/21355)