### PR TITLE
Fix GH#24153: Use single line stave for marching snare and cymbal

### DIFF
--- a/share/templates/07-Band_and_Percussion/04-Marching_Band.mscx
+++ b/share/templates/07-Band_and_Percussion/04-Marching_Band.mscx
@@ -1837,6 +1837,7 @@
       <Staff id="23">
         <StaffType group="percussion">
           <name>perc1Line</name>
+          <lines>1</lines>
           <keysig>0</keysig>
           </StaffType>
         <defaultClef>PERC</defaultClef>
@@ -2389,6 +2390,7 @@
       <Staff id="26">
         <StaffType group="percussion">
           <name>perc1Line</name>
+          <lines>1</lines>
           <keysig>0</keysig>
           </StaffType>
         <defaultClef>PERC</defaultClef>

--- a/share/templates/07-Band_and_Percussion/05-Small_Marching_Band.mscx
+++ b/share/templates/07-Band_and_Percussion/05-Small_Marching_Band.mscx
@@ -1130,6 +1130,7 @@
       <Staff id="15">
         <StaffType group="percussion">
           <name>perc1Line</name>
+          <lines>1</lines>
           <keysig>0</keysig>
           </StaffType>
         <defaultClef>PERC</defaultClef>
@@ -1685,6 +1686,7 @@
       <Staff id="18">
         <StaffType group="percussion">
           <name>perc1Line</name>
+          <lines>1</lines>
           <keysig>0</keysig>
           </StaffType>
         <defaultClef>PERC</defaultClef>

--- a/share/templates/07-Band_and_Percussion/06-Battery_Percussion.mscx
+++ b/share/templates/07-Band_and_Percussion/06-Battery_Percussion.mscx
@@ -27,6 +27,7 @@
       <Staff id="1">
         <StaffType group="percussion">
           <name>perc1Line</name>
+          <lines>1</lines>
           <keysig>0</keysig>
           </StaffType>
         <defaultClef>PERC</defaultClef>
@@ -583,6 +584,7 @@
       <Staff id="4">
         <StaffType group="percussion">
           <name>perc1Line</name>
+          <lines>1</lines>
           <keysig>0</keysig>
           </StaffType>
         <defaultClef>PERC</defaultClef>

--- a/share/templates/07-Band_and_Percussion/07-Large_Pit_Percussion.mscx
+++ b/share/templates/07-Band_and_Percussion/07-Large_Pit_Percussion.mscx
@@ -1996,6 +1996,7 @@
       <Staff id="26">
         <StaffType group="percussion">
           <name>perc1Line</name>
+          <lines>1</lines>
           <keysig>0</keysig>
           </StaffType>
         <defaultClef>PERC</defaultClef>
@@ -2552,6 +2553,7 @@
       <Staff id="29">
         <StaffType group="percussion">
           <name>perc1Line</name>
+          <lines>1</lines>
           <keysig>0</keysig>
           </StaffType>
         <defaultClef>PERC</defaultClef>

--- a/share/templates/07-Band_and_Percussion/08-Small_Pit_Percussion.mscx
+++ b/share/templates/07-Band_and_Percussion/08-Small_Pit_Percussion.mscx
@@ -1097,6 +1097,7 @@
       <Staff id="13">
         <StaffType group="percussion">
           <name>perc1Line</name>
+          <lines>1</lines>
           <keysig>0</keysig>
           </StaffType>
         <defaultClef>PERC</defaultClef>
@@ -1653,6 +1654,7 @@
       <Staff id="16">
         <StaffType group="percussion">
           <name>perc1Line</name>
+          <lines>1</lines>
           <keysig>0</keysig>
           </StaffType>
         <defaultClef>PERC</defaultClef>


### PR DESCRIPTION
Backport of #24216

Resolves: [musescore#24153](https://www.github.com/musescore/MuseScore/issues/24153)