### PR TITLE
Fix: Regression from #605 and also allow for [prev measure/system] in…

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -2370,8 +2370,8 @@ Element* Score::move(const QString& cmd)
             cr = selection().cr();
             if (cr && (cr->isGrace() || cmd == "next-chord" || cmd == "prev-chord"))
                   ;
-            else
-                  cr = inputState().cr();
+            else cr = inputState().cr() ? inputState().cr() : cr;
+
             }
       else if (selection().activeCR())
             cr = selection().activeCR();
@@ -2512,8 +2512,9 @@ Element* Score::move(const QString& cmd)
             // selection "cursor"
             // find previous chordrest, which might be a grace note
             // this may override note input cursor
-            el = noteEntryPos ? el : prevChordRest(cr);
-
+            if (auto pcr = prevChordRest(cr)) {
+                  el = (noteEntryPos && !pcr->isGrace()) ? el : pcr;
+                  }
             // Skip gap rests if we're not in note entry mode...
             while (!noteEntryMode() && el && el->isRest() && toRest(el)->isGap())
                   el = prevChordRest(toChordRest(el));


### PR DESCRIPTION
… note-entry even when input state has no ChordRest

Resolves: #604 regression and enabling previous measure/previous system when input track doesn't contain a correspondent chordrest

That should do it. Unfortunately that means your "up-port" (is that the word?) would also need to be updated 

Verification: 

1) Traversal through grace notes is verified:

[1.webm](https://github.com/user-attachments/assets/f0dce062-d9dd-45ae-a742-772e52f12678)


2) Reason for issue is verified:

[2.webm](https://github.com/user-attachments/assets/c5b292f0-63a7-4acf-86b2-dcf8e3c8f8a7)


3) Update: allow previous measure and previous system (switches to voice one, but initially wasn't working at all when in that input state of not having any existing chordrest in 3.6.2 etc):

[3.webm](https://github.com/user-attachments/assets/22065f80-5db9-49bd-8289-4ff7ee31d638)


