### PR TITLE
Fix #556: Measure Number offset not updating all systems

### DIFF
--- a/mscore/measureproperties.cpp
+++ b/mscore/measureproperties.cpp
@@ -19,6 +19,7 @@
 
 #include "measureproperties.h"
 #include "libmscore/measure.h"
+#include "libmscore/measurebase.h"
 #include "libmscore/sig.h"
 #include "libmscore/score.h"
 #include "libmscore/repeat.h"
@@ -257,12 +258,13 @@ void MeasureProperties::apply()
                   propertiesChanged = true;
                   }
             }
-
+      int measureOffset = measureNumberOffset->value();
+      bool offsetChanged = (measureOffset != m->noOffset()) ? true : false;
       m->undoChangeProperty(Pid::REPEAT_COUNT, repeatCount());
       m->undoChangeProperty(Pid::BREAK_MMR, breakMultiMeasureRest->isChecked());
       m->undoChangeProperty(Pid::USER_STRETCH, layoutStretch->value());
       m->undoChangeProperty(Pid::MEASURE_NUMBER_MODE, measureNumberMode->currentIndex());
-      m->undoChangeProperty(Pid::NO_OFFSET, measureNumberOffset->value());
+      m->undoChangeProperty(Pid::NO_OFFSET, measureOffset);
       m->undoChangeProperty(Pid::IRREGULAR, isIrregular());
 
       if (m->ticks() != len()) {
@@ -283,6 +285,9 @@ void MeasureProperties::apply()
 
       if (propertiesChanged) {
             m->triggerLayout();
+            }
+      if (offsetChanged) {
+            score->doLayoutRange(m->tick(), score->lastMeasure()->tick());
             }
 
       score->select(m, SelectType::SINGLE, 0);


### PR DESCRIPTION
Resolves: #556

This won't update undo/redo though, so if a user

1) Offsets a measure number
Results would be as expected (multi-systems updated from then on at the moment of variance)
2) Perform [undo] - Results won't revert because the undo stack didn't register a "relayout all" since it was performed in the MeasureProperties apply function...
... at least this should be a good start