### PR TITLE
Fix #GH9975: Place rosette stars appropriately

### DIFF
--- a/libmscore/pedal.cpp
+++ b/libmscore/pedal.cpp
@@ -223,8 +223,8 @@ QPointF Pedal::linePos(Grip grip, System** sys) const
       else {
             Element* e = endElement();
             ChordRest* c = toChordRest(endElement());
-            if (!e || e == startElement() || (endHookType() == HookType::HOOK_90)) {
-                  // pedal marking on single note or ends with non-angled hook:
+            if (!e || e == startElement() || (endHookType() != HookType::HOOK_45)) {
+                  // pedal marking on single note or ends with non-angled hook or line not visible (rosette star):
                   // extend to next note or end of measure
                   Segment* seg = nullptr;
                   if (!e)

--- a/libmscore/textlinebase.cpp
+++ b/libmscore/textlinebase.cpp
@@ -400,6 +400,9 @@ void TextLineBaseSegment::layout()
                         break;
                   }
             _endText->setPos(bbox().right(), 0);
+            //center end text for pedals (rosette star), prevents collision of rosette and "Ped" on following note
+            if (isPedalSegment() && !tl->lineVisible())
+                  _endText->mutldata()->moveX(-_endText->width() / 2);
             bbox() |= _endText->bbox().translated(_endText->pos());
             }
 


### PR DESCRIPTION
Backport of #20954

Resolves: [musescore#9975](https://www.github.com/musescore/MuseScore/issues/9975)
