### PR TITLE
Enforce volta anchor on all scores

### DIFF
--- a/libmscore/read206.cpp
+++ b/libmscore/read206.cpp
@@ -1757,7 +1757,7 @@ bool readChordRestProperties206(XmlReader& e, ChordRest* ch)
                   ch->add(el);
             }
       else if (tag == "leadingSpace" || tag == "trailingSpace") {
-            qDebug("ChordRest: %s obsolete", tag.toLocal8Bit().data());
+            qDebug("ChordRest: %s obsolete", tag.toLocal8Bit().constData());
             e.skipCurrentElement();
             }
       else if (tag == "Beam") {
@@ -1818,12 +1818,12 @@ bool readChordRestProperties206(XmlReader& e, ChordRest* ch)
                         if (spanner->type() == ElementType::SLUR)
                               spanner->setStartElement(ch);
                         if (e.pasteMode()) {
-                              for (ScoreElement* el : spanner->linkList()) {
+                              for (ScoreElement*& el : spanner->linkList()) {
                                     if (el == spanner)
                                           continue;
                                     Spanner* ls = static_cast<Spanner*>(el);
                                     ls->setTick(spanner->tick());
-                                    for (ScoreElement* ee : ch->linkList()) {
+                                    for (ScoreElement*& ee : ch->linkList()) {
                                           ChordRest* cr = toChordRest(ee);
                                           if (cr->score() == ee->score() && cr->staffIdx() == ls->staffIdx()) {
                                                 ls->setTrack(cr->track());
@@ -1844,12 +1844,12 @@ bool readChordRestProperties206(XmlReader& e, ChordRest* ch)
                         if (start)
                               spanner->setTrack(start->track());
                         if (e.pasteMode()) {
-                              for (ScoreElement* el : spanner->linkList()) {
+                              for (ScoreElement*& el : spanner->linkList()) {
                                     if (el == spanner)
                                           continue;
                                     Spanner* ls = static_cast<Spanner*>(el);
                                     ls->setTick2(spanner->tick2());
-                                    for (ScoreElement* ee : ch->linkList()) {
+                                    for (ScoreElement*& ee : ch->linkList()) {
                                           ChordRest* cr = toChordRest(ee);
                                           if (cr->score() == ee->score() && cr->staffIdx() == ls->staffIdx()) {
                                                 ls->setTrack2(cr->track());
@@ -2020,7 +2020,7 @@ bool readChordProperties206(XmlReader& e, Chord* ch)
 static void convertDoubleArticulations(Chord* chord, XmlReader& e)
       {
       std::vector<Articulation*> pairableArticulations;
-      for (Articulation* a : chord->articulations()) {
+      for (Articulation*& a : chord->articulations()) {
             if (a->isStaccato() || a->isTenuto()
                || a->isAccent() || a->isMarcato()) {
                   pairableArticulations.push_back(a);
@@ -2212,6 +2212,11 @@ static void readVolta206(XmlReader& e, Volta* volta)
                   }
             else if (!readTextLineProperties(e, volta))
                   e.unknown();
+            }
+      if (volta->anchor() != Volta::VOLTA_ANCHOR) {
+            // Volta strictly assumes that its anchor is measure, so don't let old scores override this.
+            qWarning("Correcting volta anchor type from %d to %d", int(volta->anchor()), int(Volta::VOLTA_ANCHOR));
+            volta->setAnchor(Volta::VOLTA_ANCHOR);
             }
       adjustPlacement(volta);
       }
@@ -3403,7 +3408,7 @@ static void readStyle(MStyle* style, XmlReader& e)
                   style->chordList()->clear();
                   style->chordList()->read(e);
                   style->setCustomChordList(true);
-                  for (ChordFont f : style->chordList()->fonts) {
+                  for (ChordFont& f : style->chordList()->fonts) {
                         if (f.family == "MuseJazz") {
                               f.family = "MuseJazz Text";
                               }
@@ -3704,7 +3709,7 @@ static bool readScore(Score* score, XmlReader& e)
 #endif
       score->fixTicks();
 
-      for (Part* p : score->parts()) {
+      for (Part*& p : score->parts()) {
             p->updateHarmonyChannels(false);
             }
 
@@ -3815,10 +3820,10 @@ Score::FileError MasterScore::read206(XmlReader& e)
       setEnableVerticalSpread(false);
 
       int id = 1;
-      for (LinkedElements* le : e.linkIds())
+      for (LinkedElements*& le : e.linkIds())
             le->setLid(this, id++);
 
-      for (Staff* s : staves())
+      for (Staff*& s : staves())
             s->updateOttava();
 
       // fix segment span
@@ -3858,7 +3863,7 @@ Score::FileError MasterScore::read206(XmlReader& e)
       // fix positions
       //    offset = saved offset - layout position
       doLayout();
-      for (auto i : e.fixOffsets()) {
+      for (auto& i : e.fixOffsets()) {
             i.first->setOffset(i.second - i.first->pos());
             }
 

--- a/libmscore/spanner.cpp
+++ b/libmscore/spanner.cpp
@@ -720,7 +720,7 @@ Note* Spanner::startElementFromSpanner(Spanner* sp, Element* newEnd)
       int   newTrack    = (newEnd->track() - oldEnd->track()) + oldStart->track();
       // look in notes linked to oldStart for a note with the
       // same score as new score and appropriate track
-      for (ScoreElement* newEl : oldStart->linkList())
+      for (ScoreElement*& newEl : oldStart->linkList())
             if (toNote(newEl)->score() == score && toNote(newEl)->track() == newTrack) {
                   newStart = toNote(newEl);
                   break;
@@ -753,7 +753,7 @@ Note* Spanner::endElementFromSpanner(Spanner* sp, Element* newStart)
       int   newTrack    = newStart->track() + (oldEnd->track() - oldStart->track());
       // look in notes linked to oldEnd for a note with the
       // same score as new score and appropriate track
-      for (ScoreElement* newEl : oldEnd->linkList())
+      for (ScoreElement*& newEl : oldEnd->linkList())
             if (toNote(newEl)->score() == score && toNote(newEl)->track() == newTrack) {
                   newEnd = toNote(newEl);
                   break;
@@ -872,6 +872,7 @@ Measure* Spanner::startMeasure() const
 
 Measure* Spanner::endMeasure() const
       {
+      Q_ASSERT(anchor() == Spanner::Anchor::MEASURE);
       return toMeasure(_endElement);
       }
 

--- a/libmscore/volta.cpp
+++ b/libmscore/volta.cpp
@@ -19,7 +19,6 @@
 #include "style.h"
 #include "system.h"
 #include "tempo.h"
-#include "text.h"
 #include "xml.h"
 
 #include <algorithm>
@@ -142,7 +141,11 @@ void Volta::read(XmlReader& e)
             const QStringRef& tag(e.name());
             if (tag == "endings") {
                   QString s = e.readElementText();
+#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
+                  QStringList sl = s.split(",", Qt::SkipEmptyParts);
+#else
                   QStringList sl = s.split(",", QString::SkipEmptyParts);
+#endif
                   _endings.clear();
                   for (const QString& l : qAsConst(sl)) {
                         int i = l.simplified().toInt();
@@ -153,6 +156,11 @@ void Volta::read(XmlReader& e)
                   ;
             else if (!readProperties(e))
                   e.unknown();
+            }
+      if (this->anchor() != Volta::VOLTA_ANCHOR) {
+            // Volta strictly assumes that its anchor is measure, so don't let old scores override this.
+            qWarning("Correcting volta anchor type from %d to %d", int(this->anchor()), int(Volta::VOLTA_ANCHOR));
+            this->setAnchor(Volta::VOLTA_ANCHOR);
             }
       }
 

--- a/libmscore/volta.h
+++ b/libmscore/volta.h
@@ -49,9 +49,9 @@ class VoltaSegment final : public TextLineBaseSegment {
 
 class Volta final : public TextLineBase {
       QList<int> _endings;
-      static constexpr Anchor VOLTA_ANCHOR = Anchor::MEASURE;
 
    public:
+      static constexpr Anchor VOLTA_ANCHOR = Anchor::MEASURE;
       enum class Type : char {
             OPEN, CLOSED
             };


### PR DESCRIPTION
Backport of #25031

Also fix most clazy warnings

Resolves: [musescore#25031](https://www.github.com/musescore/MuseScore/issues/25031), which may not be a Mu3 issue at all, but doesn't seem to harm either