### PR TITLE
Fix GH#26523: Crash on deleting instrument if last staff contains fretboard diagra

### DIFF
--- a/libmscore/fret.cpp
+++ b/libmscore/fret.cpp
@@ -1001,7 +1001,7 @@ void FretDiagram::setBarre(int string, int fret, bool add /*= false*/)
 
 void FretDiagram::undoSetFretDot(int _string, int _fret, bool _add /*= true*/, FretDotType _dtype /*= FretDotType::NORMAl*/)
       {
-      for (ScoreElement* e : linkList()) {
+      for (ScoreElement*& e : linkList()) {
             FretDiagram* fd = toFretDiagram(e);
             fd->score()->undo(new FretDot(fd, _string, _fret, _add, _dtype));
             }
@@ -1013,7 +1013,7 @@ void FretDiagram::undoSetFretDot(int _string, int _fret, bool _add /*= true*/, F
 
 void FretDiagram::undoSetFretMarker(int _string, FretMarkerType _mtype)
       {
-      for (ScoreElement* e : linkList()) {
+      for (ScoreElement*& e : linkList()) {
             FretDiagram* fd = toFretDiagram(e);
             fd->score()->undo(new FretMarker(fd, _string, _mtype));
             }
@@ -1026,7 +1026,7 @@ void FretDiagram::undoSetFretMarker(int _string, FretMarkerType _mtype)
 
 void FretDiagram::undoSetFretBarre(int _string, int _fret, bool _add /*= false*/)
       {
-      for (ScoreElement* e : linkList()) {
+      for (ScoreElement*& e : linkList()) {
             FretDiagram* fd = toFretDiagram(e);
             fd->score()->undo(new FretBarre(fd, _string, _fret, _add));
             }
@@ -1138,7 +1138,7 @@ void FretDiagram::clear()
 
 void FretDiagram::undoFretClear()
       {
-      for (ScoreElement* e : linkList()) {
+      for (ScoreElement*& e : linkList()) {
             FretDiagram* fd = toFretDiagram(e);
             fd->score()->undo(new FretClear(fd));
             }
@@ -1360,6 +1360,15 @@ QVariant FretDiagram::propertyDefault(Pid pid) const
                   }
             }
       return Element::propertyDefault(pid);
+      }
+
+void FretDiagram::setTrack(int val)
+      {
+      Element::setTrack(val);
+
+      if (_harmony) {
+            _harmony->setTrack(val);
+            }
       }
 
 //---------------------------------------------------------

--- a/libmscore/fret.h
+++ b/libmscore/fret.h
@@ -237,6 +237,8 @@ class FretDiagram final : public Element {
       bool setProperty(Pid propertyId, const QVariant&) override;
       QVariant propertyDefault(Pid) const override;
 
+      void setTrack(int val) override;
+
       qreal userMag() const         { return _userMag;   }
       void setUserMag(qreal m)      { _userMag = m;      }
 


### PR DESCRIPTION
Backport of #26703 plus fixing clazy warnings

Resolves: [musescore#26523](https://www.github.com/musescore/MuseScore/issues/26523)
