### PR TITLE
Fix GH#26414: Memory leak in MIDI export

### DIFF
--- a/audio/midi/event.h
+++ b/audio/midi/event.h
@@ -202,7 +202,7 @@ class MidiCoreEvent {
 class MidiEvent : public MidiCoreEvent {
 
    protected:
-      uchar* _edata { nullptr };           // always zero terminated (_data[_len] == 0; )
+      std::vector<uchar> _edata;
       int _len { 0 };
       int _metaType { 0 };
 
@@ -211,12 +211,12 @@ class MidiEvent : public MidiCoreEvent {
       MidiEvent(uchar t, uchar c, uchar a, uchar b)
          : MidiCoreEvent(t, c, a, b), _edata(0), _len(0) {}
 
-      const uchar* edata() const     { return _edata; }
-      void setEData(uchar* d)        { _edata = d; }
-      int len() const                { return _len; }
-      void setLen(int l)             { _len = l; }
-      int metaType() const           { return _metaType; }
-      void setMetaType(int v)        { _metaType = v; }
+      const uchar* edata() const            { return _edata.data(); }
+      void setEData(std::vector<uchar>&& d) { _edata = d; }
+      int len() const                       { return _len; }
+      void setLen(int l)                    { _len = l; }
+      int metaType() const                  { return _metaType; }
+      void setMetaType(int v)               { _metaType = v; }
       };
 
 //---------------------------------------------------------


### PR DESCRIPTION
Replace new unsigned char allocations with std::vector<unsigned char> and make sure that MidiEvent::setEData takes vector reference rather than raw pointer.

Backport of #26798

Resolves: [musescore#26414](https://www.github.com/musescore/MuseScore/issues/26414)
