### PR TITLE
Make sure Shift does not get removed from any letter key and ignore Ctrl+Alt on a few more keys

### DIFF
--- a/mscore/shortcutcapturedialog.cpp
+++ b/mscore/shortcutcapturedialog.cpp
@@ -114,7 +114,7 @@ void ShortcutCaptureDialog::keyPress(QKeyEvent* e)
 
       k |= e->modifiers();
       // remove shift-modifier for non-letter keys, except a few keys
-      if ((k & Qt::ShiftModifier) && !isShiftAllowed(e->key())) {
+      if ((k & Qt::ShiftModifier) && !isShiftAllowed(e->key(), e->text())) {
             qDebug() << k;
             k &= ~Qt::ShiftModifier;
             qDebug() << k;
@@ -190,15 +190,14 @@ void ShortcutCaptureDialog::keyPress(QKeyEvent* e)
             );
       }
 
-bool ShortcutCaptureDialog::isShiftAllowed(int k)
+bool ShortcutCaptureDialog::isShiftAllowed(int key, const QString& keyStr)
       {
-      // Letter keys where Shift should not be removed
-      if (k >= Qt::Key_A && k <= Qt::Key_Z) {
+      // letter keys where Shift should not be removed
+      if (keyStr.size() == 1 && keyStr.at(0).isLetter())
             return true;
-            }
 
       // non-letter keys where Shift should not be removed
-      switch (k) {
+      switch (key) {
             case Qt::Key_Up:
             case Qt::Key_Down:
             case Qt::Key_Left:

--- a/mscore/shortcutcapturedialog.cpp
+++ b/mscore/shortcutcapturedialog.cpp
@@ -120,6 +120,13 @@ void ShortcutCaptureDialog::keyPress(QKeyEvent* e)
             qDebug() << k;
             }
 
+      // remove Ctrl+Alt modifiers from a few keys
+      if ((k & (Qt::ControlModifier | Qt::AltModifier)) && !isCtrlAltNeeded(e->key(), e->text())) { // Qt::KeyAltGr, right Alt
+            qDebug() << k;
+            k &= ~(Qt::ControlModifier | Qt::AltModifier);
+            qDebug() << k;
+            }
+
       switch(key.count()) {
             case 0: key = QKeySequence(k); break;
             case 1: key = QKeySequence(key[0], k); break;
@@ -248,6 +255,30 @@ bool ShortcutCaptureDialog::isShiftAllowed(int key, const QString& keyStr)
                   return true;
             default:
                   return false;
+            }
+      }
+
+bool ShortcutCaptureDialog::isCtrlAltNeeded(int key, const QString& keyStr) {
+      // key that needs AltGR (here esp. on German keyboards), but should not in shortuts
+      if (keyStr.size() == 1 && (keyStr.at(0) == QChar(u'€')))
+            return false;
+
+      // (non-letter) keys that need AltGR (here esp. for German keyboards), but should not in shortuts
+      switch (key) {
+            case Qt::Key_twosuperior:   // default action: voice 2
+            case Qt::Key_threesuperior: // default action: voice 3
+            case Qt::Key_BraceLeft:     // default action: reduce strech
+            case Qt::Key_BracketLeft:
+            case Qt::Key_BracketRight:
+            case Qt::Key_BraceRight:    // default action: increase stretch
+            case Qt::Key_Backslash:
+            case Qt::Key_At:
+            //case Qt::Key_Euro:          // doesn't exist, but see above
+            case Qt::Key_AsciiTilde:
+            case Qt::Key_Bar:
+                  return false;
+            default:
+                  return true;
             }
       }
 

--- a/mscore/shortcutcapturedialog.h
+++ b/mscore/shortcutcapturedialog.h
@@ -42,7 +42,7 @@ class ShortcutCaptureDialog : public QDialog, public Ui::ShortcutCaptureDialogBa
       Shortcut* s;
       void keyPress(QKeyEvent* e);
       bool isShiftAllowed(int key, const QString& keyStr);
-      bool isCtrlAltNeeded(int key);
+      bool isCtrlAltNeeded(int key, const QString& keyStr);
       virtual bool eventFilter(QObject* o, QEvent* e);
       QKeySequence key;
       QMap<QString, Shortcut*> localShortcuts;

--- a/mscore/shortcutcapturedialog.h
+++ b/mscore/shortcutcapturedialog.h
@@ -41,7 +41,8 @@ class ShortcutCaptureDialog : public QDialog, public Ui::ShortcutCaptureDialogBa
 
       Shortcut* s;
       void keyPress(QKeyEvent* e);
-      bool isShiftAllowed(int key);
+      bool isShiftAllowed(int key, const QString& keyStr);
+      bool isCtrlAltNeeded(int key);
       virtual bool eventFilter(QObject* o, QEvent* e);
       QKeySequence key;
       QMap<QString, Shortcut*> localShortcuts;


### PR DESCRIPTION
There are more letters than just A-Z, e.g. Ä, Ö, Ü on a German keyboard and quite a few others on other keyboards, so treat those as letters too, with and without Shift, when it comes to using them for shortcuts. Idea stolen from #25141.
On some keyboards Ctrl+Alt or AltGr is needed to get to certain characters, lile e.g. {, [, ], }, \ on a German keyboard, so ignore that in keyboard shortcuts, in oder to treat them the same regardless of keyboard layout.