### PR TITLE
Fix GH#12970: Crash due to too big custom Time Signature

### DIFF
--- a/mscore/timedialog.cpp
+++ b/mscore/timedialog.cpp
@@ -17,14 +17,12 @@
 //  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 //=============================================================================
 
-#include "timedialog.h"
-#include "libmscore/timesig.h"
-#include "palette.h"
 #include "musescore.h"
-#include "libmscore/score.h"
+#include "palette.h"
+#include "timedialog.h"
 #include "libmscore/mcursor.h"
-#include "libmscore/chord.h"
-#include "libmscore/part.h"
+#include "libmscore/score.h"
+#include "libmscore/timesig.h"
 
 namespace Ms {
 
@@ -48,13 +46,13 @@ TimeDialog::TimeDialog(QWidget* parent)
       sp->setReadOnly(false);
       sp->setSelectable(true);
 
-      connect(zNominal,  SIGNAL(valueChanged(int)), SLOT(zChanged(int)));
+      connect(zNominal,  SIGNAL(editingFinished()),        SLOT(zChanged()));
       connect(nNominal,  SIGNAL(currentIndexChanged(int)), SLOT(nChanged(int)));
-      connect(sp,        SIGNAL(boxClicked(int)),   SLOT(paletteChanged(int)));
-      connect(sp,        SIGNAL(changed()),         SLOT(setDirty()));
-      connect(addButton, SIGNAL(clicked()),         SLOT(addClicked()));
-      connect(zText,     SIGNAL(textChanged(const QString&)),    SLOT(textChanged()));
-      connect(nText,     SIGNAL(textChanged(const QString&)),    SLOT(textChanged()));
+      connect(sp,        SIGNAL(boxClicked(int)),          SLOT(paletteChanged(int)));
+      connect(sp,        SIGNAL(changed()),                SLOT(setDirty()));
+      connect(addButton, SIGNAL(clicked()),                SLOT(addClicked()));
+      connect(zText,     SIGNAL(textChanged(QString&)),    SLOT(textChanged()));
+      connect(nText,     SIGNAL(textChanged(QString&)),    SLOT(textChanged()));
 
       _timePalette = new PaletteScrollArea(sp);
       QSizePolicy policy(QSizePolicy::Expanding, QSizePolicy::Expanding);
@@ -125,10 +123,14 @@ void TimeDialog::save()
 //   zChanged
 //---------------------------------------------------------
 
-void TimeDialog::zChanged(int val)
+void TimeDialog::zChanged()
       {
-      Q_UNUSED(val);
-      Fraction sig(zNominal->value(), denominator());
+      int numerator = zNominal->value();
+      int denominator = this->denominator();
+
+      Fraction sig(numerator, denominator);
+
+      // Update beam groups view
       groups->setSig(sig, Groups::endings(sig), zText->text(), nText->text());
       }
 

--- a/mscore/timedialog.h
+++ b/mscore/timedialog.h
@@ -10,11 +10,9 @@
 //  the file LICENSE.GPL
 //=============================================================================
 
-#ifndef __TIMEDIALOG_H__
-#define __TIMEDIALOG_H__
+#pragma once
 
 #include "ui_timedialog.h"
-#include "libmscore/fraction.h"
 
 namespace Ms {
 
@@ -40,7 +38,7 @@ class TimeDialog : public QWidget, Ui::TimeDialogBase {
 
    private slots:
       void addClicked();
-      void zChanged(int);
+      void zChanged();
       void nChanged(int);
       void paletteChanged(int idx);
       void textChanged();
@@ -56,5 +54,3 @@ class TimeDialog : public QWidget, Ui::TimeDialogBase {
       void save();
       };
 }
-
-#endif

--- a/mscore/timedialog.ui
+++ b/mscore/timedialog.ui
@@ -76,7 +76,7 @@
               <number>1</number>
              </property>
              <property name="maximum">
-              <number>999999</number>
+              <number>999</number>
              </property>
              <property name="value">
               <number>4</number>


### PR DESCRIPTION
Backport of #25564 plus fixing clazy warnings

Resolves: [musescoe#12970](https://www.github.com/musescore/MuseScore/issues/12970)