### PR TITLE
Fix add local time signatures in non-chronological order

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -713,6 +713,8 @@ bool Score::rewriteMeasures(Measure* fm, const Fraction& ns, int staffIdx)
             return true;
       Segment* s = nm->undoGetSegment(SegmentType::TimeSig, nm->tick());
       for (int i = 0; i < nstaves(); ++i) {
+            if (staffIdx != -1 && i != staffIdx)
+                  continue;
             if (!s->element(i * VOICES)) {
                   TimeSig* ots = staff(i)->timeSig(nm->tick());
                   if (ots) {


### PR DESCRIPTION
Resolves: [musescore#23411](https://www.github.com/musescore/MuseScore/issues/23411)

Backport of #26100, 2nd commit, the only one that seems to apply to or be needed for Mu3
