### PR TITLE
Fix GH#23499: Remove extra treatment for tab pitch in MusicXML export

### DIFF
--- a/importexport/musicxml/exportxml.cpp
+++ b/importexport/musicxml/exportxml.cpp
@@ -1540,25 +1540,6 @@ static void midipitch2xml(int pitch, char& c, int& alter, int& octave)
       }
 
 //---------------------------------------------------------
-//   tabpitch2xml
-//---------------------------------------------------------
-
-static void tabpitch2xml(const int pitch, const int tpc, QString& s, int& alter, int& octave)
-      {
-      s      = tpc2stepName(tpc);
-      alter  = tpc2alterByKey(tpc, Key::C);
-      octave = (pitch - alter) / 12 - 1;
-      if (alter < -2 || 2 < alter)
-            qDebug("tabpitch2xml(pitch %d, tpc %d) problem:  step %s, alter %d, octave %d",
-                   pitch, tpc, qPrintable(s), alter, octave);
-      /*
-      else
-            qDebug("tabpitch2xml(pitch %d, tpc %d) step %s, alter %d, octave %d",
-                   pitch, tpc, qPrintable(s), alter, octave);
-       */
-      }
-
-//---------------------------------------------------------
 //   pitch2xml
 //---------------------------------------------------------
 
@@ -3818,18 +3799,10 @@ static void writePitch(XmlWriter& xml, const Note* const note, const bool useDru
       QString step;
       int alter = 0;
       int octave = 0;
-      const Chord* chord = note->chord();
-      if (chord->staff() && chord->staff()->isTabStaff(Fraction(0,1))) {
-            tabpitch2xml(note->pitch(), note->tpc(), step, alter, octave);
-            }
-      else {
-            if (!useDrumset) {
-                  pitch2xml(note, step, alter, octave);
-                  }
-            else {
-                  unpitch2xml(note, step, octave);
-                  }
-            }
+      if (!useDrumset)
+            pitch2xml(note, step, alter, octave);
+      else
+            unpitch2xml(note, step, octave);
       xml.stag(useDrumset ? "unpitched" : "pitch");
       xml.tag(useDrumset  ? "display-step" : "step", step);
       // Check for microtonal accidentals and overwrite "alter" tag


### PR DESCRIPTION
Backport of #25594

Resolves: [musescore#23499](https://wwwgithub.com/musescore/MuseScore/issues/23499)