### PR TITLE
Fix GH#24596: Follow written tempo when 'c.' added to tempo text

### DIFF
--- a/libmscore/tempotext.cpp
+++ b/libmscore/tempotext.cpp
@@ -294,6 +294,7 @@ void TempoText::updateTempo()
       s.replace("≈", "=");
       s.replace("~", "=");
       s.replace("ca.", "");
+      s.replace("c.", "");
       s.replace("approx.", "");
       for (const TempoPattern& pa : tp) {
             QRegExp re;


### PR DESCRIPTION
Resolves: [musescore#24596](https://www.github.com/musescore/MuseScore/issues/24596)