### PR TITLE
Fix path on Windows and Linux where SMuFL expects system fonts to be

### DIFF
--- a/libmscore/sym.h
+++ b/libmscore/sym.h
@@ -3159,11 +3159,11 @@ class ScoreFont {
       mutable QFont* font { 0 };
 
       static QVector<ScoreFont> _builtinScoreFonts;
-      static QVector<ScoreFont> _userScoreFonts;
-      static QVector<ScoreFont> _systemScoreFonts;
+      static QVector<ScoreFont> _privateScoreFonts;
+      static QVector<ScoreFont> _standardScoreFonts;
       static QVector<ScoreFont> _allScoreFonts;
       static std::array<uint, size_t(SymId::lastSym)+1> _mainSymCodeTable;
-      void load(bool system = false);
+      void load(bool standard = false);
       void computeMetrics(Sym* sym, int code);
 
    public:
@@ -3185,7 +3185,7 @@ class ScoreFont {
       QString fontPath() const { return _fontPath; }
 
       static void initScoreFonts();
-      static void scanUserFonts(const QString& path, bool system = false);
+      static void scanUserFonts(const QString& path, bool standard = false);
       static ScoreFont* fontFactory(QString);
       static ScoreFont* fallbackFont();
       static const char* fallbackTextFont();


### PR DESCRIPTION
esp. their \<metadata\>.json

See https://github.com/musescore/MuseScore/pull/25773#pullrequestreview-2487230846


Bring Mu3 into sync with upstream/master after the merge of #25773