### PR TITLE
Fix GH#25617: Prevent crash importing MusicXML file containing grace rest followed by tuple starting with rest

### DIFF
--- a/importexport/musicxml/importmxmlpass2.cpp
+++ b/importexport/musicxml/importmxmlpass2.cpp
@@ -6343,9 +6343,13 @@ Note* MusicXMLParserPass2::note(const QString& partId,
 
       // begin allocation
       if (rest) {
+            if (!grace) {
             const int track = msTrack + msVoice;
             cr = addRest(_score, measure, noteStartTime, track, msMove,
                          duration, dura);
+                  }
+            else
+                  qDebug("ignoring grace rest");
             }
       else {
             if (!grace) {


### PR DESCRIPTION
Backport of #25629

Resolves: [musescore#25617](https://www.github.com/musescore/MuseScore/issues/25617)
