### PR TITLE
Fix GH#24026: Ensure correct key signature accidentals after clef change

### DIFF
--- a/libmscore/keysig.cpp
+++ b/libmscore/keysig.cpp
@@ -10,13 +10,13 @@
 //  the file LICENCE.GPL
 //=============================================================================
 
-#include "sym.h"
-#include "staff.h"
 #include "clef.h"
 #include "keysig.h"
 #include "measure.h"
-#include "segment.h"
 #include "score.h"
+#include "segment.h"
+#include "staff.h"
+#include "sym.h"
 #include "system.h"
 #include "undo.h"
 #include "xml.h"
@@ -112,7 +112,7 @@ void KeySig::layout()
             Clef* c = nullptr;
             if (segment()) {
                   for (Segment* seg = segment()->prev1(); !c && seg && seg->tick() == tick(); seg = seg->prev1())
-                        if (seg->isClefType() || seg->isHeaderClefType())
+                        if (seg->enabled() && (seg->isClefType() || seg->isHeaderClefType()))
                               c = toClef(seg->element(track()));
                   }
             if (c)


### PR DESCRIPTION
Backport of #24522

Resolves: [musescore#24026](https://www.github.com/musescore/MuseScore/issues/24026) which actually isn't an issue with 3.x at all. But the change doesn't seem to harm either