### PR TITLE
Fix a bunch of different issue connected to local time signatures

### DIFF
--- a/libmscore/check.cpp
+++ b/libmscore/check.cpp
@@ -10,16 +10,15 @@
 //  the file LICENCE.GPL
 //=============================================================================
 
-#include "score.h"
-#include "slur.h"
-#include "measure.h"
-#include "tuplet.h"
 #include "chordrest.h"
+#include "clef.h"
+#include "keysig.h"
+#include "measure.h"
 #include "rest.h"
+#include "score.h"
 #include "segment.h"
 #include "staff.h"
-#include "keysig.h"
-#include "clef.h"
+#include "tuplet.h"
 #include "utils.h"
 
 namespace Ms {
@@ -375,6 +374,8 @@ void Measure::checkMeasure(int staffIdx, bool useGapRests)
                   else if (currentPos > expectedPos) {
                         qDebug("in measure underrun %6d at %d-%d track %d", tick().ticks(), (currentPos/stretch).ticks(), (expectedPos/stretch).ticks(), track);
                         fillGap(expectedPos, currentPos - expectedPos, track, stretch);
+                        if (currentPos >= f)
+                              break;
                         }
 
                   DurationElement* de = cr;

--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -490,9 +490,10 @@ void Score::expandVoice(Segment* s, int track)
       //
       Measure* m = s->measure();
       Fraction stick  = ps ?  ps->tick() : m->tick();
+      Fraction stretch = staff(track2staff(track))->timeStretch(stick);
       Fraction ticks  = s->tick() - stick;
       if (ticks.isNotZero())
-            setRest(stick, track, ticks, false, 0);
+            setRest(stick, track, ticks * stretch, false, 0);
 
       //
       // fill from s->tick() until next chord/rest in measure
@@ -506,7 +507,7 @@ void Score::expandVoice(Segment* s, int track)
       if (ticks == m->ticks())
             addRest(s, track, TDuration(TDuration::DurationType::V_MEASURE), 0);
       else
-            setRest(s->tick(), track, ticks, false, 0);
+            setRest(s->tick(), track, ticks * stretch, false, 0);
       }
 
 void Score::expandVoice()

--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -713,6 +713,8 @@ bool Score::rewriteMeasures(Measure* fm, const Fraction& ns, int staffIdx)
             return true;
       Segment* s = nm->undoGetSegment(SegmentType::TimeSig, nm->tick());
       for (int i = 0; i < nstaves(); ++i) {
+            if (staffIdx != -1 && i != staffIdx)
+                  continue;
             if (!s->element(i * VOICES)) {
                   TimeSig* ots = staff(i)->timeSig(nm->tick());
                   if (ots) {

--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -605,21 +605,20 @@ bool Score::rewriteMeasures(Measure* fm, const Fraction& ns, int staffIdx)
       Measure* nm  = nullptr;
       LayoutBreak* sectionBreak = nullptr;
 
-      // disable local time sig modifications in linked staves
-      if (staffIdx != -1 && excerpts().size() > 0) {
-            MScore::setError(CANNOT_CHANGE_LOCAL_TIMESIG_HAS_EXCERPTS);
-            return false;
-            }
-
       //
       // split into Measure segments fm-lm
       //
+      auto foundLM = [fm, staffIdx](MeasureBase* curMeas, Measure* curLM) {
+            if (!curMeas || !curMeas->isMeasure() || curLM->sectionBreak())
+                  return true;
+            Segment* timeSigSeg = toMeasure(curMeas)->first(SegmentType::TimeSig);
+            if (timeSigSeg && curMeas != fm)
+                  return staffIdx == -1 || timeSigSeg->element(staff2track(staffIdx));
+             return false;
+            };
       for (MeasureBase* measure = fm; ; measure = measure->next()) {
 
-            if (!measure || !measure->isMeasure() || lm->sectionBreak()
-              || (toMeasure(measure)->first(SegmentType::TimeSig) && measure != fm))
-                  {
-
+            if (foundLM(measure, lm)){
                   // save section break to reinstate after rewrite
                   if (lm->sectionBreak())
                         sectionBreak = new LayoutBreak(*lm->sectionBreakElement());
@@ -774,10 +773,23 @@ void Score::cmdAddTimeSig(Measure* fm, int staffIdx, TimeSig* ts, bool local)
                         endStaffIdx   = startStaffIdx + 1;
                         }
                   else {
+#if 1
                         // TODO: get index for this score
                         qDebug("cmdAddTimeSig: unable to write local time signature change to linked score");
                         startStaffIdx = 0;
                         endStaffIdx   = 0;
+#else
+                        const Staff* thisStaff = staff(staffIdx);
+                        const Staff* linkedStaff = thisStaff->findLinkedInScore(score);
+                        if (linkedStaff) {
+                              startStaffIdx = linkedStaff->idx();
+                              endStaffIdx = startStaffIdx + 1;
+                              }
+                        else {
+                              startStaffIdx = 0;
+                              endStaffIdx = 0;
+                              }
+#endif
                         }
                   }
             else {
@@ -854,7 +866,9 @@ void Score::cmdAddTimeSig(Measure* fm, int staffIdx, TimeSig* ts, bool local)
             // we will only add time signatures if this succeeds
             // this means, however, that the rewrite cannot depend on the time signatures being in place
             if (mf) {
-                  if (!mScore->rewriteMeasures(mf, ns, local ? staffIdx : -1)) {
+                  auto staffIdxRangeOnMaster = getStaffIdxRange(mScore);
+                  if (staffIdxRangeOnMaster.second != staffIdxRangeOnMaster.first
+                      && !mScore->rewriteMeasures(mf, ns, local ? staffIdxRangeOnMaster.first : -1)) {
                         undoStack()->current()->unwind();
                         return;
                         }
@@ -909,11 +923,6 @@ void Score::cmdAddTimeSig(Measure* fm, int staffIdx, TimeSig* ts, bool local)
 
 void Score::cmdRemoveTimeSig(TimeSig* ts)
       {
-      if (ts->isLocal() && excerpts().size() > 0) {
-            MScore::setError(CANNOT_CHANGE_LOCAL_TIMESIG_HAS_EXCERPTS);
-            return;
-            }
-
       Measure* m = ts->measure();
       Segment* s = ts->segment();
 

--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -4555,11 +4555,16 @@ void Score::layoutSystemElements(System* system, LayoutContext& lc)
       // layout tuplets
       //-------------------------------------------------------------
 
+      std::map<int, Fraction> skipTo;
       for (Segment* s : sl) {
             for (Element* e : s->elist()) {
                   if (!e || !e->isChordRest() || !score()->staff(e->staffIdx())->show())
                         continue;
+                  int track = e->track();
+                  if (skipTo.count(track) && e->tick() < skipTo[track])
+                        continue; // don't lay out tuplets for this voice that have already been done
                   ChordRest* cr = toChordRest(e);
+#if 0
                   if (!isTopTuplet(cr))
                         continue;
                   DurationElement* de = cr;
@@ -4568,6 +4573,19 @@ void Score::layoutSystemElements(System* system, LayoutContext& lc)
                         t->layout();
                         de = t;
                         }
+#else
+                  // find the top tuplet for this segment
+                  DurationElement* de = cr;
+                  if (!de->tuplet())
+                        continue;
+                  while (de->tuplet())
+                        de = de->tuplet();
+                  de->layout();
+#endif
+
+                  // don't layout any tuplets covered by this top level tuplet for this voice--
+                  // they've already been laid out by Tuplet::layout().
+                  skipTo[track] = de->tick() + de->actualTicks();
                   }
             }
 


### PR DESCRIPTION
Backport of #26100, commits 2-5 (1 isn't needed, 6 might)

2. Resolves: [musescore#23411](https://www.github.com/musescore/MuseScore/issues/23411) (Does seem to fix a bug in Mu3 too)
3. Resolves: [musescore#18089](https://www.github.com/musescore/MuseScore/issues/18089) (Not yet, Mu3 is lacking `Staff* findLinkedInScore(Score*)`)
4. Resolves: [musescore#26001](https://www.github.com/musescore/MuseScore/issues/26001) (Seems not to be an issue with Mu3, may not harm though)
5. Resolves: [musescore#25110](https://www.github.com/musescore/MuseScore/issues/25110) (Seems not to be an issue with Mu3, on top the backport seems to be causeing issues with the mtests)