### PR TITLE
Fix GH#23119: Ensure TextLineBase properties are written for hairpins

### DIFF
--- a/importexport/musicxml/importmxmlpass2.cpp
+++ b/importexport/musicxml/importmxmlpass2.cpp
@@ -1454,7 +1454,7 @@ static void addTextToNote(long l, long c, QString txt, QString placement, QStrin
 
 /**
  Helper for direction().
- SLine placement is modified by changing the first segments user offset
+ SLine placement is modified by changing the first segment's user offset
  As the SLine has just been created, it does not have any segment yet
  */
 
@@ -1475,11 +1475,11 @@ static void setSLinePlacement(SLine* sli, const QString placement)
                   qreal y = 0;
                   y +=  offsAbove;
                   // add linesegment containing the user offset
-                  LineSegment* tls= sli->createLineSegment();
+                  LineSegment* tls = sli->createLineSegment();
                   //qDebug("   y = %g", y);
                   tls->setAutoplace(false);
                   y *= sli->score()->spatium();
-                  tls->setUserOff(QPointF(0, y));
+                  tls->setUserOff2(QPointF(0, y));
                   sli->add(tls);
                   }
             }
@@ -1489,7 +1489,7 @@ static void setSLinePlacement(SLine* sli, const QString placement)
 #endif
       if (placement == "above" || placement == "below") {
             sli->setPlacement(placement == "above" ? Placement::ABOVE : Placement::BELOW);
-            sli->setPropertyFlags(Pid::PLACEMENT, PropertyFlags::UNSTYLED);
+            sli->setPropertyFlags(Pid::PLACEMENT, PropertyFlags::NOSTYLE);
             sli->resetProperty(Pid::OFFSET);
             }
       }

--- a/libmscore/hairpin.cpp
+++ b/libmscore/hairpin.cpp
@@ -676,6 +676,7 @@ void Hairpin::write(XmlWriter& xml) const
       writeProperty(xml, Pid::DYNAMIC_RANGE);
       writeProperty(xml, Pid::SINGLE_NOTE_DYNAMICS);
       writeProperty(xml, Pid::VELO_CHANGE_METHOD);
+      //writeProperty(xml, Pid::PLACEMENT);
 
       TextLineBase::writeProperties(xml);
       xml.etag();

--- a/libmscore/hairpin.cpp
+++ b/libmscore/hairpin.cpp
@@ -585,7 +585,10 @@ Hairpin::Hairpin(Score* s)
       initElementStyle(&hairpinStyle);
 
       resetProperty(Pid::BEGIN_TEXT_PLACE);
+      resetProperty(Pid::END_TEXT_PLACE);
       resetProperty(Pid::CONTINUE_TEXT_PLACE);
+      resetProperty(Pid::BEGIN_HOOK_HEIGHT);
+      resetProperty(Pid::END_HOOK_HEIGHT);
       resetProperty(Pid::HAIRPIN_TYPE);
       resetProperty(Pid::LINE_VISIBLE);
 
@@ -671,18 +674,10 @@ void Hairpin::write(XmlWriter& xml) const
       writeProperty(xml, Pid::VELO_CHANGE);
       writeProperty(xml, Pid::HAIRPIN_CIRCLEDTIP);
       writeProperty(xml, Pid::DYNAMIC_RANGE);
-//      writeProperty(xml, Pid::BEGIN_TEXT);
-      writeProperty(xml, Pid::END_TEXT);
-//      writeProperty(xml, Pid::CONTINUE_TEXT);
-      writeProperty(xml, Pid::LINE_VISIBLE);
       writeProperty(xml, Pid::SINGLE_NOTE_DYNAMICS);
       writeProperty(xml, Pid::VELO_CHANGE_METHOD);
 
-      for (const StyledProperty& spp : *styledProperties()) {
-            if (!isStyled(spp.pid))
-                  writeProperty(xml, spp.pid);
-            }
-      SLine::writeProperties(xml);
+      TextLineBase::writeProperties(xml);
       xml.etag();
       }
 
@@ -840,6 +835,7 @@ QVariant Hairpin::propertyDefault(Pid id) const
 
             case Pid::BEGIN_TEXT_PLACE:
             case Pid::CONTINUE_TEXT_PLACE:
+            case Pid::END_TEXT_PLACE:
                   return int(PlaceText::LEFT);
 
             case Pid::BEGIN_TEXT_OFFSET:
@@ -853,7 +849,7 @@ QVariant Hairpin::propertyDefault(Pid id) const
 
             case Pid::BEGIN_HOOK_HEIGHT:
             case Pid::END_HOOK_HEIGHT:
-                  return Spatium(0.0);
+                  return Spatium(1.9);
 
             case Pid::LINE_VISIBLE:
                   return true;

--- a/mtest/musicxml/io/testInferredCrescLines2_ref.mscx
+++ b/mtest/musicxml/io/testInferredCrescLines2_ref.mscx
@@ -140,8 +140,8 @@
           <Spanner type="HairPin">
             <HairPin>
               <subtype>3</subtype>
-              <endText></endText>
               <lineVisible>0</lineVisible>
+              <endText></endText>
               </HairPin>
             <next>
               <location>
@@ -672,8 +672,8 @@
           <Spanner type="HairPin">
             <HairPin>
               <subtype>2</subtype>
-              <endText></endText>
               <lineVisible>0</lineVisible>
+              <endText></endText>
               </HairPin>
             <next>
               <location>
@@ -1293,8 +1293,8 @@
           <Spanner type="HairPin">
             <HairPin>
               <subtype>3</subtype>
-              <endText></endText>
               <lineVisible>0</lineVisible>
+              <endText></endText>
               </HairPin>
             <next>
               <location>

--- a/mtest/musicxml/io/testInferredCrescLines_ref.mscx
+++ b/mtest/musicxml/io/testInferredCrescLines_ref.mscx
@@ -140,8 +140,8 @@
           <Spanner type="HairPin">
             <HairPin>
               <subtype>2</subtype>
-              <endText></endText>
               <lineVisible>0</lineVisible>
+              <endText></endText>
               </HairPin>
             <next>
               <location>
@@ -251,8 +251,8 @@
           <Spanner type="HairPin">
             <HairPin>
               <subtype>2</subtype>
-              <endText></endText>
               <lineVisible>0</lineVisible>
+              <endText></endText>
               </HairPin>
             <next>
               <location>
@@ -300,8 +300,8 @@
           <Spanner type="HairPin">
             <HairPin>
               <subtype>2</subtype>
-              <endText></endText>
               <lineVisible>0</lineVisible>
+              <endText></endText>
               </HairPin>
             <next>
               <location>
@@ -446,8 +446,8 @@
           <Spanner type="HairPin">
             <HairPin>
               <subtype>3</subtype>
-              <endText></endText>
               <lineVisible>0</lineVisible>
+              <endText></endText>
               </HairPin>
             <next>
               <location>
@@ -551,8 +551,8 @@
           <Spanner type="HairPin">
             <HairPin>
               <subtype>2</subtype>
-              <endText></endText>
               <lineVisible>0</lineVisible>
+              <endText></endText>
               </HairPin>
             <next>
               <location>

--- a/mtest/musicxml/io/testInferredDynamicsExpression_ref.mscx
+++ b/mtest/musicxml/io/testInferredDynamicsExpression_ref.mscx
@@ -257,8 +257,8 @@
           <Spanner type="HairPin">
             <HairPin>
               <subtype>2</subtype>
-              <endText></endText>
               <lineVisible>0</lineVisible>
+              <endText></endText>
               </HairPin>
             <next>
               <location>

--- a/mtest/musicxml/io/testInferredDynamics_ref.mscx
+++ b/mtest/musicxml/io/testInferredDynamics_ref.mscx
@@ -151,8 +151,8 @@
           <Spanner type="HairPin">
             <HairPin>
               <subtype>2</subtype>
-              <endText></endText>
               <lineVisible>0</lineVisible>
+              <endText></endText>
               </HairPin>
             <next>
               <location>


### PR DESCRIPTION
Backport of #23125

Resolves: [musescore#23119](https://www.github.com/musescore/MuseScore/issues/23119)