### PR TITLE
Fix #368929: Crash on playback with hidden staves and 'superfluous' voltas

### DIFF
--- a/libmscore/measurebase.cpp
+++ b/libmscore/measurebase.cpp
@@ -10,19 +10,18 @@
 //  the file LICENCE.GPL
 //=============================================================================
 
-#include "measurebase.h"
+#include "layoutbreak.h"
 #include "measure.h"
+#include "measurebase.h"
+#include "note.h"
 #include "staff.h"
 #include "score.h"
-#include "chord.h"
-#include "note.h"
-#include "layoutbreak.h"
-#include "image.h"
 #include "segment.h"
+#include "staff.h"
+#include "stafftypechange.h"
+#include "system.h"
 #include "tempo.h"
 #include "xml.h"
-#include "system.h"
-#include "stafftypechange.h"
 
 namespace Ms {
 
@@ -204,13 +203,13 @@ void MeasureBase::remove(Element* el)
 
 Measure* MeasureBase::nextMeasure() const
       {
-      MeasureBase* m = _next;
-      for (;;) {
-            if (m == 0 || m->isMeasure())
-                  break;
-            m = m->_next;
+      MeasureBase* m = next();
+      while (m) {
+            if (m->isMeasure())
+                  return toMeasure(m);
+            m = m->next();
             }
-      return toMeasure(m);
+      return nullptr;
       }
 
 //---------------------------------------------------------
@@ -237,7 +236,7 @@ Measure* MeasureBase::prevMeasure() const
                   return toMeasure(m);
             m = m->prev();
             }
-      return 0;
+      return nullptr;
       }
 
 //---------------------------------------------------------
@@ -331,7 +330,7 @@ void MeasureBase::layout()
 MeasureBase* MeasureBase::top() const
       {
       const MeasureBase* mb = this;
-      while (mb->parent()) {
+      while (mb && mb->parent()) {
             if (mb->parent()->isMeasureBase())
                   mb = toMeasureBase(mb->parent());
             else

--- a/libmscore/repeat.cpp
+++ b/libmscore/repeat.cpp
@@ -10,13 +10,11 @@
 //  the file LICENCE.GPL
 //=============================================================================
 
-#include "repeat.h"
-#include "sym.h"
-#include "score.h"
-#include "system.h"
 #include "measure.h"
-#include "mscore.h"
+#include "repeat.h"
+#include "score.h"
 #include "staff.h"
+#include "system.h"
 
 namespace Ms {
 


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/368929
Resolves: [musescore#24802](https://www.github.com/musescore/MuseScore/issues/24802)

Not exactly sure what the deal is here, but the crash does happen while processing voltas, and the score does have them for both visible staves, and is also having some invisible staves (without voltas).
Just making the invisible staves visible fixes the crash, just removing the 'superfluous' voltas does not.