### PR TITLE
Fix GH#15726 (Marks & Jumps): Some elements are lost when changing time signature

### DIFF
--- a/libmscore/range.h
+++ b/libmscore/range.h
@@ -25,7 +25,9 @@ class Spanner;
 class ScoreRange;
 class ChordRest;
 class Score;
+class Jump;
 
+class Marker;
 //---------------------------------------------------------
 //   TrackList
 //---------------------------------------------------------
@@ -73,13 +75,25 @@ struct Annotation {
 //---------------------------------------------------------
 
 class ScoreRange {
-      QList<TrackList*> tracks;
+      bool endOfMeasure(Element* e) const;
+      void backupJumpsAndMarkers(Segment* first, Segment* last);
+      void restoreJumpsAndMarkers(Score* score, const Fraction& tick) const;
+      void deleteJumpsAndMarkers();
+
+      struct JumpsMarkersBackup
+      {
+          Fraction sPosition;
+          Element* e = nullptr;
+      };
+
+      QList<TrackList*> _tracks;
+      QList<JumpsMarkersBackup> _jumpsMarkers;
       Segment* _first;
       Segment* _last;
 
    protected:
-      QList<Spanner*> spanner;
-      QList<Annotation> annotations;
+      QList<Spanner*> _spanner;
+      QList<Annotation> _annotations;
 
    public:
       ScoreRange() {}


### PR DESCRIPTION
Backport of #26298 resp. their replacements #30499 and #30560

Resolves: [musescore#15726](https://www.github.com/musescore/MuseScore/issues/15726)