### PR TITLE
Fix crash when deleting last voice 2 rest in note input mode

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -2572,7 +2572,7 @@ void Score::cmdDeleteSelection()
       deselectAll();
       // make new selection if appropriate
       if (noteEntryMode()) {
-            if (!crsSelectedAfterDeletion.empty())
+            if (crsSelectedAfterDeletion[0])
                   _is.setSegment(crsSelectedAfterDeletion[0]->segment());
             else
                   crsSelectedAfterDeletion.push_back(_is.cr());


### PR DESCRIPTION
Resolves: #724

See https://musescore.org/en/node/372754 and https://github.com/Jojo-Schmitz/MuseScore/pull/328#issuecomment-2543031308