### PR TITLE
Fix: anacrusis has wrong tempo if not explicitly set

### DIFF
--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -441,12 +441,7 @@ void Score::fixTicks()
             if (m->mmRest())
                   m->mmRest()->moveTicks(diff);
 
-            // TODO: Better to use Measure::isAnacrusis() here
-            // but since it requires irregular() return true it's not working as expected
-            // if user didn't checked "Exclude from measure count" in measure properties,
-            // but reduces the real measure length.
-            // So we use the following workaround:
-            if (m->ticks() < m->timesig())
+            if (m->isAnacrusis())
                   anacrusisMeasures.push_back(m);
 
             rebuildTempoAndTimeSigMaps(m);

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -18,15 +18,14 @@
  Definition of Score class.
 */
 
-#include "config.h"
 #include "input.h"
 #include "instrument.h"
-#include "select.h"
-#include "synthesizerstate.h"
-#include "mscoreview.h"
-#include "spannermap.h"
 #include "layoutbreak.h"
+#include "mscoreview.h"
 #include "property.h"
+#include "select.h"
+#include "spannermap.h"
+#include "synthesizerstate.h"
 #include "sym.h"
 
 namespace Ms {
@@ -853,6 +852,7 @@ class Score : public QObject, public ScoreElement {
       Segment* tick2leftSegmentMM(const Fraction& tick) { return tick2leftSegment(tick, /* useMMRest */ true); }
       void fixTicks();
       void rebuildTempoAndTimeSigMaps(Measure* m);
+      void fixAnacrusisTempo(const std::vector<Measure*>& measures) const;
       Element* nextElement();
       Element* prevElement();
       ChordRest* cmdNextPrevSystem(ChordRest*, bool);
@@ -937,7 +937,7 @@ class Score : public QObject, public ScoreElement {
       void setInputTrack(int t)                { inputState().setTrack(t);    }
 
       void spatiumChanged(qreal oldValue, qreal newValue);
-      void styleChanged();
+      void styleChanged() override;
 
       void cmdPaste(const QMimeData* ms, MuseScoreView* view, Fraction scale = Fraction(1, 1));
       bool pasteStaff(XmlReader&, Segment* dst, int staffIdx, Fraction scale = Fraction(1, 1));


### PR DESCRIPTION
Reopened #546, backport of #23656 / #24643

Plus some includes files cleanup

Resolves: [musescore#24570](https://www.github.com/musescore/MuseScore/issues/24570)