### PR TITLE
Allow reversal of hook flags within Inspector: Chord

### DIFF
--- a/libmscore/chord.h
+++ b/libmscore/chord.h
@@ -58,6 +58,7 @@ class Chord final : public ChordRest {
 
       Stem*               _stem;
       Hook*               _hook;
+      bool                _hookIsReversed;
       StemSlash*          _stemSlash;    // for acciacatura
 
       Arpeggio*           _arpeggio;
@@ -230,6 +231,9 @@ class Chord final : public ChordRest {
       QString accessibleExtraInfo() const override;
 
       Note* firstGraceOrNote();
+
+      bool hookIsReversed () const  { return hook() ? _hookIsReversed : false; }
+      void setHookReversed(bool v)  { _hookIsReversed = v; }
 
       Shape shape() const override;
       };

--- a/libmscore/element.cpp
+++ b/libmscore/element.cpp
@@ -1533,6 +1533,11 @@ void Element::undoSetVisible(bool v)
 //   drawSymbol
 //---------------------------------------------------------
 
+void Element::drawSymbolReversed(SymId id, QPainter* p, const QPointF& o, qreal scale) const
+      {
+      score()->scoreFont()->drawReversed(id, p, magS() * scale, o);
+      }
+
 void Element::drawSymbol(SymId id, QPainter* p, const QPointF& o, qreal scale) const
       {
       score()->scoreFont()->draw(id, p, magS() * scale, o);

--- a/libmscore/element.h
+++ b/libmscore/element.h
@@ -476,6 +476,7 @@ class Element : public ScoreElement {
       bool custom(Pid) const;
       virtual bool isUserModified() const;
 
+      void drawSymbolReversed(SymId id, QPainter* p, const QPointF& o = QPointF(), qreal scale = 1.0) const;
       void drawSymbol(SymId id, QPainter* p, const QPointF& o = QPointF(), qreal scale = 1.0) const;
       void drawSymbol(SymId id, QPainter* p, const QPointF& o, int n) const;
       void drawSymbols(const std::vector<SymId>&, QPainter* p, const QPointF& o = QPointF(), qreal scale = 1.0) const;

--- a/libmscore/hook.cpp
+++ b/libmscore/hook.cpp
@@ -80,7 +80,15 @@ void Hook::draw(QPainter* painter) const
             return;
 
       painter->setPen(curColor());
-      drawSymbol(_sym, painter);
+
+      if (chord()->hookIsReversed()) {
+            qreal scale = 1.0;
+            qreal dx = chord()->hook()->width() + (1.5 * chord()->stem()->lineWidthMag());
+            QPointF offset = QPointF(-dx, 0.0);
+            drawSymbolReversed(_sym, painter, offset, scale);
+            }
+      else drawSymbol(_sym, painter);
+
       }
 
 }

--- a/libmscore/property.cpp
+++ b/libmscore/property.cpp
@@ -78,6 +78,7 @@ static constexpr PropertyMetaData propertyList[] = {
       { Pid::DIRECTION,               false, "direction",             P_TYPE::DIRECTION,           DUMMY_QT_TRANSLATE_NOOP("propertyName", "direction")        },
       { Pid::STEM_DIRECTION,          false, "StemDirection",         P_TYPE::DIRECTION,           DUMMY_QT_TRANSLATE_NOOP("propertyName", "stem direction")   },
       { Pid::NO_STEM,                 false, "noStem",                P_TYPE::INT,                 DUMMY_QT_TRANSLATE_NOOP("propertyName", "no stem")          },
+      { Pid::HOOK_REVERSED,           false, "hookReversed",          P_TYPE::BOOL,                DUMMY_QT_TRANSLATE_NOOP("propertyName", "reversed hook")    },
       { Pid::SLUR_DIRECTION,          false, "up",                    P_TYPE::DIRECTION,           DUMMY_QT_TRANSLATE_NOOP("propertyName", "up")               },
       { Pid::LEADING_SPACE,           false, "leadingSpace",          P_TYPE::SPATIUM,             DUMMY_QT_TRANSLATE_NOOP("propertyName", "leading space")    },
       { Pid::DISTRIBUTE,              false, "distribute",            P_TYPE::BOOL,                DUMMY_QT_TRANSLATE_NOOP("propertyName", "distributed")      },

--- a/libmscore/property.h
+++ b/libmscore/property.h
@@ -85,6 +85,7 @@ enum class Pid {
       DIRECTION,
       STEM_DIRECTION,
       NO_STEM,
+      HOOK_REVERSED,
       SLUR_DIRECTION,
       LEADING_SPACE,
       DISTRIBUTE,

--- a/libmscore/stem.cpp
+++ b/libmscore/stem.cpp
@@ -403,7 +403,7 @@ QPointF Stem::hookPos() const
       {
       QPointF p(pos() + line.p2());
 
-      qreal xoff = 0.5 * lineWidthMag();
+      qreal xoff = !chord()->hookIsReversed() ? 0.5 * lineWidthMag() : -chord()->hook()->width();
       p.rx() += xoff;
       return p;
       }

--- a/libmscore/sym.cpp
+++ b/libmscore/sym.cpp
@@ -6403,6 +6403,15 @@ void ScoreFont::draw(SymId id, QPainter* painter, const QSizeF& mag, const QPoin
       draw(id, painter, mag, pos, worldScale);
       }
 
+void ScoreFont::drawReversed(SymId id, QPainter* painter, qreal mag, const QPointF& pos) const
+      {
+      qreal worldScale = painter->worldTransform().m11();
+      painter->save();
+         painter->scale(-1.0, +1.0);
+         draw(id, painter, QSizeF(mag, mag), pos, worldScale);
+      painter->restore();
+      }
+
 void ScoreFont::draw(SymId id, QPainter* painter, qreal mag, const QPointF& pos, qreal worldScale) const
       {
       draw(id, painter, QSizeF(mag, mag), pos, worldScale);

--- a/libmscore/sym.h
+++ b/libmscore/sym.h
@@ -3195,6 +3195,8 @@ class ScoreFont {
       QString toString(SymId) const;
       QPixmap sym2pixmap(SymId, qreal) { return QPixmap(); }      // TODOxxxx
 
+      void drawReversed
+               (SymId id,                  QPainter*, qreal mag,         const QPointF& pos) const;
       void draw(SymId id,                  QPainter*, const QSizeF& mag, const QPointF& pos, qreal scale) const;
       void draw(SymId id,                  QPainter*, qreal mag,         const QPointF& pos, qreal scale) const;
       void draw(SymId id,                  QPainter*, qreal mag,         const QPointF& pos) const;

--- a/mscore/inspector/inspectorNote.cpp
+++ b/mscore/inspector/inspectorNote.cpp
@@ -112,6 +112,7 @@ InspectorNote::InspectorNote(QWidget* parent)
             { Pid::SMALL,          1, c.isSmall,       c.resetSmall         },
             { Pid::NO_STEM,        1, c.stemless,      c.resetStemless      },
             { Pid::STEM_DIRECTION, 1, c.stemDirection, c.resetStemDirection },
+            { Pid::HOOK_REVERSED,  1, c.reversedHook,  c.resetReversedHook  },
 
             { Pid::LEADING_SPACE,  2, s.leadingSpace,  s.resetLeadingSpace  },
             };

--- a/mscore/inspector/inspector_chord.ui
+++ b/mscore/inspector/inspector_chord.ui
@@ -76,66 +76,6 @@
       <property name="spacing">
        <number>3</number>
       </property>
-      <item row="3" column="1">
-       <widget class="QComboBox" name="stemDirection">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="accessibleName">
-         <string>Stem direction</string>
-        </property>
-        <item>
-         <property name="text">
-          <string>Auto</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Up</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Down</string>
-         </property>
-        </item>
-       </widget>
-      </item>
-      <item row="3" column="0">
-       <widget class="QLabel" name="label">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="text">
-         <string>Stem direction:</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-        </property>
-        <property name="buddy">
-         <cstring>stemDirection</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="2">
-       <widget class="Ms::ResetButton" name="resetStemless" native="true">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="accessibleName">
-         <string>Reset 'Stemless' value</string>
-        </property>
-       </widget>
-      </item>
       <item row="3" column="2">
        <widget class="Ms::ResetButton" name="resetStemDirection" native="true">
         <property name="sizePolicy">
@@ -148,6 +88,42 @@
          <string>Reset 'Stem direction' value</string>
         </property>
        </widget>
+      </item>
+      <item row="1" column="0" colspan="2">
+       <layout class="QHBoxLayout" name="horizontalLayout_2">
+        <item>
+         <widget class="QLabel" name="label_2">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>Offset:</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+          </property>
+          <property name="buddy">
+           <cstring>offset</cstring>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="Ms::OffsetSelect" name="offset" native="true">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="accessibleName">
+           <string>Offset</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </item>
       <item row="2" column="0" colspan="2">
        <layout class="QHBoxLayout" name="horizontalLayout">
@@ -205,6 +181,34 @@
         </item>
        </layout>
       </item>
+      <item row="3" column="1">
+       <widget class="QComboBox" name="stemDirection">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="accessibleName">
+         <string>Stem direction</string>
+        </property>
+        <item>
+         <property name="text">
+          <string>Auto</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Up</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Down</string>
+         </property>
+        </item>
+       </widget>
+      </item>
       <item row="1" column="2">
        <widget class="Ms::ResetButton" name="resetOffset" native="true">
         <property name="sizePolicy">
@@ -218,41 +222,47 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="0" colspan="2">
-       <layout class="QHBoxLayout" name="horizontalLayout_2">
-        <item>
-         <widget class="QLabel" name="label_2">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="text">
-           <string>Offset:</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-          </property>
-          <property name="buddy">
-           <cstring>offset</cstring>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="Ms::OffsetSelect" name="offset" native="true">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="accessibleName">
-           <string>Offset</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
+      <item row="2" column="2">
+       <widget class="Ms::ResetButton" name="resetStemless" native="true">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="accessibleName">
+         <string>Reset 'Stemless' value</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="label">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Stem direction:</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+        </property>
+        <property name="buddy">
+         <cstring>stemDirection</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0">
+       <widget class="QCheckBox" name="reversedHook">
+        <property name="text">
+         <string>Reversed hook</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="1">
+       <widget class="Ms::ResetButton" name="resetReversedHook" native="true"/>
       </item>
      </layout>
     </widget>

--- a/mscore/plugin/api/elements.h
+++ b/mscore/plugin/api/elements.h
@@ -172,6 +172,7 @@ class Element : public Ms::PluginAPI::ScoreElement {
       API_PROPERTY( articulationAnchor,      ARTICULATION_ANCHOR       )
       API_PROPERTY( direction,               DIRECTION                 )
       API_PROPERTY( stemDirection,           STEM_DIRECTION            )
+      API_PROPERTY( hookReversed,            HOOK_REVERSED             )
       API_PROPERTY( noStem,                  NO_STEM                   )
       API_PROPERTY( slurDirection,           SLUR_DIRECTION            )
       API_PROPERTY( leadingSpace,            LEADING_SPACE             )


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/109706

Provides chord inspector checkbox to reverse hooks.
Didn't "hand-roll" the .ui changes but used Qt Creator so there may be some extra changes in there not absolutely necessary.

To test:
1) Select a note head
2) Make sure it's of the flag duration type 1/8th or lesser in value
3) Enable "reversed hook"

![image](https://github.com/user-attachments/assets/13afbce9-4f7e-4827-99a5-91528fa77fd4)

Kind of a gimmick, but so long as it doesn't hurt anything I suppose it might fulfill little niche use cases for some people.

Testing appreciated