### PR TITLE
Fix GH#23063: (import) MusicXML alter element not exported 

### DIFF
--- a/importexport/musicxml/exportxml.cpp
+++ b/importexport/musicxml/exportxml.cpp
@@ -3824,27 +3824,22 @@ static void writePitch(XmlWriter& xml, const Note* const note, const bool useDru
       xml.tag(useDrumset  ? "display-step" : "step", step);
       // Check for microtonal accidentals and overwrite "alter" tag
       const Accidental* acc = note->accidental();
-      double alter2 = 0.0;
+      double microtonalAlter  = 0.0;
       if (acc) {
             switch (acc->accidentalType()) {
-                  case AccidentalType::MIRRORED_FLAT:  alter2 = -0.5; break;
-                  case AccidentalType::SHARP_SLASH:    alter2 = 0.5;  break;
-                  case AccidentalType::MIRRORED_FLAT2: alter2 = -1.5; break;
-                  case AccidentalType::SHARP_SLASH4:   alter2 = 1.5;  break;
-                  default:                                             break;
+                  case AccidentalType::MIRRORED_FLAT:  microtonalAlter  = -0.5; break;
+                  case AccidentalType::SHARP_SLASH:    microtonalAlter  =  0.5; break;
+                  case AccidentalType::MIRRORED_FLAT2: microtonalAlter  = -1.5; break;
+                  case AccidentalType::SHARP_SLASH4:   microtonalAlter  =  1.5; break;
+                  default:                                                      break;
                   }
             }
       // Override accidental with explicit note tuning
       qreal tuning = note->tuning();
-      if (fabs(tuning) > 0.01)
-            alter2 = tuning / 100.0;
-      // `alter` represents the "regular" (Western) pitch which can be
-      // 0 (natural), 1 (sharp), -1 (flat), etc. or some other integer depending on transposing instruments.
-      // `alter2` represents a microtone or manually-adjusted note tuning.
-      // In MusicXML, These two values are merged in the same "alter" tag.
-      // https://usermanuals.musicxml.com/MusicXML/Content/EL-MusicXML-alter.htm
-      if (alter || alter2)
-            xml.tag("alter", alter + alter2);
+      if (!qFuzzyIsNull(tuning))
+            microtonalAlter  = tuning / 100.0;
+      if (alter || microtonalAlter )
+            xml.tag("alter", alter + microtonalAlter );
       xml.tag(useDrumset ? "display-octave" : "octave", octave);
       xml.etag();
       }

--- a/importexport/musicxml/importmxmlnotepitch.cpp
+++ b/importexport/musicxml/importmxmlnotepitch.cpp
@@ -109,6 +109,7 @@ void mxmlNotePitch::pitch(QXmlStreamReader& e)
       // defaults
       _step = -1;
       _alter = 0;
+      _tuning = 0.0;
       _octave = -1;
 
       while (e.readNextStartElement()) {
@@ -123,6 +124,10 @@ void mxmlNotePitch::pitch(QXmlStreamReader& e)
                         if (ok2 && (qAbs(altervalue) < 2.0) && (_accType == AccidentalType::NONE)) {
                               // try to see if a microtonal accidental is needed
                               _accType = microtonalGuess(altervalue);
+
+                              // If it's not a microtonal accidental we will use tuning
+                              if (_accType == AccidentalType::NONE)
+                                    _tuning = 100 * altervalue;
                               }
                         _alter = 0;
                         }

--- a/importexport/musicxml/importmxmlnotepitch.h
+++ b/importexport/musicxml/importmxmlnotepitch.h
@@ -37,6 +37,7 @@ public:
       Accidental* acc() const { return _acc; }
       AccidentalType accType() const { return _accType; }
       int alter() const { return _alter; }
+      qreal tuning() const { return _tuning; }
       int displayOctave() const { return _displayOctave; }
       int displayStep() const { return _displayStep; }
       void displayStepOctave(QXmlStreamReader& e);
@@ -48,6 +49,7 @@ private:
       Accidental* _acc = 0;                                 // created based on accidental element
       AccidentalType _accType = AccidentalType::NONE;       // set by pitch() based on alter value (can be microtonal)
       int _alter = 0;
+      qreal _tuning = 0.0;
       int _displayStep = -1;                                // invalid
       int _displayOctave = -1;                              // invalid
       int _octave = -1;

--- a/importexport/musicxml/importmxmlpass2.cpp
+++ b/importexport/musicxml/importmxmlpass2.cpp
@@ -234,7 +234,7 @@ static int MusicXMLStepAltOct2Pitch(int step, int alter, int octave)
  Note that n's staff and track have not been set yet
  */
 
-static void xmlSetPitch(Note* n, int step, int alter, int octave, const int octaveShift, const Instrument* const instr, Interval inferredTranspose = Interval(0))
+static void xmlSetPitch(Note* n, int step, int alter, qreal tuning, int octave, const int octaveShift, const Instrument* const instr, Interval inferredTranspose = Interval(0))
       {
       //qDebug("xmlSetPitch(n=%p, step=%d, alter=%d, octave=%d, octaveShift=%d)",
       //       n, step, alter, octave, octaveShift);
@@ -258,6 +258,7 @@ static void xmlSetPitch(Note* n, int step, int alter, int octave, const int octa
       tpc2 = Ms::transposeTpc(tpc2, inferredTranspose, true);
       int tpc1 = Ms::transposeTpc(tpc2, combinedIntval, true);
       n->setPitch(pitch, tpc1, tpc2);
+      n->setTuning(tuning);
       //qDebug("  pitch=%d tpc1=%d tpc2=%d", n->pitch(), n->tpc1(), n->tpc2());
       }
 
@@ -5946,11 +5947,11 @@ static void setPitch(Note* note, MusicXMLParserPass1& pass1, const QString& part
                   }
             else {
                   //qDebug("disp step %d oct %d", displayStep, displayOctave);
-                  xmlSetPitch(note, mnp.displayStep(), 0, mnp.displayOctave(), 0, instrument);
+                  xmlSetPitch(note, mnp.displayStep(), 0, 0.0, mnp.displayOctave(), 0, instrument);
                   }
             }
       else {
-            xmlSetPitch(note, mnp.step(), mnp.alter(), mnp.octave(), octaveShift, instrument, pass1.getMusicXmlPart(partId)._inferredTranspose);
+            xmlSetPitch(note, mnp.step(), mnp.alter(), mnp.tuning(), mnp.octave(), octaveShift, instrument, pass1.getMusicXmlPart(partId)._inferredTranspose);
             }
       }
 


### PR DESCRIPTION
Resolves: [musescore#23063](https://www.github.com/musescore/MuseScore/issues/23063), the import part (export is in 3.7 since May 2022)