### PR TITLE
[Note Entry] Allow [move to previous chord] to use note-entry voice when score selection is of a different voice

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -2488,6 +2488,7 @@ Element* Score::move(const QString& cmd)
             }
       else if (cmd == "prev-chord" && cr) {
             // note input cursor
+            bool noteEntryPos = false;
             if (noteEntryMode() && _is.segment()) {
                   Measure* m = _is.segment()->measure();
                   Segment* s = _is.segment()->prev1(SegmentType::ChordRest);
@@ -2495,6 +2496,8 @@ Element* Score::move(const QString& cmd)
                   for (; s; s = s->prev1(SegmentType::ChordRest)) {
                         if (s->element(track) || (s->measure() != m && s->rtick().isZero())) {
                               if (s->element(track)) {
+                                    el = s->nextChordRest(track, true);
+                                    noteEntryPos = true;
                                     if (s->element(track)->isRest() && toRest(s->element(track))->isGap())
                                           continue;
                                     }
@@ -2507,7 +2510,7 @@ Element* Score::move(const QString& cmd)
             // selection "cursor"
             // find previous chordrest, which might be a grace note
             // this may override note input cursor
-            el = prevChordRest(cr);
+            el = noteEntryPos ? el : prevChordRest(cr);
 
             // Skip gap rests if we're not in note entry mode...
             while (!noteEntryMode() && el && el->isRest() && toRest(el)->isGap())


### PR DESCRIPTION
Resolves: #604