### PR TITLE
Fix GH#552: Electric Guitar (treble clef) incorrectly transposes when linking to a TAB staff

### DIFF
--- a/mtest/guitarpro/UncompletedMeasure.gpx-ref.mscx
+++ b/mtest/guitarpro/UncompletedMeasure.gpx-ref.mscx
@@ -93,8 +93,23 @@
           <velocity>120</velocity>
           <gateTime>100</gateTime>
           </Articulation>
-        <Channel>
+        <Channel name="open">
           <program value="27"/>
+          </Channel>
+        <Channel name="mute">
+          <program value="28"/>
+          </Channel>
+        <Channel name="jazz">
+          <program value="26"/>
+          </Channel>
+        <Channel name="harmonics">
+          <program value="31"/>
+          </Channel>
+        <Channel name="distortion">
+          <program value="30"/>
+          </Channel>
+        <Channel name="overdriven">
+          <program value="29"/>
           </Channel>
         </Instrument>
       </Part>
@@ -259,8 +274,23 @@
             <velocity>120</velocity>
             <gateTime>100</gateTime>
             </Articulation>
-          <Channel>
+          <Channel name="open">
             <program value="27"/>
+            </Channel>
+          <Channel name="mute">
+            <program value="28"/>
+            </Channel>
+          <Channel name="jazz">
+            <program value="26"/>
+            </Channel>
+          <Channel name="harmonics">
+            <program value="31"/>
+            </Channel>
+          <Channel name="distortion">
+            <program value="30"/>
+            </Channel>
+          <Channel name="overdriven">
+            <program value="29"/>
             </Channel>
           </Instrument>
         </Part>

--- a/mtest/guitarpro/artificial-harmonic.gpx-ref.mscx
+++ b/mtest/guitarpro/artificial-harmonic.gpx-ref.mscx
@@ -93,8 +93,23 @@
           <velocity>120</velocity>
           <gateTime>100</gateTime>
           </Articulation>
-        <Channel>
+        <Channel name="open">
           <program value="27"/>
+          </Channel>
+        <Channel name="mute">
+          <program value="28"/>
+          </Channel>
+        <Channel name="jazz">
+          <program value="26"/>
+          </Channel>
+        <Channel name="harmonics">
+          <program value="31"/>
+          </Channel>
+        <Channel name="distortion">
+          <program value="30"/>
+          </Channel>
+        <Channel name="overdriven">
+          <program value="29"/>
           </Channel>
         </Instrument>
       </Part>
@@ -431,8 +446,23 @@
             <velocity>120</velocity>
             <gateTime>100</gateTime>
             </Articulation>
-          <Channel>
+          <Channel name="open">
             <program value="27"/>
+            </Channel>
+          <Channel name="mute">
+            <program value="28"/>
+            </Channel>
+          <Channel name="jazz">
+            <program value="26"/>
+            </Channel>
+          <Channel name="harmonics">
+            <program value="31"/>
+            </Channel>
+          <Channel name="distortion">
+            <program value="30"/>
+            </Channel>
+          <Channel name="overdriven">
+            <program value="29"/>
             </Channel>
           </Instrument>
         </Part>

--- a/mtest/guitarpro/dotted-gliss.gpx-ref.mscx
+++ b/mtest/guitarpro/dotted-gliss.gpx-ref.mscx
@@ -93,10 +93,35 @@
           <velocity>120</velocity>
           <gateTime>100</gateTime>
           </Articulation>
-        <Channel>
+        <Channel name="open">
           <program value="30"/>
           <midiPort>0</midiPort>
           <midiChannel>3</midiChannel>
+          </Channel>
+        <Channel name="mute">
+          <program value="28"/>
+          <midiPort>0</midiPort>
+          <midiChannel>0</midiChannel>
+          </Channel>
+        <Channel name="jazz">
+          <program value="26"/>
+          <midiPort>0</midiPort>
+          <midiChannel>1</midiChannel>
+          </Channel>
+        <Channel name="harmonics">
+          <program value="31"/>
+          <midiPort>0</midiPort>
+          <midiChannel>2</midiChannel>
+          </Channel>
+        <Channel name="distortion">
+          <program value="30"/>
+          <midiPort>0</midiPort>
+          <midiChannel>4</midiChannel>
+          </Channel>
+        <Channel name="overdriven">
+          <program value="29"/>
+          <midiPort>0</midiPort>
+          <midiChannel>5</midiChannel>
           </Channel>
         </Instrument>
       </Part>
@@ -328,8 +353,23 @@ Innuendo</text>
             <velocity>120</velocity>
             <gateTime>100</gateTime>
             </Articulation>
-          <Channel>
+          <Channel name="open">
             <program value="30"/>
+            </Channel>
+          <Channel name="mute">
+            <program value="28"/>
+            </Channel>
+          <Channel name="jazz">
+            <program value="26"/>
+            </Channel>
+          <Channel name="harmonics">
+            <program value="31"/>
+            </Channel>
+          <Channel name="distortion">
+            <program value="30"/>
+            </Channel>
+          <Channel name="overdriven">
+            <program value="29"/>
             </Channel>
           </Instrument>
         </Part>

--- a/mtest/guitarpro/free-time.gpx-ref.mscx
+++ b/mtest/guitarpro/free-time.gpx-ref.mscx
@@ -93,8 +93,23 @@
           <velocity>120</velocity>
           <gateTime>100</gateTime>
           </Articulation>
-        <Channel>
+        <Channel name="open">
           <program value="27"/>
+          </Channel>
+        <Channel name="mute">
+          <program value="28"/>
+          </Channel>
+        <Channel name="jazz">
+          <program value="26"/>
+          </Channel>
+        <Channel name="harmonics">
+          <program value="31"/>
+          </Channel>
+        <Channel name="distortion">
+          <program value="30"/>
+          </Channel>
+        <Channel name="overdriven">
+          <program value="29"/>
           </Channel>
         </Instrument>
       </Part>
@@ -320,8 +335,23 @@
             <velocity>120</velocity>
             <gateTime>100</gateTime>
             </Articulation>
-          <Channel>
+          <Channel name="open">
             <program value="27"/>
+            </Channel>
+          <Channel name="mute">
+            <program value="28"/>
+            </Channel>
+          <Channel name="jazz">
+            <program value="26"/>
+            </Channel>
+          <Channel name="harmonics">
+            <program value="31"/>
+            </Channel>
+          <Channel name="distortion">
+            <program value="30"/>
+            </Channel>
+          <Channel name="overdriven">
+            <program value="29"/>
             </Channel>
           </Instrument>
         </Part>

--- a/mtest/guitarpro/keysig.gpx-ref.mscx
+++ b/mtest/guitarpro/keysig.gpx-ref.mscx
@@ -93,8 +93,23 @@
           <velocity>120</velocity>
           <gateTime>100</gateTime>
           </Articulation>
-        <Channel>
+        <Channel name="open">
           <program value="27"/>
+          </Channel>
+        <Channel name="mute">
+          <program value="28"/>
+          </Channel>
+        <Channel name="jazz">
+          <program value="26"/>
+          </Channel>
+        <Channel name="harmonics">
+          <program value="31"/>
+          </Channel>
+        <Channel name="distortion">
+          <program value="30"/>
+          </Channel>
+        <Channel name="overdriven">
+          <program value="29"/>
           </Channel>
         </Instrument>
       </Part>
@@ -2078,8 +2093,23 @@
             <velocity>120</velocity>
             <gateTime>100</gateTime>
             </Articulation>
-          <Channel>
+          <Channel name="open">
             <program value="27"/>
+            </Channel>
+          <Channel name="mute">
+            <program value="28"/>
+            </Channel>
+          <Channel name="jazz">
+            <program value="26"/>
+            </Channel>
+          <Channel name="harmonics">
+            <program value="31"/>
+            </Channel>
+          <Channel name="distortion">
+            <program value="30"/>
+            </Channel>
+          <Channel name="overdriven">
+            <program value="29"/>
             </Channel>
           </Instrument>
         </Part>

--- a/mtest/guitarpro/let-ring.gpx-ref.mscx
+++ b/mtest/guitarpro/let-ring.gpx-ref.mscx
@@ -93,8 +93,23 @@
           <velocity>120</velocity>
           <gateTime>100</gateTime>
           </Articulation>
-        <Channel>
+        <Channel name="open">
           <program value="27"/>
+          </Channel>
+        <Channel name="mute">
+          <program value="28"/>
+          </Channel>
+        <Channel name="jazz">
+          <program value="26"/>
+          </Channel>
+        <Channel name="harmonics">
+          <program value="31"/>
+          </Channel>
+        <Channel name="distortion">
+          <program value="30"/>
+          </Channel>
+        <Channel name="overdriven">
+          <program value="29"/>
           </Channel>
         </Instrument>
       </Part>
@@ -301,8 +316,23 @@
             <velocity>120</velocity>
             <gateTime>100</gateTime>
             </Articulation>
-          <Channel>
+          <Channel name="open">
             <program value="27"/>
+            </Channel>
+          <Channel name="mute">
+            <program value="28"/>
+            </Channel>
+          <Channel name="jazz">
+            <program value="26"/>
+            </Channel>
+          <Channel name="harmonics">
+            <program value="31"/>
+            </Channel>
+          <Channel name="distortion">
+            <program value="30"/>
+            </Channel>
+          <Channel name="overdriven">
+            <program value="29"/>
             </Channel>
           </Instrument>
         </Part>

--- a/mtest/guitarpro/ottava2.gpx-ref.mscx
+++ b/mtest/guitarpro/ottava2.gpx-ref.mscx
@@ -171,8 +171,23 @@
           <velocity>120</velocity>
           <gateTime>100</gateTime>
           </Articulation>
-        <Channel>
+        <Channel name="open">
           <program value="27"/>
+          </Channel>
+        <Channel name="mute">
+          <program value="28"/>
+          </Channel>
+        <Channel name="jazz">
+          <program value="26"/>
+          </Channel>
+        <Channel name="harmonics">
+          <program value="31"/>
+          </Channel>
+        <Channel name="distortion">
+          <program value="30"/>
+          </Channel>
+        <Channel name="overdriven">
+          <program value="29"/>
           </Channel>
         </Instrument>
       </Part>
@@ -1070,8 +1085,23 @@
             <velocity>120</velocity>
             <gateTime>100</gateTime>
             </Articulation>
-          <Channel>
+          <Channel name="open">
             <program value="27"/>
+            </Channel>
+          <Channel name="mute">
+            <program value="28"/>
+            </Channel>
+          <Channel name="jazz">
+            <program value="26"/>
+            </Channel>
+          <Channel name="harmonics">
+            <program value="31"/>
+            </Channel>
+          <Channel name="distortion">
+            <program value="30"/>
+            </Channel>
+          <Channel name="overdriven">
+            <program value="29"/>
             </Channel>
           </Instrument>
         </Part>

--- a/mtest/guitarpro/ottava3.gpx-ref.mscx
+++ b/mtest/guitarpro/ottava3.gpx-ref.mscx
@@ -171,8 +171,23 @@
           <velocity>120</velocity>
           <gateTime>100</gateTime>
           </Articulation>
-        <Channel>
+        <Channel name="open">
           <program value="27"/>
+          </Channel>
+        <Channel name="mute">
+          <program value="28"/>
+          </Channel>
+        <Channel name="jazz">
+          <program value="26"/>
+          </Channel>
+        <Channel name="harmonics">
+          <program value="31"/>
+          </Channel>
+        <Channel name="distortion">
+          <program value="30"/>
+          </Channel>
+        <Channel name="overdriven">
+          <program value="29"/>
           </Channel>
         </Instrument>
       </Part>
@@ -590,8 +605,23 @@
             <velocity>120</velocity>
             <gateTime>100</gateTime>
             </Articulation>
-          <Channel>
+          <Channel name="open">
             <program value="27"/>
+            </Channel>
+          <Channel name="mute">
+            <program value="28"/>
+            </Channel>
+          <Channel name="jazz">
+            <program value="26"/>
+            </Channel>
+          <Channel name="harmonics">
+            <program value="31"/>
+            </Channel>
+          <Channel name="distortion">
+            <program value="30"/>
+            </Channel>
+          <Channel name="overdriven">
+            <program value="29"/>
             </Channel>
           </Instrument>
         </Part>

--- a/mtest/guitarpro/ottava4.gpx-ref.mscx
+++ b/mtest/guitarpro/ottava4.gpx-ref.mscx
@@ -171,8 +171,23 @@
           <velocity>120</velocity>
           <gateTime>100</gateTime>
           </Articulation>
-        <Channel>
+        <Channel name="open">
           <program value="27"/>
+          </Channel>
+        <Channel name="mute">
+          <program value="28"/>
+          </Channel>
+        <Channel name="jazz">
+          <program value="26"/>
+          </Channel>
+        <Channel name="harmonics">
+          <program value="31"/>
+          </Channel>
+        <Channel name="distortion">
+          <program value="30"/>
+          </Channel>
+        <Channel name="overdriven">
+          <program value="29"/>
           </Channel>
         </Instrument>
       </Part>
@@ -1104,8 +1119,23 @@
             <velocity>120</velocity>
             <gateTime>100</gateTime>
             </Articulation>
-          <Channel>
+          <Channel name="open">
             <program value="27"/>
+            </Channel>
+          <Channel name="mute">
+            <program value="28"/>
+            </Channel>
+          <Channel name="jazz">
+            <program value="26"/>
+            </Channel>
+          <Channel name="harmonics">
+            <program value="31"/>
+            </Channel>
+          <Channel name="distortion">
+            <program value="30"/>
+            </Channel>
+          <Channel name="overdriven">
+            <program value="29"/>
             </Channel>
           </Instrument>
         </Part>

--- a/mtest/guitarpro/ottava5.gpx-ref.mscx
+++ b/mtest/guitarpro/ottava5.gpx-ref.mscx
@@ -171,8 +171,23 @@
           <velocity>120</velocity>
           <gateTime>100</gateTime>
           </Articulation>
-        <Channel>
+        <Channel name="open">
           <program value="27"/>
+          </Channel>
+        <Channel name="mute">
+          <program value="28"/>
+          </Channel>
+        <Channel name="jazz">
+          <program value="26"/>
+          </Channel>
+        <Channel name="harmonics">
+          <program value="31"/>
+          </Channel>
+        <Channel name="distortion">
+          <program value="30"/>
+          </Channel>
+        <Channel name="overdriven">
+          <program value="29"/>
           </Channel>
         </Instrument>
       </Part>
@@ -749,8 +764,23 @@
             <velocity>120</velocity>
             <gateTime>100</gateTime>
             </Articulation>
-          <Channel>
+          <Channel name="open">
             <program value="27"/>
+            </Channel>
+          <Channel name="mute">
+            <program value="28"/>
+            </Channel>
+          <Channel name="jazz">
+            <program value="26"/>
+            </Channel>
+          <Channel name="harmonics">
+            <program value="31"/>
+            </Channel>
+          <Channel name="distortion">
+            <program value="30"/>
+            </Channel>
+          <Channel name="overdriven">
+            <program value="29"/>
             </Channel>
           </Instrument>
         </Part>

--- a/mtest/guitarpro/palm-mute.gpx-ref.mscx
+++ b/mtest/guitarpro/palm-mute.gpx-ref.mscx
@@ -93,8 +93,23 @@
           <velocity>120</velocity>
           <gateTime>100</gateTime>
           </Articulation>
-        <Channel>
+        <Channel name="open">
           <program value="27"/>
+          </Channel>
+        <Channel name="mute">
+          <program value="28"/>
+          </Channel>
+        <Channel name="jazz">
+          <program value="26"/>
+          </Channel>
+        <Channel name="harmonics">
+          <program value="31"/>
+          </Channel>
+        <Channel name="distortion">
+          <program value="30"/>
+          </Channel>
+        <Channel name="overdriven">
+          <program value="29"/>
           </Channel>
         </Instrument>
       </Part>
@@ -301,8 +316,23 @@
             <velocity>120</velocity>
             <gateTime>100</gateTime>
             </Articulation>
-          <Channel>
+          <Channel name="open">
             <program value="27"/>
+            </Channel>
+          <Channel name="mute">
+            <program value="28"/>
+            </Channel>
+          <Channel name="jazz">
+            <program value="26"/>
+            </Channel>
+          <Channel name="harmonics">
+            <program value="31"/>
+            </Channel>
+          <Channel name="distortion">
+            <program value="30"/>
+            </Channel>
+          <Channel name="overdriven">
+            <program value="29"/>
             </Channel>
           </Instrument>
         </Part>

--- a/mtest/guitarpro/repeated-bars.gpx-ref.mscx
+++ b/mtest/guitarpro/repeated-bars.gpx-ref.mscx
@@ -93,8 +93,23 @@
           <velocity>120</velocity>
           <gateTime>100</gateTime>
           </Articulation>
-        <Channel>
+        <Channel name="open">
           <program value="27"/>
+          </Channel>
+        <Channel name="mute">
+          <program value="28"/>
+          </Channel>
+        <Channel name="jazz">
+          <program value="26"/>
+          </Channel>
+        <Channel name="harmonics">
+          <program value="31"/>
+          </Channel>
+        <Channel name="distortion">
+          <program value="30"/>
+          </Channel>
+        <Channel name="overdriven">
+          <program value="29"/>
           </Channel>
         </Instrument>
       </Part>
@@ -293,8 +308,23 @@
             <velocity>120</velocity>
             <gateTime>100</gateTime>
             </Articulation>
-          <Channel>
+          <Channel name="open">
             <program value="27"/>
+            </Channel>
+          <Channel name="mute">
+            <program value="28"/>
+            </Channel>
+          <Channel name="jazz">
+            <program value="26"/>
+            </Channel>
+          <Channel name="harmonics">
+            <program value="31"/>
+            </Channel>
+          <Channel name="distortion">
+            <program value="30"/>
+            </Channel>
+          <Channel name="overdriven">
+            <program value="29"/>
             </Channel>
           </Instrument>
         </Part>

--- a/mtest/guitarpro/rest-centered.gpx-ref.mscx
+++ b/mtest/guitarpro/rest-centered.gpx-ref.mscx
@@ -93,8 +93,23 @@
           <velocity>120</velocity>
           <gateTime>100</gateTime>
           </Articulation>
-        <Channel>
+        <Channel name="open">
           <program value="27"/>
+          </Channel>
+        <Channel name="mute">
+          <program value="28"/>
+          </Channel>
+        <Channel name="jazz">
+          <program value="26"/>
+          </Channel>
+        <Channel name="harmonics">
+          <program value="31"/>
+          </Channel>
+        <Channel name="distortion">
+          <program value="30"/>
+          </Channel>
+        <Channel name="overdriven">
+          <program value="29"/>
           </Channel>
         </Instrument>
       </Part>
@@ -269,8 +284,23 @@
             <velocity>120</velocity>
             <gateTime>100</gateTime>
             </Articulation>
-          <Channel>
+          <Channel name="open">
             <program value="27"/>
+            </Channel>
+          <Channel name="mute">
+            <program value="28"/>
+            </Channel>
+          <Channel name="jazz">
+            <program value="26"/>
+            </Channel>
+          <Channel name="harmonics">
+            <program value="31"/>
+            </Channel>
+          <Channel name="distortion">
+            <program value="30"/>
+            </Channel>
+          <Channel name="overdriven">
+            <program value="29"/>
             </Channel>
           </Instrument>
         </Part>

--- a/mtest/guitarpro/testIrrTuplet.gpx-ref.mscx
+++ b/mtest/guitarpro/testIrrTuplet.gpx-ref.mscx
@@ -93,10 +93,35 @@
           <velocity>120</velocity>
           <gateTime>100</gateTime>
           </Articulation>
-        <Channel>
+        <Channel name="open">
           <program value="29"/>
           <midiPort>0</midiPort>
           <midiChannel>15</midiChannel>
+          </Channel>
+        <Channel name="mute">
+          <program value="28"/>
+          <midiPort>0</midiPort>
+          <midiChannel>0</midiChannel>
+          </Channel>
+        <Channel name="jazz">
+          <program value="26"/>
+          <midiPort>0</midiPort>
+          <midiChannel>1</midiChannel>
+          </Channel>
+        <Channel name="harmonics">
+          <program value="31"/>
+          <midiPort>0</midiPort>
+          <midiChannel>2</midiChannel>
+          </Channel>
+        <Channel name="distortion">
+          <program value="30"/>
+          <midiPort>0</midiPort>
+          <midiChannel>3</midiChannel>
+          </Channel>
+        <Channel name="overdriven">
+          <program value="29"/>
+          <midiPort>0</midiPort>
+          <midiChannel>4</midiChannel>
           </Channel>
         </Instrument>
       </Part>
@@ -322,7 +347,22 @@
             <velocity>120</velocity>
             <gateTime>100</gateTime>
             </Articulation>
-          <Channel>
+          <Channel name="open">
+            <program value="29"/>
+            </Channel>
+          <Channel name="mute">
+            <program value="28"/>
+            </Channel>
+          <Channel name="jazz">
+            <program value="26"/>
+            </Channel>
+          <Channel name="harmonics">
+            <program value="31"/>
+            </Channel>
+          <Channel name="distortion">
+            <program value="30"/>
+            </Channel>
+          <Channel name="overdriven">
             <program value="29"/>
             </Channel>
           </Instrument>

--- a/mtest/guitarpro/text.gpx-ref.mscx
+++ b/mtest/guitarpro/text.gpx-ref.mscx
@@ -93,8 +93,23 @@
           <velocity>120</velocity>
           <gateTime>100</gateTime>
           </Articulation>
-        <Channel>
+        <Channel name="open">
           <program value="27"/>
+          </Channel>
+        <Channel name="mute">
+          <program value="28"/>
+          </Channel>
+        <Channel name="jazz">
+          <program value="26"/>
+          </Channel>
+        <Channel name="harmonics">
+          <program value="31"/>
+          </Channel>
+        <Channel name="distortion">
+          <program value="30"/>
+          </Channel>
+        <Channel name="overdriven">
+          <program value="29"/>
           </Channel>
         </Instrument>
       </Part>
@@ -288,8 +303,23 @@
             <velocity>120</velocity>
             <gateTime>100</gateTime>
             </Articulation>
-          <Channel>
+          <Channel name="open">
             <program value="27"/>
+            </Channel>
+          <Channel name="mute">
+            <program value="28"/>
+            </Channel>
+          <Channel name="jazz">
+            <program value="26"/>
+            </Channel>
+          <Channel name="harmonics">
+            <program value="31"/>
+            </Channel>
+          <Channel name="distortion">
+            <program value="30"/>
+            </Channel>
+          <Channel name="overdriven">
+            <program value="29"/>
             </Channel>
           </Instrument>
         </Part>

--- a/mtest/guitarpro/trill.gpx-ref.mscx
+++ b/mtest/guitarpro/trill.gpx-ref.mscx
@@ -93,8 +93,23 @@
           <velocity>120</velocity>
           <gateTime>100</gateTime>
           </Articulation>
-        <Channel>
+        <Channel name="open">
           <program value="27"/>
+          </Channel>
+        <Channel name="mute">
+          <program value="28"/>
+          </Channel>
+        <Channel name="jazz">
+          <program value="26"/>
+          </Channel>
+        <Channel name="harmonics">
+          <program value="31"/>
+          </Channel>
+        <Channel name="distortion">
+          <program value="30"/>
+          </Channel>
+        <Channel name="overdriven">
+          <program value="29"/>
           </Channel>
         </Instrument>
       </Part>
@@ -294,8 +309,23 @@
             <velocity>120</velocity>
             <gateTime>100</gateTime>
             </Articulation>
-          <Channel>
+          <Channel name="open">
             <program value="27"/>
+            </Channel>
+          <Channel name="mute">
+            <program value="28"/>
+            </Channel>
+          <Channel name="jazz">
+            <program value="26"/>
+            </Channel>
+          <Channel name="harmonics">
+            <program value="31"/>
+            </Channel>
+          <Channel name="distortion">
+            <program value="30"/>
+            </Channel>
+          <Channel name="overdriven">
+            <program value="29"/>
             </Channel>
           </Instrument>
         </Part>

--- a/mtest/guitarpro/vibrato.gpx-ref.mscx
+++ b/mtest/guitarpro/vibrato.gpx-ref.mscx
@@ -93,8 +93,23 @@
           <velocity>120</velocity>
           <gateTime>100</gateTime>
           </Articulation>
-        <Channel>
+        <Channel name="open">
           <program value="27"/>
+          </Channel>
+        <Channel name="mute">
+          <program value="28"/>
+          </Channel>
+        <Channel name="jazz">
+          <program value="26"/>
+          </Channel>
+        <Channel name="harmonics">
+          <program value="31"/>
+          </Channel>
+        <Channel name="distortion">
+          <program value="30"/>
+          </Channel>
+        <Channel name="overdriven">
+          <program value="29"/>
           </Channel>
         </Instrument>
       </Part>
@@ -416,8 +431,23 @@
             <velocity>120</velocity>
             <gateTime>100</gateTime>
             </Articulation>
-          <Channel>
+          <Channel name="open">
             <program value="27"/>
+            </Channel>
+          <Channel name="mute">
+            <program value="28"/>
+            </Channel>
+          <Channel name="jazz">
+            <program value="26"/>
+            </Channel>
+          <Channel name="harmonics">
+            <program value="31"/>
+            </Channel>
+          <Channel name="distortion">
+            <program value="30"/>
+            </Channel>
+          <Channel name="overdriven">
+            <program value="29"/>
             </Channel>
           </Instrument>
         </Part>

--- a/share/instruments/instruments.xml
+++ b/share/instruments/instruments.xml
@@ -11200,12 +11200,12 @@ Aeolus organ synthesizer, currently disabled -->
                   <musicXMLid>pluck.guitar.electric</musicXMLid>
                   <StringData>
                         <frets>24</frets>
-                        <string>40</string>
-                        <string>45</string>
-                        <string>50</string>
-                        <string>55</string>
-                        <string>59</string>
-                        <string>64</string>
+                        <string>52</string>
+                        <string>57</string>
+                        <string>62</string>
+                        <string>67</string>
+                        <string>71</string>
+                        <string>76</string>
                   </StringData>
                   <transposingClef>G</transposingClef>
                   <concertClef>G8vb</concertClef>
@@ -11215,9 +11215,29 @@ Aeolus organ synthesizer, currently disabled -->
                   <singleNoteDynamics>0</singleNoteDynamics>
                   <transposeDiatonic>-7</transposeDiatonic>
                   <transposeChromatic>-12</transposeChromatic>
-                  <Channel>
+                  <Channel name="open">
                         <!--MIDI: Bank 0, Prog 27; MS General: Clean Guitar-->
                         <program value="27"/> <!--Electric Guitar (clean)-->
+                  </Channel>
+                  <Channel name="mute">
+                        <!--MIDI: Bank 0, Prog 28; MS General: Palm Muted Guitar-->
+                        <program value="28"/> <!--Electric Guitar (muted)-->
+                  </Channel>
+                  <Channel name="jazz">
+                        <!--MIDI: Bank 0, Prog 26; MS General: Jazz Guitar-->
+                        <program value="26"/> <!--Electric Guitar (jazz)-->
+                  </Channel>
+                  <Channel name="harmonics">
+                        <!--MIDI: Bank 0, Prog 31; MS General: Guitar Harmonics-->
+                        <program value="31"/> <!--Guitar Harmonics-->
+                  </Channel>
+                  <Channel name="distortion">
+                        <!--MIDI: Bank 0, Prog 30; MS General: Distortion Guitar-->
+                        <program value="30"/> <!--Distortion Guitar-->
+                  </Channel>
+                  <Channel name="overdriven">
+                        <!--MIDI: Bank 0, Prog 29; MS General: Overdrive Guitar-->
+                        <program value="29"/> <!--Overdriven Guitar-->
                   </Channel>
             </Instrument>
             <Instrument id="electric-guitar-tablature">


### PR DESCRIPTION
Resolves: #552