### PR TITLE
Fix GH#25891: do not write muted strings

### DIFF
--- a/importexport/musicxml/exportxml.cpp
+++ b/importexport/musicxml/exportxml.cpp
@@ -6054,6 +6054,11 @@ static void writeMusicXML(const FiguredBass* item, XmlWriter& xml, bool isOrigin
       QString stag = "figured-bass";
       if (item->hasParentheses())
             stag += " parentheses=\"yes\"";
+      if (item->placeAbove())
+            stag += " placement=\"above\"";
+      stag += color2xml(item);
+      if (!item->visible())
+            stag += " print-object=\"no\"";
       xml.stag(stag);
       for (FiguredBassItem* fbItem : item->items())
             writeMusicXML(fbItem, xml, isOriginalFigure, crEndTick, fbEndTick);

--- a/importexport/musicxml/importmxmlpass2.cpp
+++ b/importexport/musicxml/importmxmlpass2.cpp
@@ -6636,6 +6636,30 @@ void MusicXMLParserPass2::duration(Fraction& dura)
       //qDebug("duration %s valid %d", qPrintable(dura.print()), dura.isValid());
       }
 
+static FiguredBassItem::Modifier MusicXML2Modifier(const QString prefix)
+      {
+      if (prefix == "sharp")
+            return FiguredBassItem::Modifier::SHARP;
+      else if (prefix == "flat")
+            return FiguredBassItem::Modifier::FLAT;
+      else if (prefix == "natural")
+            return FiguredBassItem::Modifier::NATURAL;
+      else if (prefix == "double-sharp")
+            return FiguredBassItem::Modifier::DOUBLESHARP;
+      else if (prefix == "flat-flat")
+            return FiguredBassItem::Modifier::DOUBLEFLAT;
+      else if (prefix == "sharp-sharp")
+            return FiguredBassItem::Modifier::DOUBLESHARP;
+      else if (prefix == "cross")
+            return FiguredBassItem::Modifier::CROSS;
+      else if (prefix == "backslash")
+            return FiguredBassItem::Modifier::BACKSLASH;
+      else if (prefix == "slash")
+            return FiguredBassItem::Modifier::SLASH;
+      else
+            return FiguredBassItem::Modifier::NONE;
+      }
+
 //---------------------------------------------------------
 //   figure
 //---------------------------------------------------------
@@ -6676,9 +6700,9 @@ FiguredBassItem* MusicXMLParserPass2::figure(const int idx, const bool paren)
                         _logger->logError(QString("incorrect figure-number '%1'").arg(val), &_e);
                   }
             else if (_e.name() == "prefix")
-                  fgi->setPrefix(fgi->MusicXML2Modifier(_e.readElementText()));
+                  fgi->setPrefix(MusicXML2Modifier(_e.readElementText()));
             else if (_e.name() == "suffix")
-                  fgi->setSuffix(fgi->MusicXML2Modifier(_e.readElementText()));
+                  fgi->setSuffix(MusicXML2Modifier(_e.readElementText()));
             else
                   skipLogCurrElem();
             }

--- a/libmscore/figuredbass.h
+++ b/libmscore/figuredbass.h
@@ -13,7 +13,7 @@
 #ifndef __FIGUREDBASS_H__
 #define __FIGUREDBASS_H__
 
-#include "text.h"
+#include "textbase.h"
 
 namespace Ms {
 
@@ -139,8 +139,6 @@ class FiguredBassItem final : public Element {
       int               parsePrefixSuffix(QString& str, bool bPrefix);
 
       void              setDisplayText(const QString& s)    { _displayText = s;       }
-      // read / write MusicXML support
-      QString           Modifier2MusicXML(FiguredBassItem::Modifier prefix) const;
 
    public:
       FiguredBassItem(Score * s = 0, int line = 0);
@@ -148,8 +146,6 @@ class FiguredBassItem final : public Element {
       ~FiguredBassItem();
 
       FiguredBassItem &operator=(const FiguredBassItem&) = delete;
-
-      FiguredBassItem::Modifier MusicXML2Modifier(const QString prefix) const;
 
       // standard re-implemented virtual functions
       FiguredBassItem*  clone() const override  { return new FiguredBassItem(*this); }
@@ -159,8 +155,6 @@ class FiguredBassItem final : public Element {
       void              read(XmlReader&) override;
       void              write(XmlWriter& xml) const override;
 
-      // read / write MusicXML
-      void              writeMusicXML(XmlWriter& xml, bool isOriginalFigure, int crEndTick, int fbEndTick) const;
       bool              startsWithParenthesis() const;
 
       // specific API
@@ -230,14 +224,13 @@ struct FiguredBassFont {
 //---------------------------------------------------------
 
 class FiguredBass final : public TextBase {
-      std::vector<FiguredBassItem*> items;      // the individual lines of the F.B.
+      std::vector<FiguredBassItem*> _items;      // the individual lines of the F.B.
       QVector<qreal>    _lineLengths;           // lengths of duration indicator lines (in raster units)
       bool              _onNote;                // true if this element is on a staff note | false if it is betweee notes
       Fraction          _ticks;                 // the duration (used for cont. lines and for multiple F.B.
                                                 // under the same note)
       qreal             _printedLineLength;     // the length of lines actually printed (i.e. continuation lines)
       void              layoutLines();
-      bool              hasParentheses() const; // read / write MusicXML support
 
       Sid getPropertyStyle(Pid) const override;
 
@@ -267,29 +260,26 @@ class FiguredBass final : public TextBase {
       void      startEdit(EditData&) override;
       void      write(XmlWriter& xml) const override;
 
-      // read / write MusicXML
-      void              writeMusicXML(XmlWriter& xml, bool isOriginalFigure, int crEndTick, int fbEndTick, bool writeDuration, int divisions) const;
-
 //DEBUG
 //Q_INVOKABLE Ms::FiguredBassItem* addItem();
 
       // getters / setters / properties
 //      void qmlItemsAppend(QDeclarativeListProperty<FiguredBassItem> *list, FiguredBassItem * pItem)
 //                                                {     list->append(pItem);
-//                                                      items.append(&pItem);
+//                                                      _items.append(&pItem);
 //                                                }
 //      QDeclarativeListProperty<FiguredBassItem> qmlItems()
 //                                                {     QList<FiguredBassItem*> list;
-//                                                      foreach(FiguredBassItem item, items)
+//                                                      foreach(FiguredBassItem item, _items)
 //                                                            list.append(&item);
-//                                                      return QDeclarativeListProperty<FiguredBassItem>(this, &items, qmlItemsAppend);
+//                                                      return QDeclarativeListProperty<FiguredBassItem>(this, &_items, qmlItemsAppend);
 //                                                }
       qreal             lineLength(int idx) const     {   if(_lineLengths.size() > idx)
                                                             return _lineLengths.at(idx);
                                                           return 0;   }
       qreal             printedLineLength() const     { return _printedLineLength; }
       bool              onNote() const          { return _onNote; }
-      size_t            numOfItems() const      { return items.size(); }
+      size_t            numOfItems() const      { return _items.size(); }
       void              setOnNote(bool val)     { _onNote = val;  }
       Segment *         segment() const         { return (Segment*)(parent()); }
       Fraction          ticks() const           { return _ticks;  }
@@ -302,7 +292,9 @@ class FiguredBass final : public TextBase {
       bool      setProperty(Pid propertyId, const QVariant&) override;
       QVariant  propertyDefault(Pid) const override;
 
-      void appendItem(FiguredBassItem* item) {  items.push_back(item); }
+      void appendItem(FiguredBassItem* item) {  _items.push_back(item); }
+      const std::vector<FiguredBassItem*>& items() const { return _items; }
+      bool hasParentheses() const; // read / write MusicXML support
       };
 
 

--- a/libmscore/fret.cpp
+++ b/libmscore/fret.cpp
@@ -1291,13 +1291,13 @@ void FretDiagram::writeMusicXML(XmlWriter& xml) const
             xml.tag("first-fret", fretOffset() + 1);
 
       for (int i = 0; i < _strings; ++i) {
-            int mxmlString = _strings - i;
+            const int mxmlString = _strings - i;
 
             std::vector<int> bStarts;
             std::vector<int> bEnds;
             for (auto const& j : _barres) {
                   FretItem::Barre b = j.second;
-                  int fret = j.first;
+                  const int fret = j.first;
                   int mxmlFret = fret + fretOffset();
                   if (!b.exists())
                         continue;
@@ -1318,7 +1318,7 @@ void FretDiagram::writeMusicXML(XmlWriter& xml) const
             // Markers may exists alongside with dots
             // Write dots
             for (auto const& d : dot(i)) {
-                  if (!d.exists())
+                  if (!d.exists() || d.dtype == FretDotType::CROSS)
                         continue;
                   xml.stag("frame-note");
                   xml.tag("string", mxmlString);

--- a/libmscore/fret.h
+++ b/libmscore/fret.h
@@ -183,10 +183,6 @@ class FretDiagram final : public Element {
       QVector<QLineF> dragAnchorLines() const override;
       QPointF pagePos() const override;
 
-      // read / write MusicXML
-      void readMusicXML(XmlReader& de);
-      void writeMusicXML(XmlWriter& xml) const;
-
       int  strings() const    { return _strings; }
       int  frets()   const    { return _frets; }
       void setStrings(int n);


### PR DESCRIPTION
Backport of #25912

Resolves: [musescore#25891](https://www.github.com/musescore/MuseScore/issues/25891)

And a (partial) backport of d2285d8a to move MusicXML export of fretboard diagrams from fret.cpp and figured bass from figuredbass.cpp to exportxml.cpp and the import of figured bass from figuredbass.cpp to importmxmlpass2.cpp

Also doing a remainder from backporting #19132