### PR TITLE
[Cmd: insert/append measure] dialogue should have spinbox highlighted…

### DIFF
--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -315,8 +315,11 @@ void MuseScore::cmdInsertMeasures()
                         tr("No measure selected:\n" "Please select a measure and try again"));
                   }
             else {
-                  insertMeasuresDialog = new InsertMeasuresDialog;
+                  if (!insertMeasuresDialog)
+                        insertMeasuresDialog = new InsertMeasuresDialog;
                   insertMeasuresDialog->show();
+                  insertMeasuresDialog->insmeasures->setFocus();
+                  insertMeasuresDialog->insmeasures->selectAll();
                   }
             }
       }
@@ -3107,9 +3110,11 @@ void MuseScore::showPlayPanel(bool visible)
 void MuseScore::cmdAppendMeasures()
       {
       if (cs) {
-            if (measuresDialog == 0)
+            if (!measuresDialog)
                   measuresDialog = new MeasuresDialog;
             measuresDialog->show();
+            measuresDialog->measures->setFocus();
+            measuresDialog->measures->selectAll();
             }
       }
 


### PR DESCRIPTION
… by default ready for keyboard entry

little knick-knack benefits. I'll try to keep sending them your way if I find them


Results in 

![image](https://github.com/user-attachments/assets/f0920647-7ba9-4bb8-b69f-03b6dbb20806)

... which allows a quick [type in number] + [press enter] finish. Matter of fact, seems crazy that it didn't do this by default already.