### PR TITLE
Fix #554 - Import XML - Verify segment to prevent potential crash

### DIFF
--- a/importexport/musicxml/importmxmlpass2.cpp
+++ b/importexport/musicxml/importmxmlpass2.cpp
@@ -1096,6 +1096,7 @@ static void addFermataToChord(const Notation& notation, ChordRest* cr)
       const SymId articSym = notation.symId();
       const QString direction = notation.attribute("type");
       const QColor color { notation.attribute("color") };
+      Segment* seg = cr->segment();
       Fermata* na = new Fermata(articSym, cr->score());
       na->setTrack(cr->track());
       if (color.isValid()/* && preferences.getBool(PREF_IMPORT_MUSICXML_IMPORTLAYOUT)*/)
@@ -1105,15 +1106,17 @@ static void addFermataToChord(const Notation& notation, ChordRest* cr)
       else
             na->setPlacement(na->propertyDefault(Pid::PLACEMENT).value<Placement>());
       setElementPropertyFlags(na, Pid::PLACEMENT, direction);
-      if (cr->segment() == nullptr && cr->isGrace())
+      if (!seg && cr->isGrace())
             cr->el().push_back(na);       // store for later move to segment
+      else if (seg)
+            seg->add(na);
       else
-            cr->segment()->add(na);
+            return;
 
       // Move or hide fermata based on existing fermatas.
       bool alreadyAbove = false;
       bool alreadyBelow = false;
-      for (Element* e: cr->segment()->annotations()) {
+      for (Element* e: seg->annotations()) {
             if (e->isFermata() && e != na
             && e->staffIdx() == na->staffIdx() && e->track() != na->track()) {
                   Element* otherCr = cr->segment()->elist()[e->track()];


### PR DESCRIPTION
Resolves (hopefully): #554

I tested one of the XML files in the issue. Checked debug output, a bunch of:
```
/importmxmllogger.cpp:Ms::log: Error at line 169 col 10: Non-started tie terminated. No-op.
importmxmllogger.cpp:Ms::log: Error at line 185 col 10: Non-started tie terminated. No-op.
importmxmlpass2.cpp:Ms::convertNotehead: unknown notehead square
importmxmlpass2.cpp:Ms::convertNotehead: unknown notehead square
```

But that doesn't seem the main culprit. Crash on application of a fermata. Notice that the present code assumes a valid chord segment, which probably should be valid, but I think that's where it was crashing. Could be a sign of something worse (why not valid?), but by demanding validity before iterating through annotations or whatever, it should fix the issue.

Needs testing (built locally and verified opening one of the provided xml files, but my local state isn't currently equivalent to 3.7 "evolution")
