### PR TITLE
Fix GH#25783: Write color only once for line spanners

### DIFF
--- a/libmscore/line.cpp
+++ b/libmscore/line.cpp
@@ -1226,7 +1226,6 @@ void SLine::writeProperties(XmlWriter& xml) const
             xml.tag("diagonal", _diagonal);
       writeProperty(xml, Pid::LINE_WIDTH);
       writeProperty(xml, Pid::LINE_STYLE);
-      writeProperty(xml, Pid::COLOR);
       writeProperty(xml, Pid::ANCHOR);
       writeProperty(xml, Pid::DASH_LINE_LEN);
       writeProperty(xml, Pid::DASH_GAP_LEN);

--- a/mtest/libmscore/spanners/linecolor01-ref.mscx
+++ b/mtest/libmscore/spanners/linecolor01-ref.mscx
@@ -98,7 +98,6 @@
               <endHookType>1</endHookType>
               <beginHookType>1</beginHookType>
               <color r="255" g="0" b="0" a="255"/>
-              <color r="255" g="0" b="0" a="255"/>
               <Segment>
                 <subtype>0</subtype>
                 <offset x="0" y="2.5"/>


### PR DESCRIPTION
Backport of #25789

Resolves: [musescore#25783](https://wwwgithub.com/musescore/MuseScore/issues/25783)