### PR TITLE
[Command] Voice cycling within range-selection without need of selection filter

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -4300,6 +4300,135 @@ void Score::cmdApplyInputState()
       }
 
 //---------------------------------------------------------
+//   cmdCycleVoiceFilter();
+//
+//   Cycle through voices 1 - 4 of a selection range, and
+//   resets to ALL to begin again.
+//   Note: Selection Filter checkboxes are not updated when
+//         using this
+//---------------------------------------------------------
+
+void Score::cmdCycleVoiceFilter(int voice)
+      {
+      static int nextVoice  = 1;
+      static bool failed    = false;
+      const int lastVoice   = 4;
+
+      if (!selection().isRange())
+            return;
+
+      auto& sf = selectionFilter();
+      auto first      = selection().firstChordRest();
+      auto last       = selection().lastChordRest();
+      auto staffBegin = selection().staffStart();
+      auto staffEnd   = selection().staffEnd() - 1;
+      bool firstVoiceAlreadyActive = (first->voice() == 0);
+      if (failed) {
+            // Still engaged in the cycle rather than starting over just yet
+            selection().hasTemporaryFilter(true);
+            }
+
+      if (noteEntryMode() && voice == 0) {
+            bool notLimited = sf.isFiltered(SelectionFilterType::DYNAMIC);
+            if (notLimited) {
+                  // Cycle between [limited/all] of note entry's current voice
+                  voice = inputState().voice() + 1;
+                  }
+            }
+
+      bool validVoice = (voice >= 1) && (voice <= lastVoice);
+      if (validVoice) {
+            sf.setFiltered(SelectionFilterType::FIRST_VOICE,   false);
+            sf.setFiltered(SelectionFilterType::SECOND_VOICE,  false);
+            sf.setFiltered(SelectionFilterType::THIRD_VOICE,   false);
+            sf.setFiltered(SelectionFilterType::FOURTH_VOICE,  false);
+
+            if (noteEntryMode()) {
+                  // Initial note-entry range limitations:
+                  // Since user can cycle between all and limited, the limitation includes all these:
+                  nextVoice = voice;
+                  sf.setFiltered(SelectionFilterType::DYNAMIC,      false);
+                  sf.setFiltered(SelectionFilterType::HAIRPIN,      false);
+                  sf.setFiltered(SelectionFilterType::LYRICS,       false);
+                  sf.setFiltered(SelectionFilterType::CHORD_SYMBOL, false);
+                  sf.setFiltered(SelectionFilterType::FIGURED_BASS, false);
+                  sf.setFiltered(SelectionFilterType::FINGERING,    false);
+                  sf.setFiltered(SelectionFilterType::FRET_DIAGRAM, false);
+                  sf.setFiltered(SelectionFilterType::OTHER_LINE,   false);
+                  sf.setFiltered(SelectionFilterType::OTHER_TEXT,   false);
+                  sf.setFiltered(SelectionFilterType::PEDAL_LINE,   false);
+                  sf.setFiltered(SelectionFilterType::OTTAVA,       false);
+                  }
+
+            switch (voice)
+            {
+            case 1: sf.setFiltered(SelectionFilterType::FIRST_VOICE,  true); break;
+            case 2: sf.setFiltered(SelectionFilterType::SECOND_VOICE, true); break;
+            case 3: sf.setFiltered(SelectionFilterType::THIRD_VOICE,  true); break;
+            case 4: sf.setFiltered(SelectionFilterType::FOURTH_VOICE, true); break;
+            }
+
+            selection().hasTemporaryFilter(true);
+            update();
+            return;
+            }
+
+      // Voice cycle:
+
+      // Left over cycling (e.g. an old range selection) should prepare for filtering at voice-1
+      if (firstVoiceAlreadyActive && !noteEntryMode()) {
+            bool toBeVoiceOne = (!nextVoice || nextVoice > 2);
+            if (toBeVoiceOne) {
+                  nextVoice = 1;
+                  }
+            }
+
+      sf.setFiltered(SelectionFilterType::ALL, true);
+      sf.setFiltered(SelectionFilterType::FIRST_VOICE,  false);
+      sf.setFiltered(SelectionFilterType::SECOND_VOICE, false);
+      sf.setFiltered(SelectionFilterType::THIRD_VOICE,  false);
+      sf.setFiltered(SelectionFilterType::FOURTH_VOICE, false);
+
+      switch (nextVoice)
+      {
+      case 1: sf.setFiltered(SelectionFilterType::FIRST_VOICE,  true); break;
+      case 2: sf.setFiltered(SelectionFilterType::SECOND_VOICE, true); break;
+      case 3: sf.setFiltered(SelectionFilterType::THIRD_VOICE,  true); break;
+      case 4: sf.setFiltered(SelectionFilterType::FOURTH_VOICE, true); break;
+      case 0: default: sf.setFiltered(SelectionFilterType::ALL, true); break;
+      }
+
+      selection().hasTemporaryFilter((!nextVoice ? false : true));
+
+      if (++nextVoice > lastVoice)
+            nextVoice = 0;
+
+      setUpdateAll();
+      update();
+
+      // Attempted to cycle into non-existent voice:
+      if (!selection().isRange()) {
+            failed = true;
+            deselectAll();
+            sf.setFiltered(SelectionFilterType::ALL, true);
+            selectRange(first, staffBegin);
+            selectRange(last, staffEnd);
+            setUpdateAll();
+            update();
+
+            // Reset filter if needed after having failed
+            bool resetFilter = (nextVoice >= lastVoice);
+            if (resetFilter) {
+                  selection().hasTemporaryFilter(false);
+                  nextVoice = 1;
+                  failed = false;
+                  }
+            else cmdCycleVoiceFilter();
+            }
+      else failed = false;
+      }
+
+//---------------------------------------------------------
 //   cmd
 //---------------------------------------------------------
 
@@ -4477,6 +4606,7 @@ void Score::cmd(const QAction* a, EditData& ed)
             { "toggle-autoplace",           [](Score* cs, EditData&){ cs->cmdToggleAutoplace(false);                                  }},
             { "autoplace-enabled",          [](Score* cs, EditData&){ cs->cmdToggleAutoplace(true);                                   }},
             { "apply-input-state",          [](Score* cs, EditData&){ cs->cmdApplyInputState();                                       }},
+            { "voice-selection-cycle",      [](Score* cs, EditData&){ cs->cmdCycleVoiceFilter();                                      }},
             };
 
       for (const auto& c : cmdList) {

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -775,6 +775,7 @@ class Score : public QObject, public ScoreElement {
       void cmdRelayout();
       void cmdToggleAutoplace(bool all);
       void cmdApplyInputState();
+      void cmdCycleVoiceFilter(int voice=0);
 
       bool playNote() const                 { return _updateState._playNote; }
       void setPlayNote(bool v)              { _updateState._playNote = v;    }

--- a/libmscore/select.cpp
+++ b/libmscore/select.cpp
@@ -723,10 +723,18 @@ void Selection::updateState()
       {
       int n = _el.size();
       Element* e = element();
-      if (n == 0)
+
+      if (n == 0) {
             setState(SelState::NONE);
-      else if (_state == SelState::NONE)
+            if (hasTemporaryFilter()) {
+                  hasTemporaryFilter(false);
+                  auto& sf = score()->selectionFilter();
+                  sf.setFiltered(SelectionFilterType::ALL, true);
+                  }
+            }
+      else if (_state == SelState::NONE) {
             setState(SelState::LIST);
+            }
       if (e) {
             if (e->isSpannerSegment())
                   _currentTick = toSpannerSegment(e)->spanner()->tick();

--- a/libmscore/select.h
+++ b/libmscore/select.h
@@ -151,6 +151,8 @@ class Selection {
       Segment* _activeSegment;
       int _activeTrack;
 
+      bool _temporaryFilter { false };
+
       Fraction _currentTick;  // tracks the most recent selection
       int _currentTrack;
 
@@ -193,6 +195,10 @@ class Selection {
       void deselectAll();
       void remove(Element*);
       void clear();
+
+      bool hasTemporaryFilter() { return _temporaryFilter; }
+      void hasTemporaryFilter(bool v) { _temporaryFilter = v; }
+
       Element* element() const;
       ChordRest* cr() const;
       Segment* firstChordRestSegment() const;

--- a/mscore/events.cpp
+++ b/mscore/events.cpp
@@ -1132,6 +1132,19 @@ void ScoreView::changeState(ViewState s)
             return;
 
       qDebug("changeState %s  -> %s", stateName(state), stateName(s));
+
+      auto& selection = _score->selection();
+
+      if (selection.hasTemporaryFilter()) {
+            auto& sf = score()->selectionFilter();
+            sf.setFiltered(SelectionFilterType::ALL, true);
+            sf.setFiltered(SelectionFilterType::FIRST_VOICE, true);
+            sf.setFiltered(SelectionFilterType::SECOND_VOICE, true);
+            sf.setFiltered(SelectionFilterType::THIRD_VOICE, true);
+            sf.setFiltered(SelectionFilterType::FOURTH_VOICE, true);
+            selection.hasTemporaryFilter(false);
+            }
+
       //
       //    end current state
       //

--- a/mscore/shortcut.cpp
+++ b/mscore/shortcut.cpp
@@ -1937,6 +1937,13 @@ Shortcut Shortcut::_sc[] = {
       {
          MsWidget::SCORE_TAB,
          STATE_NORMAL | STATE_NOTE_ENTRY,
+         "voice-selection-cycle",
+         QT_TRANSLATE_NOOP("action","Cycle through voices in range-selection"),
+         QT_TRANSLATE_NOOP("action","Cycle through voices in range-selection")
+         },
+      {
+         MsWidget::SCORE_TAB,
+         STATE_NORMAL | STATE_NOTE_ENTRY,
          "toggle-mouse-entry",
          QT_TRANSLATE_NOOP("action","Toggle mouse for note entry"),
          QT_TRANSLATE_NOOP("action","Toggle mouse for note entry"),


### PR DESCRIPTION
I've had this ability for a few years now and find it really useful, but I'm not 100% it is totally compatible to your code. Looks like it was intertwined with my ability to have hairpins and pedal-lines be added during note-entry a-la "slur-style" note entry, but I ripped that out hoping it should be okay. I present this to you for testing the artifacts. It's an extra command function and works in range-selection. 

Test it out if you find some time later on and if you like it... do the rest of course ;) Or if some issues comes up we can discuss here or something

Fwiw I use the ` (grave) character to cycle through quickly since it isn't used by default

Edit: I'll describe its behavior in some videos soon, and mention a few characteristics. 

Edit: Testing seems to be okay. The code is 'prepared' for allowing note-entry ranges to do further filterings, but that would require more commits and I'll do that in another PR in the future possibly.