### PR TITLE
Fix GH#775: Crash due to missing/bad libvorbisfile.3.dynlib

### DIFF
--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -9,6 +9,11 @@ on:
     - cron: '0 4 */1 * *' # At 04:00 on every day-of-month
   workflow_dispatch:
     inputs:
+      platforms:
+        description: 'Platforms to build:'
+        default: 'macos_apple macos_intel'
+        type: string
+        required: true
       build_mode:
         description: 'Build mode: devel, nightly, testing, stable'
         default: 'devel'
@@ -19,6 +24,11 @@ on:
         required: false
   workflow_call:
     inputs:
+      platforms:
+        description: 'Platforms to build:'
+        default: 'macos_apple macos_intel'
+        type: string
+        required: true
       build_mode:
         description: 'Build mode: devel, nightly, testing, stable'
         default: 'devel'
@@ -34,7 +44,7 @@ env:
   DEVELOPER_DIR: /Applications/Xcode_15.2.app/Contents/Developer
 
 jobs:
-  macos:
+  macos_apple:
     runs-on: macos-13
     steps:
     - name: Cancel Previous Runs
@@ -78,7 +88,8 @@ jobs:
         if [ "${{ github.event_name }}" == "pull_request" ]; then
           ADD_INFO="_${{ github.event.pull_request.number }}_${pull_request_title}"
         fi
-        UPLOAD_ARTIFACT_NAME="$(tr '":<>|*?/\\’' '_' <<<"Mu3.7_${BUILD_NUMBER}_Mac${ADD_INFO}")"
+        BUILD_ARCH="Apple"
+        UPLOAD_ARTIFACT_NAME="$(tr '":<>|*?/\\’' '_' <<<"Mu3.7_${BUILD_NUMBER}_Mac${ADD_INFO}_${BUILD_ARCH}")"
 
         echo "github.repository: ${{ github.repository }}"
         echo "BUILD_MODE=$BUILD_MODE" | tee -a $GITHUB_ENV
@@ -94,7 +105,8 @@ jobs:
         sudo rm -rf "/Users/runner/Library/Android/sdk"
     - name: Setup environment
       run: |
-        bash ./build/ci/macos/setup.sh
+        BUILD_ARCH="Apple"
+        bash ./build/ci/macos/setup.sh --arch "$BUILD_ARCH"
     - name: Build
       run: |
         T_ID=${{ secrets.TELEMETRY_TRACK_ID }}; if [ -z "$T_ID" ]; then T_ID="''"; fi
@@ -104,7 +116,106 @@ jobs:
         S_S="${{ secrets.MAC_SIGN_CERTIFICATE_ENCRYPT_SECRET }}"; if [ -z "$S_S" ]; then S_S="''"; fi
         S_P="${{ secrets.MAC_SIGN_CERTIFICATE_PASSWORD }}"; if [ -z "$S_P" ]; then S_P="''"; fi
         S_D="${{ secrets.DEVELOPER_NAME }}"; if [ -z "$S_D" ]; then S_D="MuseScore"; fi
-        bash ./build/ci/macos/package.sh --signpass "$S_P" --signsecret "$S_S" --developer_name "$S_D"
+        BUILD_ARCH="Apple"
+        bash ./build/ci/macos/package.sh --signpass "$S_P" --signsecret "$S_S" --developer_name "$S_D"  --arch "$BUILD_ARCH"
+    - name: Notarize
+      if: env.DO_NOTARIZE == 'true'
+      run: |
+        USER=${{ secrets.APPLE_USERNAME }}; if [ -z "$USER" ]; then USER=""; fi
+        PW=${{ secrets.APPLE_PASSWORD }}; if [ -z "$PW" ]; then PW=""; fi
+        TID=${{ secrets.APPLE_TEAM_ID }}; if [ -z "$TID" ]; then TID=""; fi
+        bash ./build/ci/macos/notarize.sh -u $USER -p $PW -t $TID
+    - name: Checksum
+      run: |
+        bash ./build/ci/tools/checksum.sh
+    - name: AppCast
+      run: |
+        bash ./build/ci/tools/sparkle_appcast_gen.sh -p macos
+    - name: Publish to OSUOSL
+      if: env.DO_PUBLISH == 'true'
+      run: |
+        bash ./build/ci/tools/osuosl/publish.sh -s ${{ secrets.OSUOSL_SSH_ENCRYPT_SECRET }} --os macos -v 3
+    - name: Upload artifacts on GitHub
+      if: ${{ always() }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ env.UPLOAD_ARTIFACT_NAME }}
+        path: ./build.artifacts/
+
+  macos_intel:
+    runs-on: macos-13
+    steps:
+    - name: Cancel Previous Runs
+      uses: styfle/cancel-workflow-action@0.12.1
+      with:
+        access_token: ${{ github.token }}
+    - name: Clone repository
+      uses: actions/checkout@v4
+    - name: Configure workflow
+      env:
+        pull_request_title: ${{ github.event.pull_request.title }}
+      run: |
+        bash ./build/ci/tools/make_build_mode_env.sh -e ${{ github.event_name }} -m ${{ inputs.build_mode }}
+        BUILD_MODE=$(cat ./build.artifacts/env/build_mode.env)
+
+        bash ./build/ci/tools/make_build_number.sh
+        BUILD_NUMBER=$(cat ./build.artifacts/env/build_number.env)
+
+        DO_PUBLISH='false'
+        if [[ "${{ inputs.publish }}" == "on" || ("${{ github.event_name }}" == "schedule" && "$BUILD_MODE" == "nightly") ]]; then
+          DO_PUBLISH='true'
+          if [ -z "${{ secrets.OSUOSL_SSH_ENCRYPT_SECRET }}" ]; then
+            echo "::warning::OSUOSL_SSH_ENCRYPT_SECRET is empty; not publishing to OSUOSL"
+            DO_PUBLISH='false'
+          fi
+        fi
+
+        DO_NOTARIZE='false'
+        if [ "$BUILD_MODE" != "devel" ]; then
+          DO_NOTARIZE='true'
+          if [ -z "${{ secrets.APPLE_USERNAME }}" ]; then
+            echo "::warning::APPLE_USERNAME is empty; notarization disabled"
+            DO_NOTARIZE='false'
+          elif [ -z "${{ secrets.APPLE_PASSWORD }}" ]; then
+            echo "::warning::APPLE_PASSWORD is empty, notarization disabled"
+            DO_NOTARIZE='false'
+          fi
+        fi
+
+        ADD_INFO="_${GITHUB_REF#refs/heads/}"
+        if [ "${{ github.event_name }}" == "pull_request" ]; then
+          ADD_INFO="_${{ github.event.pull_request.number }}_${pull_request_title}"
+        fi
+        BUILD_ARCH="Intel"
+        UPLOAD_ARTIFACT_NAME="$(tr '":<>|*?/\\’' '_' <<<"Mu3.7_${BUILD_NUMBER}_Mac${ADD_INFO}_${BUILD_ARCH}")"
+
+        echo "github.repository: ${{ github.repository }}"
+        echo "BUILD_MODE=$BUILD_MODE" | tee -a $GITHUB_ENV
+        echo "BUILD_NUMBER=$BUILD_NUMBER" | tee -a $GITHUB_ENV
+        echo "DO_NOTARIZE=$DO_NOTARIZE" | tee -a $GITHUB_ENV
+        echo "DO_PUBLISH=$DO_PUBLISH" | tee -a $GITHUB_ENV
+        echo "UPLOAD_ARTIFACT_NAME=$UPLOAD_ARTIFACT_NAME" | tee -a $GITHUB_ENV
+
+    - name: Free disk space
+      run: |
+        sudo rm -rf "/Applications/Visual Studio.app"
+        sudo rm -rf "/Applications/Visual Studio 2019.app"
+        sudo rm -rf "/Users/runner/Library/Android/sdk"
+    - name: Setup environment
+      run: |
+        BUILD_ARCH="Intel"
+        bash ./build/ci/macos/setup.sh --arch "$BUILD_ARCH"
+    - name: Build
+      run: |
+        T_ID=${{ secrets.TELEMETRY_TRACK_ID }}; if [ -z "$T_ID" ]; then T_ID="''"; fi
+        bash ./build/ci/macos/build.sh -n ${{ github.run_id }} --telemetry $T_ID
+    - name: Package
+      run: |
+        S_S="${{ secrets.MAC_SIGN_CERTIFICATE_ENCRYPT_SECRET }}"; if [ -z "$S_S" ]; then S_S="''"; fi
+        S_P="${{ secrets.MAC_SIGN_CERTIFICATE_PASSWORD }}"; if [ -z "$S_P" ]; then S_P="''"; fi
+        S_D="${{ secrets.DEVELOPER_NAME }}"; if [ -z "$S_D" ]; then S_D="MuseScore"; fi
+        BUILD_ARCH="Intel"
+        bash ./build/ci/macos/package.sh --signpass "$S_P" --signsecret "$S_S" --developer_name "$S_D"  --arch "$BUILD_ARCH"
     - name: Notarize
       if: env.DO_NOTARIZE == 'true'
       run: |

--- a/build/ci/macos/build.sh
+++ b/build/ci/macos/build.sh
@@ -7,14 +7,14 @@ SKIP_ERR=true
 
 ARTIFACTS_DIR=build.artifacts
 TELEMETRY_TRACK_ID=""
-BUILD_UI_MU4=OFF 		# not used, only for easier synchronization and compatibility
+#BUILD_UI_MU4=OFF 		# not used, only for easier synchronization and compatibility
 BUILD_AUTOUPDATE=OFF
 
 while [[ "$#" -gt 0 ]]; do
     case $1 in
         -n|--number) BUILD_NUMBER="$2"; shift ;;
         --telemetry) TELEMETRY_TRACK_ID="$2"; shift ;;
-        --build_mu4) BUILD_UI_MU4="$2"; shift;;
+#        --build_mu4) BUILD_UI_MU4="$2"; shift;;
         *) echo "Unknown parameter passed: $1"; exit 1 ;;
     esac
     shift
@@ -36,7 +36,7 @@ fi
 echo "MUSESCORE_BUILD_CONFIG: $MUSESCORE_BUILD_CONFIG"
 echo "BUILD_NUMBER: $BUILD_NUMBER"
 echo "TELEMETRY_TRACK_ID: $TELEMETRY_TRACK_ID"
-echo "BUILD_UI_MU4: $BUILD_UI_MU4"
+#echo "BUILD_UI_MU4: $BUILD_UI_MU4"
 
 MUSESCORE_REVISION=$(git rev-parse --short=7 HEAD)
 

--- a/build/ci/macos/package.sh
+++ b/build/ci/macos/package.sh
@@ -7,12 +7,14 @@ ARTIFACTS_DIR="build.artifacts"
 SIGN_CERTIFICATE_ENCRYPT_SECRET="''"
 SIGN_CERTIFICATE_PASSWORD="''"
 DEVELOPER_NAME="MuseSore"
+BUILD_ARCH="Apple"
 
 while [[ "$#" -gt 0 ]]; do
     case $1 in
         --signsecret) SIGN_CERTIFICATE_ENCRYPT_SECRET="$2"; shift ;;
         --signpass) SIGN_CERTIFICATE_PASSWORD="$2"; shift ;;
         --developer_name) DEVELOPER_NAME="$2"; shift ;;
+        --arch) BUILD=ARCH="$2"; shift ;;
         *) echo "Unknown parameter passed: $1"; exit 1 ;;
     esac
     shift
@@ -86,11 +88,11 @@ if [ "$BUILD_MODE" == "nightly" ]; then
 
   BUILD_DATETIME=$(cat $ARTIFACTS_DIR/env/build_datetime.env)
   BUILD_BRANCH=$(cat $ARTIFACTS_DIR/env/build_branch.env)
-  ARTIFACT_NAME=MuseScoreNightly-${BUILD_DATETIME}-${BUILD_BRANCH}-${BUILD_REVISION}.dmg
+  ARTIFACT_NAME=MuseScoreNightly-${BUILD_DATETIME}-${BUILD_BRANCH}-${BUILD_REVISION}-${BUILD_ARCH}.dmg
 
 else
 
-  ARTIFACT_NAME=MuseScore-${BUILD_VERSION}.dmg  
+  ARTIFACT_NAME=MuseScore-${BUILD_VERSION}-${BUILD_ARCH}.dmg  
 
 fi
 

--- a/build/ci/macos/setup.sh
+++ b/build/ci/macos/setup.sh
@@ -5,94 +5,106 @@ echo "Setup MacOS build environment"
 trap 'echo Setup failed; exit 1' ERR
 SKIP_ERR_FLAG=true
 
+BUILD_ARCH=Apple
+
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        --arch) BUILD_ARCH="$2"; shift ;;
+        *) echo "Unknown parameter passed: $1"; exit 1 ;;
+    esac
+    shift
+done
+
 export MACOSX_DEPLOYMENT_TARGET=10.13
 
-curl -LO https://github.com/macports/macports-base/releases/download/v2.10.5/MacPorts-2.10.5-13-Ventura.pkg
-sudo installer -verbose -pkg MacPorts-2.10.5-13-Ventura.pkg -target /
-rm MacPorts-2.10.5-13-Ventura.pkg
-export PATH="/opt/local/bin:/opt/local/sbin:$PATH"
-echo -e "universal_target ${MACOSX_DEPLOYMENT_TARGET}\nmacosx_deployment_target ${MACOSX_DEPLOYMENT_TARGET}\nmacosx_sdk_version ${MACOSX_DEPLOYMENT_TARGET}" | sudo tee -a /opt/local/etc/macports/macports.conf
-sudo port install git pkgconfig cmake
-sudo port install libsndfile lame portaudio jack
+if [ "$BUILD_ARCH" == "Apple" ]
+then
+    curl -LO https://github.com/macports/macports-base/releases/download/v2.10.5/MacPorts-2.10.5-13-Ventura.pkg
+    sudo installer -verbose -pkg MacPorts-2.10.5-13-Ventura.pkg -target /
+    rm MacPorts-2.10.5-13-Ventura.pkg
+    export PATH="/opt/local/bin:/opt/local/sbin:$PATH"
+    echo -e "universal_target ${MACOSX_DEPLOYMENT_TARGET}\nmacosx_deployment_target ${MACOSX_DEPLOYMENT_TARGET}\nmacosx_sdk_version ${MACOSX_DEPLOYMENT_TARGET}" | sudo tee -a /opt/local/etc/macports/macports.conf
+    sudo port install git pkgconfig cmake
+    sudo port install flac libogg libvorbis libopus mpg123 lame libsndfile portaudio jack
+else # Intel
+    # install dependencies
+    wget -c --no-check-certificate -nv -O bottles.zip https://musescore.org/sites/musescore.org/files/2020-02/bottles-MuseScore-3.0-yosemite.zip
+    unzip bottles.zip
+    #
+    # we don't use freetype
+    rm bottles/freetype* | $SKIP_ERR_FLAG
+    #
+    brew update >/dev/null | $SKIP_ERR_FLAG
+    #
+    # fixing install python 3.11 error (it is a dependency for JACK)
+    rm '/usr/local/bin/2to3'
+    rm '/usr/local/bin/2to3-3.11'
+    rm '/usr/local/bin/idle3'
+    rm '/usr/local/bin/idle3.11'
+    rm '/usr/local/bin/pydoc3'
+    rm '/usr/local/bin/pydoc3.11'
+    rm '/usr/local/bin/python3'
+    rm '/usr/local/bin/python3.11'
+    rm '/usr/local/bin/python3-config'
+    rm '/usr/local/bin/python3.11-config'
 
-# install dependencies
-#wget -c --no-check-certificate -nv -O bottles.zip https://musescore.org/sites/musescore.org/files/2020-02/bottles-MuseScore-3.0-yosemite.zip
-#unzip bottles.zip
-#
-# we don't use freetype
-#rm bottles/freetype* | $SKIP_ERR_FLAG
-#
-#brew update >/dev/null | $SKIP_ERR_FLAG
-#
-# fixing install python 3.11 error (it is a dependency for JACK)
-#rm '/usr/local/bin/2to3'
-#rm '/usr/local/bin/2to3-3.11'
-#rm '/usr/local/bin/idle3'
-#rm '/usr/local/bin/idle3.11'
-#rm '/usr/local/bin/pydoc3'
-#rm '/usr/local/bin/pydoc3.11'
-#rm '/usr/local/bin/python3'
-#rm '/usr/local/bin/python3.11'
-#rm '/usr/local/bin/python3-config'
-#rm '/usr/local/bin/python3.11-config'
-#
-# additional dependencies
-#brew install jack
-#brew install lame
-#
-#BREW_CELLAR=$(brew --cellar)
-#BREW_PREFIX=$(brew --prefix)
-#
-#function fixBrewPath {
-#  DYLIB_FILE=$1
-#  BREW_CELLAR=$(brew --cellar)
-#  BREW_PREFIX=$(brew --prefix)
-#  chmod 644 $DYLIB_FILE
-#  # change ID
-#  DYLIB_ID=$(otool -D  $DYLIB_FILE | tail -n 1)
-#  if [[ "$DYLIB_ID" == *@@HOMEBREW_CELLAR@@* ]]
-#  then
-#      PSLASH=$(echo $DYLIB_ID | sed "s,@@HOMEBREW_CELLAR@@,$BREW_CELLAR,g")
-#      install_name_tool -id $PSLASH $DYLIB_FILE
-#  fi
-#  if [[ "$DYLIB_ID" == *@@HOMEBREW_PREFIX@@* ]]
-#  then
-#      PSLASH=$(echo $DYLIB_ID | sed "s,@@HOMEBREW_PREFIX@@,$BREW_PREFIX,g")
-#      install_name_tool -id $PSLASH $DYLIB_FILE
-#  fi
-#  # Change dependencies
-#  for P in `otool -L $DYLIB_FILE | awk '{print $1}'`
-#  do
-#    if [[ "$P" == *@@HOMEBREW_CELLAR@@* ]]
-#    then
-#        PSLASH=$(echo $P | sed "s,@@HOMEBREW_CELLAR@@,$BREW_CELLAR,g")
-#        install_name_tool -change $P $PSLASH $DYLIB_FILE
-#    fi
-#    if [[ "$P" == *@@HOMEBREW_PREFIX@@* ]]
-#    then
-#        PSLASH=$(echo $P | sed "s,@@HOMEBREW_PREFIX@@,$BREW_PREFIX,g")
-#        install_name_tool -change $P $PSLASH $DYLIB_FILE
-#    fi
-#  done
-#  chmod 444 $DYLIB_FILE
-#}
-#export -f fixBrewPath
-#
-#function installBottleManually {
-#  brew unlink $1 2>/dev/null  # supress 'error' reg. "No such keg"
-#  rm -rf /usr/local/Cellar/$1
-#  tar xzvf bottles/$1*.tar.gz -C $BREW_CELLAR
-#  find $BREW_CELLAR/$1 -type f -name '*.pc' -exec sed -i '' "s:@@HOMEBREW_CELLAR@@:$BREW_CELLAR:g" {} +
-#  find $BREW_CELLAR/$1 -type f -name '*.dylib' -exec bash -c 'fixBrewPath "$1"' _ {} \;
-#  brew link $1
-#}
-#
-#installBottleManually libogg
-#installBottleManually libvorbis
-#installBottleManually flac
-#installBottleManually libsndfile
-#installBottleManually portaudio
+    # additional dependencies
+    brew install jack
+    brew install lame
 
+    BREW_CELLAR=$(brew --cellar)
+    BREW_PREFIX=$(brew --prefix)
+
+    function fixBrewPath {
+        DYLIB_FILE=$1
+        BREW_CELLAR=$(brew --cellar)
+        BREW_PREFIX=$(brew --prefix)
+        chmod 644 $DYLIB_FILE
+        # change ID
+        DYLIB_ID=$(otool -D  $DYLIB_FILE | tail -n 1)
+        if [[ "$DYLIB_ID" == *@@HOMEBREW_CELLAR@@* ]]
+        then
+            PSLASH=$(echo $DYLIB_ID | sed "s,@@HOMEBREW_CELLAR@@,$BREW_CELLAR,g")
+            install_name_tool -id $PSLASH $DYLIB_FILE
+        fi
+        if [[ "$DYLIB_ID" == *@@HOMEBREW_PREFIX@@* ]]
+        then
+            PSLASH=$(echo $DYLIB_ID | sed "s,@@HOMEBREW_PREFIX@@,$BREW_PREFIX,g")
+            install_name_tool -id $PSLASH $DYLIB_FILE
+        fi
+        # Change dependencies
+        for P in `otool -L $DYLIB_FILE | awk '{print $1}'`
+        do
+            if [[ "$P" == *@@HOMEBREW_CELLAR@@* ]]
+            then
+                PSLASH=$(echo $P | sed "s,@@HOMEBREW_CELLAR@@,$BREW_CELLAR,g")
+                install_name_tool -change $P $PSLASH $DYLIB_FILE
+            fi
+            if [[ "$P" == *@@HOMEBREW_PREFIX@@* ]]
+            then
+                PSLASH=$(echo $P | sed "s,@@HOMEBREW_PREFIX@@,$BREW_PREFIX,g")
+                install_name_tool -change $P $PSLASH $DYLIB_FILE
+            fi
+        done
+        chmod 444 $DYLIB_FILE
+    }
+    export -f fixBrewPath
+
+    function installBottleManually {
+        brew unlink $1 2>/dev/null  # supress 'error' reg. "No such keg"
+        rm -rf /usr/local/Cellar/$1
+        tar xzvf bottles/$1*.tar.gz -C $BREW_CELLAR
+        find $BREW_CELLAR/$1 -type f -name '*.pc' -exec sed -i '' "s:@@HOMEBREW_CELLAR@@:$BREW_CELLAR:g" {} +
+        find $BREW_CELLAR/$1 -type f -name '*.dylib' -exec bash -c 'fixBrewPath "$1"' _ {} \;
+        brew link $1
+    }
+
+    installBottleManually libogg
+    installBottleManually libvorbis
+    installBottleManually flac
+    installBottleManually libsndfile
+    installBottleManually portaudio
+fi
 
 export QT_SHORT_VERSION=5.15.9
 export QT_PATH=$HOME/Qt
@@ -103,7 +115,6 @@ wget -nv -O qt5.zip https://s3.amazonaws.com/utils.musescore.org/Qt5159_mac.zip
 mkdir -p $QT_MACOS
 unzip -qq qt5.zip -d $QT_MACOS
 rm qt5.zip
-
 
 #install sparkle
 export SPARKLE_VERSION=1.20.0


### PR DESCRIPTION
by separating Mac builds for Intel and Apple silicone and using HomeBrew for one and MacPorts for the other. They still remain universal builds, not native ones though, so should both run on either CPU type (but may crash on one and have no sound on the other).
Also being more explicit, for the MacPorts, which packages to use and in what order, rather than relying on automatic dependencies.
Disabling BUILD_UI_MU4, which doesn't apply to Mu3 at all.
And while at it, enabling building PortableApps for Windows in PRs too, not just in nightly builds, esp. as it doesn't seem to cause any delay in the builds.

Resolves: #775