### PR TITLE
Fix GH#26494: MusicXML Import - Beams don't have their color imported

### DIFF
--- a/importexport/musicxml/importmxmlpass2.cpp
+++ b/importexport/musicxml/importmxmlpass2.cpp
@@ -2486,7 +2486,7 @@ static void removeBeam(Beam*& beam)
 //   handleBeamAndStemDir
 //---------------------------------------------------------
 
-static void handleBeamAndStemDir(ChordRest* cr, const Beam::Mode bm, const Direction sd, Beam*& beam, bool hasBeamingInfo)
+static void handleBeamAndStemDir(ChordRest* cr, const Beam::Mode bm, const Direction sd, Beam*& beam, bool hasBeamingInfo, QColor beamColor)
       {
       if (!cr) return;
       // create a new beam
@@ -2500,6 +2500,8 @@ static void handleBeamAndStemDir(ChordRest* cr, const Beam::Mode bm, const Direc
             beam = new Beam(cr->score());
             beam->setTrack(cr->track());
             beam->setBeamDirection(sd);
+            if (beamColor.isValid()/* && preferences.getBool(PREF_IMPORT_MUSICXML_IMPORTLAYOUT)*/)
+                  beam->setColor(beamColor);
             }
       // add ChordRest to beam
       if (beam) {
@@ -6169,6 +6171,7 @@ Note* MusicXMLParserPass2::note(const QString& partId,
       const QColor noteColor = _e.attributes().value("color").toString();
       QColor noteheadColor = QColor::Invalid;
       QColor stemColor = QColor::Invalid;
+      QColor beamColor = QColor::Invalid;
       bool noteheadParentheses = false;
       QString noteheadFilled;
       int velocity = round(_e.attributes().value("dynamics").toDouble() * 0.9);
@@ -6191,8 +6194,10 @@ Note* MusicXMLParserPass2::note(const QString& partId,
             else if (mnd.readProperties(_e)) {
                   // element handled
                   }
-            else if (_e.name() == "beam")
+            else if (_e.name() == "beam") {
+                  beamColor.setNamedColor(_e.attributes().value("color").toString());
                   beam(beamTypes);
+                  }
             else if (_e.name() == "chord") {
                   chord = true;
                   _e.skipCurrentElement();  // skip but don't log
@@ -6449,7 +6454,7 @@ Note* MusicXMLParserPass2::note(const QString& partId,
                   // regular note
                   // handle beam
                   if (!chord)
-                        handleBeamAndStemDir(c, bm, stemDir, currBeam, _pass1.hasBeamingInfo());
+                        handleBeamAndStemDir(c, bm, stemDir, currBeam, _pass1.hasBeamingInfo(), beamColor);
 
                   // append any grace chord after chord to the previous chord
                   Chord*const prevChord = measure->findChord(prevSTime, msTrack + msVoice);

--- a/mtest/musicxml/io/testColors.xml
+++ b/mtest/musicxml/io/testColors.xml
@@ -35,7 +35,7 @@
   <part id="P1">
     <measure number="1">
       <attributes>
-        <divisions>1</divisions>
+        <divisions>4</divisions>
         <key color="#00FDFF">
           <fifths>-1</fifths>
           </key>
@@ -53,7 +53,7 @@
           <step>D</step>
           <octave>4</octave>
           </pitch>
-        <duration>1</duration>
+        <duration>4</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>down</stem>
@@ -66,7 +66,7 @@
           <step>G</step>
           <octave>4</octave>
           </pitch>
-        <duration>1</duration>
+        <duration>4</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>down</stem>
@@ -83,7 +83,7 @@
           <step>E</step>
           <octave>4</octave>
           </pitch>
-        <duration>1</duration>
+        <duration>4</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>down</stem>
@@ -96,7 +96,7 @@
           <step>A</step>
           <octave>4</octave>
           </pitch>
-        <duration>1</duration>
+        <duration>4</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>down</stem>
@@ -118,7 +118,7 @@
           <step>G</step>
           <octave>4</octave>
           </pitch>
-        <duration>1</duration>
+        <duration>4</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem color="#2468AC">down</stem>
@@ -131,7 +131,7 @@
           <step>A</step>
           <octave>4</octave>
           </pitch>
-        <duration>1</duration>
+        <duration>4</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>down</stem>
@@ -141,7 +141,7 @@
           <step>B</step>
           <octave>4</octave>
           </pitch>
-        <duration>1</duration>
+        <duration>4</duration>
         <voice>1</voice>
         <type>quarter</type>
         <accidental color="#0F12A7">natural</accidental>
@@ -158,7 +158,7 @@
           <alter>1</alter>
           <octave>5</octave>
           </pitch>
-        <duration>1</duration>
+        <duration>4</duration>
         <voice>1</voice>
         <type>quarter</type>
         <accidental color="#A632F0">sharp</accidental>
@@ -176,13 +176,53 @@
           <step>D</step>
           <octave>5</octave>
           </pitch>
-        <duration>4</duration>
+        <duration>16</duration>
         <voice>1</voice>
         <type>whole</type>
         <notehead color="#9437FF">normal</notehead>
         <notations>
           <slur type="stop" number="1"/>
           </notations>
+        </note>
+      </measure>
+    <measure number="4">
+      <note>
+        <pitch>
+          <step>D</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>down</stem>
+        <notehead color="#9437FF">normal</notehead>
+        <beam number="1" color="#FF0000">begin</beam>
+        </note>
+      <note>
+        <pitch>
+          <step>D</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>16th</type>
+        <stem>down</stem>
+        <notehead color="#9437FF">normal</notehead>
+        <beam number="1">continue</beam>
+        <beam number="2" color="#FF0000">begin</beam>
+        </note>
+      <note>
+        <pitch>
+          <step>D</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>16th</type>
+        <stem>down</stem>
+        <notehead color="#9437FF">normal</notehead>
+        <beam number="1">end</beam>
+        <beam number="2">end</beam>
         </note>
       </measure>
     </part>


### PR DESCRIPTION
'Backport' of #26495 (this here existed first, at least the part about beams)

Resolves: [musescore#26494](https://www.github.com/musescore/MuseScore/issues/26494)

Current restriction: doesn't work for grace note beams
Further restriction: if in the MusicXML different colors are set for different strokes of a beam, like for 16ths' beams' upper and lower stroke, the last color wins, MuseScore does not allow for this, it colors the entire beam, not single strokes of it.