### PR TITLE
Fix Cubase XML chord symbol import

### DIFF
--- a/importexport/musicxml/importmxmlpass2.cpp
+++ b/importexport/musicxml/importmxmlpass2.cpp
@@ -3032,7 +3032,7 @@ void MusicXMLParserPass2::staffTuning(StringData* t)
       int octave = 0;
       while (_e.readNextStartElement()) {
             if (_e.name() == "tuning-alter")
-                  alter = _e.readElementText().toInt();
+                  alter = _e.readElementText().trimmed().toInt();
             else if (_e.name() == "tuning-octave")
                   octave = _e.readElementText().toInt();
             else if (_e.name() == "tuning-step") {
@@ -5273,7 +5273,7 @@ void MusicXMLParserPass2::key(const QString& partId, Measure* measure, const Fra
                   keyStep = _e.readElementText();
                   }
             else if (_e.name() == "key-alter")
-                  keyAlter = _e.readElementText();
+                  keyAlter = _e.readElementText().trimmed();
             else if (_e.name() == "key-accidental") {
                   smufl = _e.attributes().value("smufl").toString();
                   keyAccidental = _e.readElementText();
@@ -6873,8 +6873,7 @@ void MusicXMLParserPass2::harmony(const QString& partId, Measure* measure, const
                         else if (_e.name() == "root-alter") {
                               // attributes: print-object
                               //             location (left-right)
-                              // Cubase exports this value with a trailing newline
-                              alter = _e.readElementText().simplified().toInt();
+                              alter = _e.readElementText().trimmed().toInt();
                               }
                         else
                               skipLogCurrElem();
@@ -6918,7 +6917,7 @@ void MusicXMLParserPass2::harmony(const QString& partId, Measure* measure, const
                         else if (_e.name() == "bass-alter") {
                               // attributes: print-object
                               //             location (left-right)
-                              alter = _e.readElementText().toInt();
+                              alter = _e.readElementText().trimmed().toInt();
                               }
                         else
                               skipLogCurrElem();
@@ -6934,7 +6933,7 @@ void MusicXMLParserPass2::harmony(const QString& partId, Measure* measure, const
                               degreeValue = _e.readElementText().toInt();
                               }
                         else if (_e.name() == "degree-alter") {
-                              degreeAlter = _e.readElementText().toInt();
+                              degreeAlter = _e.readElementText().trimmed().toInt();
                               }
                         else if (_e.name() == "degree-type") {
                               degreeType = _e.readElementText();


### PR DESCRIPTION
Follow up to #637, `bass-alter` needs the same treatment as `root-alter`
'Backport' of #24967 (actually this one here existed first)

Resolves: [musescore#24865](https://www.github.com/musescore/MuseScore/issues/24865) and https://musescore.org/en/node/368990#comment-1260723