### PR TITLE
Fix GH#261: Interfacing with musescore.com crashes program

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,14 +65,14 @@ if (MSVC)
 endif (MSVC)
 
 # We need this early, before FindQt5
-option(BUILD_WEBENGINE "Built in webengine support" ON)
+option(BUILD_WEBENGINE "Built in webengine support" OFF)
 
 if (BUILD_WEBENGINE)
-   if (MINGW)
+   if (MINGW OR MSVC)
       SET (USE_WEBENGINE 0)
-   else (MINGW)
+   else (MINGW OR MSVC)
       SET (USE_WEBENGINE 1)
-   endif(MINGW)
+   endif(MINGW OR MSVC)
 else (BUILD_WEBENGINE)
    SET (USE_WEBENGINE 0)
 endif (BUILD_WEBENGINE)

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ BUILD_JACK="ON"       # Override with "OFF" to disable.
 BUILD_ALSA="ON"       # Override with "OFF" to disable.
 BUILD_PORTAUDIO="ON"  # Override with "OFF" to disable.
 BUILD_PORTMIDI="ON"   # Override with "OFF" to disable.
-BUILD_WEBENGINE="ON"  # Override with "OFF" to disable.
+BUILD_WEBENGINE="OFF" # Override with "ON" to enable.
 USE_SYSTEM_FREETYPE="OFF" # Override with "ON" to enable. Requires freetype >= 2.5.2.
 COVERAGE="OFF"        # Override with "ON" to enable.
 DOWNLOAD_SOUNDFONT="ON"   # Override with "OFF" to disable latest soundfont download.

--- a/vtest/gen
+++ b/vtest/gen
@@ -49,7 +49,7 @@ else
        flag flag-straight ledger-lines-2 ledger-lines-3 frame frametext ottava bend-1 \
        barline-1 barline-2 text-barline-alignment instrument-1 instrument-names-1 symbol-1 \
        slurs-1 slurs-2 slurs-3 slurs-4 slurs-5 slurs-6 slurs-7 slurs-8 slurs-9 slurs-10 \
-       hairpins-1 pedal-1 line-1 line-2 line-3 line-4 line-5 line-6 line-7 line-colour line-dashed text-line-alignment gliss-1 gliss-2 gliss-3 \
+       hairpins-1 pedal-1 line-1 line-2 line-3 line-4 line-5 line-6 line-7 line-dashed text-line-alignment gliss-1 gliss-2 gliss-3 \
        chord-layout-1 chord-layout-2 chord-layout-3 chord-layout-4 chord-layout-5\
        chord-layout-6 chord-layout-7 chord-layout-8 chord-layout-9 chord-layout-10\
        chord-layout-11 chord-layout-12 chord-layout-13 chord-layout-14 chord-layout-15 chord-layout-16 chord-layout-17 chord-small\
@@ -67,7 +67,7 @@ else
        figured-bass-1\
        beams-1 beams-2 beams-3 beams-4 beams-5 beams-6 beams-7 beams-8 beams-9 beams-10\
        beams-11 beams-12 beams-13 beams-14 beams-15 beams-16 beams-17 beams-18 beams-19 beams-anacrusis brackets-2\
-       user-offset-1 user-offset-2 chord-space-1 chord-space-2 tablature-1 image-1\
+       user-offset-1 user-offset-2 chord-space-1 chord-space-2 image-1\
        lyrics-1 lyrics-2 lyrics-3 lyrics-4 lyrics-5 lyrics-6 lyrics-7 lyrics-8 lyrics-9\
        voice-1 voice-2 slash-1 slash-2\
        system-1 system-2 system-3 system-4 system-5 system-6 system-7 system-8 system-9 system-10 system-11\


### PR DESCRIPTION
by disabling WebEngine support.
It now uses the system's default browser instead.
Also resolves the issue with a blank dialog when using Save online, like seen with the Windows 32-bit builds as well as with the 3.6.2 Windows versions. 
No idea how the Mac and Linux version behave, feedback wanted...

Resolves: #261 (and #716)
