### PR TITLE
Fix #320037: PortAudio Grayed out in Musescore 3.6.2, but working on 3.5.0

### DIFF
--- a/build/ci/macos/setup.sh
+++ b/build/ci/macos/setup.sh
@@ -7,83 +7,91 @@ SKIP_ERR_FLAG=true
 
 export MACOSX_DEPLOYMENT_TARGET=10.13
 
+curl -LO https://github.com/macports/macports-base/releases/download/v2.10.5/MacPorts-2.10.5-13-Ventura.pkg
+sudo installer -verbose -pkg MacPorts-2.10.5-13-Ventura.pkg -target /
+rm MacPorts-2.10.5-13-Ventura.pkg
+export PATH="/opt/local/bin:/opt/local/sbin:$PATH"
+echo -e "universal_target ${MACOSX_DEPLOYMENT_TARGET}\nmacosx_deployment_target ${MACOSX_DEPLOYMENT_TARGET}\nmacosx_sdk_version ${MACOSX_DEPLOYMENT_TARGET}" | sudo tee -a /opt/local/etc/macports/macports.conf
+sudo port install git pkgconfig cmake
+sudo port install libsndfile lame portaudio jack
+
 # install dependencies
-wget -c --no-check-certificate -nv -O bottles.zip https://musescore.org/sites/musescore.org/files/2020-02/bottles-MuseScore-3.0-yosemite.zip
-unzip bottles.zip
-
+#wget -c --no-check-certificate -nv -O bottles.zip https://musescore.org/sites/musescore.org/files/2020-02/bottles-MuseScore-3.0-yosemite.zip
+#unzip bottles.zip
+#
 # we don't use freetype
-rm bottles/freetype* | $SKIP_ERR_FLAG
-
-brew update >/dev/null | $SKIP_ERR_FLAG
-
+#rm bottles/freetype* | $SKIP_ERR_FLAG
+#
+#brew update >/dev/null | $SKIP_ERR_FLAG
+#
 # fixing install python 3.11 error (it is a dependency for JACK)
-rm '/usr/local/bin/2to3'
-rm '/usr/local/bin/2to3-3.11'
-rm '/usr/local/bin/idle3'
-rm '/usr/local/bin/idle3.11'
-rm '/usr/local/bin/pydoc3'
-rm '/usr/local/bin/pydoc3.11'
-rm '/usr/local/bin/python3'
-rm '/usr/local/bin/python3.11'
-rm '/usr/local/bin/python3-config'
-rm '/usr/local/bin/python3.11-config'
-
+#rm '/usr/local/bin/2to3'
+#rm '/usr/local/bin/2to3-3.11'
+#rm '/usr/local/bin/idle3'
+#rm '/usr/local/bin/idle3.11'
+#rm '/usr/local/bin/pydoc3'
+#rm '/usr/local/bin/pydoc3.11'
+#rm '/usr/local/bin/python3'
+#rm '/usr/local/bin/python3.11'
+#rm '/usr/local/bin/python3-config'
+#rm '/usr/local/bin/python3.11-config'
+#
 # additional dependencies
-brew install jack
-brew install lame
-
-BREW_CELLAR=$(brew --cellar)
-BREW_PREFIX=$(brew --prefix)
-
-function fixBrewPath {
-  DYLIB_FILE=$1
-  BREW_CELLAR=$(brew --cellar)
-  BREW_PREFIX=$(brew --prefix)
-  chmod 644 $DYLIB_FILE
-  # change ID
-  DYLIB_ID=$(otool -D  $DYLIB_FILE | tail -n 1)
-  if [[ "$DYLIB_ID" == *@@HOMEBREW_CELLAR@@* ]]
-  then
-      PSLASH=$(echo $DYLIB_ID | sed "s,@@HOMEBREW_CELLAR@@,$BREW_CELLAR,g")
-      install_name_tool -id $PSLASH $DYLIB_FILE
-  fi
-  if [[ "$DYLIB_ID" == *@@HOMEBREW_PREFIX@@* ]]
-  then
-      PSLASH=$(echo $DYLIB_ID | sed "s,@@HOMEBREW_PREFIX@@,$BREW_PREFIX,g")
-      install_name_tool -id $PSLASH $DYLIB_FILE
-  fi
-  # Change dependencies
-  for P in `otool -L $DYLIB_FILE | awk '{print $1}'`
-  do
-    if [[ "$P" == *@@HOMEBREW_CELLAR@@* ]]
-    then
-        PSLASH=$(echo $P | sed "s,@@HOMEBREW_CELLAR@@,$BREW_CELLAR,g")
-        install_name_tool -change $P $PSLASH $DYLIB_FILE
-    fi
-    if [[ "$P" == *@@HOMEBREW_PREFIX@@* ]]
-    then
-        PSLASH=$(echo $P | sed "s,@@HOMEBREW_PREFIX@@,$BREW_PREFIX,g")
-        install_name_tool -change $P $PSLASH $DYLIB_FILE
-    fi
-  done
-  chmod 444 $DYLIB_FILE
-}
-export -f fixBrewPath
-
-function installBottleManually {
-  brew unlink $1 2>/dev/null  # supress 'error' reg. "No such keg"
-  rm -rf /usr/local/Cellar/$1
-  tar xzvf bottles/$1*.tar.gz -C $BREW_CELLAR
-  find $BREW_CELLAR/$1 -type f -name '*.pc' -exec sed -i '' "s:@@HOMEBREW_CELLAR@@:$BREW_CELLAR:g" {} +
-  find $BREW_CELLAR/$1 -type f -name '*.dylib' -exec bash -c 'fixBrewPath "$1"' _ {} \;
-  brew link $1
-}
-
-installBottleManually libogg
-installBottleManually libvorbis
-installBottleManually flac
-installBottleManually libsndfile
-installBottleManually portaudio
+#brew install jack
+#brew install lame
+#
+#BREW_CELLAR=$(brew --cellar)
+#BREW_PREFIX=$(brew --prefix)
+#
+#function fixBrewPath {
+#  DYLIB_FILE=$1
+#  BREW_CELLAR=$(brew --cellar)
+#  BREW_PREFIX=$(brew --prefix)
+#  chmod 644 $DYLIB_FILE
+#  # change ID
+#  DYLIB_ID=$(otool -D  $DYLIB_FILE | tail -n 1)
+#  if [[ "$DYLIB_ID" == *@@HOMEBREW_CELLAR@@* ]]
+#  then
+#      PSLASH=$(echo $DYLIB_ID | sed "s,@@HOMEBREW_CELLAR@@,$BREW_CELLAR,g")
+#      install_name_tool -id $PSLASH $DYLIB_FILE
+#  fi
+#  if [[ "$DYLIB_ID" == *@@HOMEBREW_PREFIX@@* ]]
+#  then
+#      PSLASH=$(echo $DYLIB_ID | sed "s,@@HOMEBREW_PREFIX@@,$BREW_PREFIX,g")
+#      install_name_tool -id $PSLASH $DYLIB_FILE
+#  fi
+#  # Change dependencies
+#  for P in `otool -L $DYLIB_FILE | awk '{print $1}'`
+#  do
+#    if [[ "$P" == *@@HOMEBREW_CELLAR@@* ]]
+#    then
+#        PSLASH=$(echo $P | sed "s,@@HOMEBREW_CELLAR@@,$BREW_CELLAR,g")
+#        install_name_tool -change $P $PSLASH $DYLIB_FILE
+#    fi
+#    if [[ "$P" == *@@HOMEBREW_PREFIX@@* ]]
+#    then
+#        PSLASH=$(echo $P | sed "s,@@HOMEBREW_PREFIX@@,$BREW_PREFIX,g")
+#        install_name_tool -change $P $PSLASH $DYLIB_FILE
+#    fi
+#  done
+#  chmod 444 $DYLIB_FILE
+#}
+#export -f fixBrewPath
+#
+#function installBottleManually {
+#  brew unlink $1 2>/dev/null  # supress 'error' reg. "No such keg"
+#  rm -rf /usr/local/Cellar/$1
+#  tar xzvf bottles/$1*.tar.gz -C $BREW_CELLAR
+#  find $BREW_CELLAR/$1 -type f -name '*.pc' -exec sed -i '' "s:@@HOMEBREW_CELLAR@@:$BREW_CELLAR:g" {} +
+#  find $BREW_CELLAR/$1 -type f -name '*.dylib' -exec bash -c 'fixBrewPath "$1"' _ {} \;
+#  brew link $1
+#}
+#
+#installBottleManually libogg
+#installBottleManually libvorbis
+#installBottleManually flac
+#installBottleManually libsndfile
+#installBottleManually portaudio
 
 
 export QT_SHORT_VERSION=5.15.9


### PR DESCRIPTION
and GH# 227: MacOS - playback is greyed out because can't find audio device

by partly reverting 7f89edd, just with a) a newer version of the MacPorts and b) the Ventura (13) variant, being the one GitHub CI builds 3.7 on currently

Resolves: https://musescore.org/en/node/320037
Resolves: #227
