### PR TITLE
Fix Cubase XML chord symbol import

### DIFF
--- a/importexport/musicxml/importmxmlpass2.cpp
+++ b/importexport/musicxml/importmxmlpass2.cpp
@@ -6873,7 +6873,8 @@ void MusicXMLParserPass2::harmony(const QString& partId, Measure* measure, const
                         else if (_e.name() == "root-alter") {
                               // attributes: print-object
                               //             location (left-right)
-                              alter = _e.readElementText().toInt();
+                              // Cubase exports this value with a trailing newline
+                              alter = _e.readElementText().simplified().toInt();
                               }
                         else
                               skipLogCurrElem();


### PR DESCRIPTION
Backport of #24915

Resolves: [musescore#24865](https://www.github.com/musescore/MuseScore/issues/24865)