### PR TITLE
[Cmd: Paste Clone] insert cloned measure bases via shortcut or right-…

### DIFF
--- a/libmscore/box.cpp
+++ b/libmscore/box.cpp
@@ -515,6 +515,11 @@ bool Box::acceptDrop(EditData& data) const
             case ElementType::STAFF_TEXT:
             case ElementType::IMAGE:
             case ElementType::SYMBOL:
+            case ElementType::VBOX:
+            case ElementType::HBOX:
+            case ElementType::TBOX:
+            case ElementType::MEASURE_LIST:
+            case ElementType::MEASURE:
                   return true;
             case ElementType::ICON:
                   switch (toIcon(data.dropElement)->iconType()) {
@@ -587,6 +592,19 @@ Element* Box::drop(EditData& data)
                   return text;
                   }
 
+            case ElementType::HBOX:
+            case ElementType::VBOX:
+            case ElementType::TBOX:
+                  {
+                  if (auto mbSource = e->findMeasureBase()) {
+                        auto mbDestination = this->findMeasureBase();
+                        auto boxClone = mbSource->clone();
+                        boxClone->setPrev(this->prevMM());
+                        boxClone->setNext(mbDestination);
+                        score()->undo(new InsertMeasures(boxClone, boxClone));
+                        }
+                  break;
+                  }
             case ElementType::ICON:
                   switch (toIcon(e)->iconType()) {
                         case IconType::VFRAME:

--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -1410,6 +1410,10 @@ bool Measure::acceptDrop(EditData& data) const
             case ElementType::SYMBOL:
             case ElementType::CLEF:
             case ElementType::STAFFTYPE_CHANGE:
+            case ElementType::VBOX:
+            case ElementType::HBOX:
+            case ElementType::TBOX:
+
                   viewer->setDropRectangle(staffR);
                   return true;
 
@@ -1696,6 +1700,19 @@ Element* Measure::drop(EditData& data)
                   {
                   delete e;
                   return cmdInsertRepeatMeasure(staffIdx);
+                  }
+            case ElementType::HBOX:
+            case ElementType::VBOX:
+            case ElementType::TBOX:
+                  {
+                  if (auto mbSource = e->findMeasureBase()) {
+                        auto mbDestination = this->findMeasureBase();
+                        auto boxClone = mbSource->clone();
+                        boxClone->setPrev(this->prevMM());
+                        boxClone->setNext(mbDestination);
+                        score()->undo(new InsertMeasures(boxClone, boxClone));
+                        }
+                  break;
                   }
             case ElementType::ICON:
                   switch(toIcon(e)->iconType()) {
@@ -3191,6 +3208,126 @@ Measure* Measure::cloneMeasure(Score* sc, const Fraction& tick, TieMap* tieMap)
       for (Element* e : el()) {
             Element* ne = e->clone();
             ne->setScore(sc);
+            ne->setOffset(e->offset());
+            m->add(ne);
+            }
+      return m;
+      }
+
+//---------------------------------------------------------
+//   cloneMeasure
+//---------------------------------------------------------
+
+Measure* Measure::cloneMeasureLimited(Score* scoreDest, const Fraction& tick, TieMap* tieMap, int startStaff, int endStaff)
+      {
+      Measure* m      = new Measure(scoreDest);
+      m->_timesig     = _timesig;
+      m->_len         = _len;
+      m->_repeatCount = _repeatCount;
+
+      // Limited edition: Allow discrepancy of staves amount, to be limited by start/endStaff during cloning
+      // Code reuse: nearly identical to above cloneMeasure()
+
+      m->setNo(no());
+      m->setNoOffset(noOffset());
+      m->setIrregular(irregular());
+      m->_userStretch           = _userStretch;
+      m->_breakMultiMeasureRest = _breakMultiMeasureRest;
+      m->_playbackCount         = _playbackCount;
+
+      m->setTick(tick);
+      m->setLineBreak(lineBreak());
+      m->setPageBreak(pageBreak());
+      m->setSectionBreak(sectionBreak() ? new LayoutBreak(*sectionBreakElement()) : 0);
+
+      m->setHeader(header()); m->setTrailer(trailer());
+      TupletMap tupletMap;
+
+      auto fcr = scoreDest->selection().firstChordRest();
+      auto destStaffStart = fcr ? fcr->staffIdx() : 0;
+      int initTrack  = (startStaff * VOICES);
+      int limitTrack = (endStaff * VOICES);
+      int destTrack  = (destStaffStart * VOICES);
+
+      for (Segment* oseg = first(); oseg; oseg = oseg->next()) {
+            Segment* s = new Segment(m, oseg->segmentType(), oseg->rtick());
+            s->setEnabled(oseg->enabled()); s->setVisible(oseg->visible());
+            s->setHeader(oseg->header()); s->setTrailer(oseg->trailer());
+
+            m->_segments.push_back(s);
+            for (int track = initTrack; track < limitTrack; ++track) {
+                  int newTrack = track - initTrack + destTrack;
+                  Element* oe = oseg->element(track);
+                  for (Element* e : oseg->annotations()) {
+                        if (e->generated() || e->track() != track)
+                              continue;
+                        Element* ne = e->clone();
+                        ne->setTrack(newTrack);
+                        ne->setOffset(e->offset());
+                        ne->setScore(scoreDest);
+                        s->add(ne);
+                        }
+                  if (!oe)
+                        continue;
+                  Element* ne = oe->clone();
+                  ne->setTrack(newTrack);
+                  if (oe->isChordRest()) {
+                        ChordRest* ocr = toChordRest(oe);
+                        ChordRest* ncr = toChordRest(ne);
+                        Tuplet* ot     = ocr->tuplet();
+                        ncr->setTrack(newTrack);
+                        if (ot) {
+                              Tuplet* nt = tupletMap.findNew(ot);
+                              if (nt == 0) {
+                                    nt = new Tuplet(*ot);
+                                    nt->clear();
+                                    nt->setTrack(newTrack);
+                                    nt->setScore(scoreDest);
+                                    nt->setParent(m);
+                                    nt->setTick(m->tick() + ot->rtick());
+                                    tupletMap.add(ot, nt);
+                                    }
+                              ncr->setTuplet(nt);
+                              nt->add(ncr);
+                              }
+                        if (oe->isChord()) {
+                              Chord* och = toChord(ocr);
+                              Chord* nch = toChord(ncr);
+                              nch->setTrack(newTrack);
+                              size_t n = och->notes().size();
+                              for (size_t i = 0; i < n; ++i) {
+                                    Note* on = och->notes().at(i);
+                                    Note* nn = nch->notes().at(i);
+                                    if (on->tieFor()) {
+                                          Tie* tie = on->tieFor()->clone();
+                                          tie->setScore(scoreDest);
+                                          tie->setTrack(newTrack);
+                                          nn->setTieFor(tie);
+                                          tie->setStartNote(nn);
+                                          tieMap->add(on->tieFor(), tie);
+                                          }
+                                    if (on->tieBack()) {
+                                          Tie* tie = tieMap->findNew(on->tieBack());
+                                          if (tie) {
+                                                tie->setTrack(nch->track());
+                                                nn->setTieBack(tie);
+                                                tie->setEndNote(nn);
+                                                }
+                                          else {
+                                                qDebug("cloneMeasure: cannot find tie, track %d", newTrack);
+                                                }
+                                          }
+                                    }
+                              }
+                        }
+                  ne->setOffset(oe->offset());
+                  ne->setScore(scoreDest);
+                  s->add(ne);
+                  }
+            }
+      for (Element* e : el()) {
+            Element* ne = e->clone();
+            ne->setScore(scoreDest);
             ne->setOffset(e->offset());
             m->add(ne);
             }

--- a/libmscore/measure.h
+++ b/libmscore/measure.h
@@ -101,6 +101,7 @@ class Measure final : public MeasureBase {
       ElementType type() const override { return ElementType::MEASURE; }
       void setScore(Score* s) override;
       Measure* cloneMeasure(Score*, const Fraction& tick, TieMap*);
+      Measure* cloneMeasureLimited(Score*, const Fraction& tick, TieMap*, int startStaff, int endStaff);
 
       void read(XmlReader&, int idx);
       void read(XmlReader& d) override { read(d, 0); }

--- a/libmscore/measurebase.cpp
+++ b/libmscore/measurebase.cpp
@@ -155,7 +155,9 @@ void MeasureBase::add(Element* e)
             if (next())
                   next()->triggerLayout();
             }
-      triggerLayout();
+      // Observation: Cloning a MeasureBase has an issue with triggerlayout here,
+      // Will keep comment in case there's a problem later to refer back here
+      // triggerLayout()
       _el.push_back(e);
       }
 

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -644,6 +644,9 @@ class Score : public QObject, public ScoreElement {
       bool trKeys, bool transposeChordNames, bool useDoubleSharpsFlats);
 
       bool appendMeasuresFromScore(Score* score, const Fraction& startTick, const Fraction& endTick);
+
+      MeasureBase* insertMeasuresFromScore (Score* scoreSource, const Selection& selectionSource, MeasureBase& mbInsert);
+
       bool appendScore(Score*, bool addPageBreak = false, bool addSectionBreak = true);
 
       void write(XmlWriter&, bool onlySelection);

--- a/libmscore/segment.cpp
+++ b/libmscore/segment.cpp
@@ -641,6 +641,8 @@ void Segment::remove(Element* el)
       {
 // qDebug("%p Segment::remove %s %p", this, el->name(), el);
 
+      if (!el) return;
+
       int track = el->track();
 
       switch(el->type()) {

--- a/libmscore/textframe.cpp
+++ b/libmscore/textframe.cpp
@@ -43,6 +43,7 @@ TBox::TBox(const TBox& tbox)
    : VBox(tbox)
       {
       _text = new Text(*(tbox._text));
+      _text->setParent(this);
       }
 
 TBox::~TBox()
@@ -59,7 +60,8 @@ TBox::~TBox()
 void TBox::layout()
       {
       setPos(QPointF());      // !?
-      bbox().setRect(0.0, 0.0, system()->width(), 0);
+      auto w = system() ? system()->width() : 0;
+      bbox().setRect(0.0, 0.0, w, 0);
       _text->layout();
 
       qreal h = _text->height();
@@ -80,7 +82,7 @@ void TBox::layout()
 #endif
       _text->setPos(leftMargin() * DPMM, y);
       h += topMargin() * DPMM + bottomMargin() * DPMM;
-      bbox().setRect(0.0, 0.0, system()->width(), h);
+      bbox().setRect(0.0, 0.0, w, h);
 
       MeasureBase::layout();  // layout LayoutBreak's
       }

--- a/mscore/dragdrop.cpp
+++ b/mscore/dragdrop.cpp
@@ -334,8 +334,9 @@ void ScoreView::dragMoveEvent(QDragMoveEvent* event)
       QPointF pos(imatrix.map(QPointF(event->pos())));
       editData.pos       = pos;
       editData.modifiers = event->keyboardModifiers();
+      auto dropType = editData.dropElement->type();
 
-      switch (editData.dropElement->type()) {
+      switch (dropType) {
             case ElementType::VOLTA:
                   event->setAccepted(dragMeasureAnchorElement(pos));
                   break;
@@ -394,6 +395,9 @@ void ScoreView::dragMoveEvent(QDragMoveEvent* event)
             case ElementType::LYRICS:
             case ElementType::FRET_DIAGRAM:
             case ElementType::STAFFTYPE_CHANGE:
+            case ElementType::VBOX:
+            case ElementType::TBOX:
+            case ElementType::HBOX:
                   event->setAccepted(getDropTarget(editData));
                   break;
             default:
@@ -496,6 +500,7 @@ void ScoreView::dropEvent(QDropEvent* event)
                         break;
                   case ElementType::HBOX:
                   case ElementType::VBOX:
+                  case ElementType::TBOX:
                   case ElementType::KEYSIG:
                   case ElementType::CLEF:
                   case ElementType::TIMESIG:

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -4239,6 +4239,7 @@ void MuseScore::clipboardChanged()
 
       bool flag = true;
       getAction("paste")->setEnabled(flag);
+      getAction("paste-clone")->setEnabled(flag);
       getAction("swap")->setEnabled(flag);
       }
 

--- a/mscore/musescore.h
+++ b/mscore/musescore.h
@@ -113,6 +113,7 @@ struct PaletteTree;
 class PaletteWidget;
 class PaletteWorkspace;
 class QmlDockWidget;
+class Selection;
 
 struct PluginDescription;
 enum class SelState : char;
@@ -203,6 +204,8 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
       QSettings settings;
       ScoreView* cv                        { 0 };
       ScoreTab* ctab                       { 0 };
+      Score* copiedFromScore               { 0 };
+      Selection copiedSelection;
       QMap<MasterScore*, bool> scoreWasShown; // whether each score in scoreList has ever been shown
       ScoreState _sstate;
       UpdateChecker* ucheck;
@@ -678,6 +681,11 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
       void changeState(ScoreState);
       void updateInputState(Score*);
       void updateShadowNote();
+
+      Score* getLastScoreCopiedFrom(void)       { return copiedFromScore;}
+      void setLastScoreCopiedFrom(Score* s)     { copiedFromScore = s;   }
+      Selection& getLastScoreSelection(void)    { return copiedSelection;}
+      void setLastScoreSelection(Selection& s)  { copiedSelection = s;   }
 
       bool readLanguages(const QString& path);
       void setRevision(QString& r)  {rev = r;}

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -303,6 +303,7 @@ void ScoreView::objectPopup(const QPoint& pos, Element* obj)
       popup->addAction(getAction("cut"));
       popup->addAction(getAction("copy"));
       popup->addAction(getAction("paste"));
+      popup->addAction(getAction("paste-clone"));
       popup->addAction(getAction("swap"));
       popup->addAction(getAction("delete"));
       if (obj->isNote() || obj->isRest()) {
@@ -339,7 +340,7 @@ void ScoreView::objectPopup(const QPoint& pos, Element* obj)
       if (a == 0)
             return;
       const QByteArray& cmd(a->data().toByteArray());
-      if (cmd == "cut" || cmd =="copy" || cmd == "paste" || cmd == "swap"
+      if (cmd == "cut" || cmd =="copy" || cmd == "paste" || cmd == "paste-clone" || cmd == "swap"
          || cmd == "delete" || cmd == "time-delete") {
             // these actions are already activated
             return;
@@ -427,6 +428,7 @@ void ScoreView::measurePopup(QContextMenuEvent* ev, Measure* obj)
       popup->addAction(getAction("cut"));
       popup->addAction(getAction("copy"));
       popup->addAction(getAction("paste"));
+      popup->addAction(getAction("paste-clone"));
       popup->addAction(getAction("swap"));
       popup->addAction(getAction("delete"));
       popup->addAction(getAction("time-delete"));
@@ -1926,6 +1928,9 @@ void ScoreView::normalCopy()
       {
       if (!checkCopyOrCut())
             return;
+
+      mscore->setLastScoreSelection(_score->selection());
+
       QString mimeType = _score->selection().mimeType();
       if (!mimeType.isEmpty()) {
             QMimeData* mimeData = new QMimeData;
@@ -1944,6 +1949,9 @@ void ScoreView::normalCut()
       {
       if (!checkCopyOrCut())
             return;
+
+      mscore->setLastScoreSelection(_score->selection());
+
       _score->startCmd();
       normalCopy();
       _score->cmdDeleteSelection();
@@ -2032,9 +2040,91 @@ void ScoreView::normalSwap()
 bool ScoreView::normalPaste(Fraction scale)
       {
       _score->startCmd();
+
+      // Also allow for H/V/T boxes to be copied with their contents and be pasted (back inserted)
+      auto srcSelection = mscore->getLastScoreSelection();
+      auto srcScore = srcSelection.score();
+      MeasureBase* insertionMeasureBase = nullptr;
+      if (auto e = _score->selection().element()) {
+            if (auto mb = e->findMeasureBase()) {
+                  insertionMeasureBase = mb;
+                  }
+            }
+      else if (auto seg = _score->selection().startSegment()) {
+            if (auto mb = seg->findMeasureBase()) {
+                  insertionMeasureBase = mb;
+                  }
+            }
+      if (insertionMeasureBase) {
+            if (auto oe = srcSelection.element()) {
+                  if (oe->isBox() && !oe->isFBox()) {
+                        // Allow normal paste to insert clone of V/H/T boxes
+                        _score->insertMeasuresFromScore(srcScore, srcSelection, *insertionMeasureBase);
+                        _score->endCmd();
+                        return MScore::_error == MS_NO_ERROR;
+                        }
+                  }
+            }
+
       const QMimeData* ms = QApplication::clipboard()->mimeData();
       _score->cmdPaste(ms, this, scale);
       bool rv = MScore::_error == MS_NO_ERROR;
+      _score->endCmd();
+      return rv;
+      }
+
+//---------------------------------------------------------
+//   clonePaste
+//---------------------------------------------------------
+
+bool ScoreView::clonePaste()
+      {
+      MeasureBase* mbFirstInsertion = nullptr;
+      auto currentStaff = _score->selection().staffStart();
+      _score->startCmd();
+
+      auto srcScore = mscore->getLastScoreSelection().score();
+      auto copiedSel = mscore->getLastScoreSelection();
+      if (!copiedSel.isRange() && !copiedSel.isSingle()) {
+            QMessageBox::warning(0, "MuseScore",
+                   tr("A valid range or single selection required for measure position."));
+            return false;
+            }
+      if (!srcScore) {
+            QMessageBox::warning(0, "MuseScore",
+                                 tr("Invalid source score."));
+            return false;
+            }
+
+      MeasureBase* insertionMeasureBase = nullptr;
+      bool rv;
+
+      if (auto e = _score->selection().element()) {
+            if (auto mb = e->findMeasureBase()) {
+                  insertionMeasureBase = mb;
+                  }
+            }
+      else if (auto seg = _score->selection().startSegment()) {
+            if (auto mb = seg->findMeasureBase()) {
+                  insertionMeasureBase = mb;
+                  }
+            }
+      if (insertionMeasureBase) {
+            mbFirstInsertion = _score->insertMeasuresFromScore(srcScore, copiedSel, *insertionMeasureBase);
+            rv = MScore::_error == MS_NO_ERROR;
+            }
+      else rv = MScore::_error == NO_DEST;
+
+      // Circumvent spanners not cloning node offsets by a work-around regular pasting after clone....
+      if (mbFirstInsertion) {
+            if (auto mFirstInsertion = mbFirstInsertion->findMeasure()) {
+                  _score->select(mFirstInsertion, SelectType::RANGE, currentStaff);
+                  const QMimeData* ms = QApplication::clipboard()->mimeData();
+                  _score->cmdPaste(ms, this);
+                  rv = MScore::_error == MS_NO_ERROR;
+                  }
+            }
+
       _score->endCmd();
       return rv;
       }
@@ -2191,6 +2281,9 @@ void ScoreView::cmd(const char* s)
                         cv->normalPaste();
                   else if (cv->state == ViewState::EDIT)
                         cv->editPaste();
+                  }},
+            {{"paste-clone"}, [](ScoreView* cv, const QByteArray&) {
+                  cv->clonePaste();
                   }},
             {{"paste-half"}, [](ScoreView* cv, const QByteArray&) {
                   cv->normalPaste(Fraction(1, 2));
@@ -4329,7 +4422,7 @@ void ScoreView::cmdChangeEnharmonic(bool both)
 
 void ScoreView::cloneElement(Element* e)
       {
-      if (e->isMeasure() || e->isNote() || e->isVBox())
+      if (e->isMeasure() || e->isNote())
             return;
       QDrag* drag = new QDrag(this);
       QMimeData* mimeData = new QMimeData;

--- a/mscore/scoreview.h
+++ b/mscore/scoreview.h
@@ -362,6 +362,7 @@ class ScoreView : public QWidget, public MuseScoreView {
       void normalCopy();
       void fotoModeCopy(bool includeLink = false);
       bool normalPaste(Fraction scale = Fraction(1, 1));
+      bool clonePaste();
       void normalSwap();
 
       void setControlCursorVisible(bool v);

--- a/mscore/shortcut.cpp
+++ b/mscore/shortcut.cpp
@@ -207,6 +207,16 @@ Shortcut Shortcut::_sc[] = {
       {
          MsWidget::SCORE_TAB,
          STATE_NORMAL,
+         "paste-clone",
+         QT_TRANSLATE_NOOP("action","Paste (Clone)"),
+         0,
+         0,
+         Icons::paste_ICON,
+         Qt::ApplicationShortcut
+         },
+      {
+         MsWidget::SCORE_TAB,
+         STATE_NORMAL,
          "paste-half",
          QT_TRANSLATE_NOOP("action","Paste Half Duration"),
          QT_TRANSLATE_NOOP("action","Paste half duration"),


### PR DESCRIPTION
…click score menu

Frames work with regular copy paste (as insertion, not appending) [Keysig/Timesig/Clef] Copied before performing
[Score to score]
V/H/T Boxes to allow copy-drag to clone. Also work as regular copy/paste since they didn't do anything beforehand

Resolves/relates:  #638

Probably will want to link this to the .org forums to get some 3.7 users to test it out and give feedback or find undesirable behavior or crashes so I can work them out further. 

Once again:
Cloning occurs before selection as an insert
Shift+Ctrl+Drag allows cloning frames, even text frames.
Some "undesirable" behavior is inevitable because clefs can be from a measure "before" the range selection, and things of that sort, but I tried to keep it within a reasonable default. 