### PR TITLE
Fix GH#24763: In note input mode, add clef / time / key before cursor

### DIFF
--- a/mscore/palette.cpp
+++ b/mscore/palette.cpp
@@ -610,6 +610,15 @@ bool Palette::applyPaletteElement(Element* element, Qt::KeyboardModifiers modifi
                   score->cmdAddSpanner(spanner, cr1->staffIdx(), startSegment, endSegment);
                   spanner->isVoiceSpecific();
                   }
+            else if ((element->isClef() || element->isTimeSig() || element->isKeySig()) && score->noteEntryMode()) {
+                  // in note input mode place clef / time sig / key sig before cursor
+                  Element* e = score->inputState().cr();
+                  if (!e)
+                        e = sel.elements().front();
+                  else if (e->isChord())
+                        e = toChord(e)->notes().front();
+                  applyDrop(score, viewer, e, element, modifiers);
+                  }
             else {
                   for (Element* e : sel.elements())
                         applyDrop(score, viewer, e, element, modifiers);


### PR DESCRIPTION
Backport of #24811

Resolves: [musescore#24763](https://www.github.com/musescore/MuseScore/issues/24763)