### PR TITLE
Fix GH#25429: Disable the display of the key signature when changing transposing instruments if score is in concert pitch

### DIFF
--- a/libmscore/keysig.cpp
+++ b/libmscore/keysig.cpp
@@ -89,6 +89,10 @@ void KeySig::addLayout(SymId sym, qreal x, int line)
 
 void KeySig::layout()
       {
+      // We do not show keys if the key is for instrument change and we are in concert pitch mode
+      if (forInstrumentChange() && concertPitch())
+            return;
+
       qreal _spatium = spatium();
       setbbox(QRectF());
 
@@ -100,7 +104,6 @@ void KeySig::layout()
                   }
             return;
             }
-
       _sig.keySymbols().clear();
       if (staff() && !staff()->staffType(tick())->genKeysig())
             return;


### PR DESCRIPTION
Backport of #25601 (closed unmerged meanwhile)

Resolves: [musescore#25429](https://www.github.com/musescore/MuseScore/issues/25429)