### PR TITLE
Update Linux builds to use Ubuntu 22.04

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -75,9 +75,8 @@ jobs:
         # Expose edge cases like different command versions, CRLF line endings, etc.
         # Use same OS versions as used in real build workflows.
         os:
-        - ubuntu-20.04 # linux_x64, backend
-        - ubuntu-22.04 # linux_arm32, linux_arm64
-        - macos-latest
+        - ubuntu-22.04 # linux_x64, backend, linux_arm32, linux_arm64
+        - macos-13
         - windows-2022 # windows_x64, windows_portable
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -31,7 +31,7 @@ on:
 
 jobs:
   linux_x64:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Cancel Previous Runs
       uses: styfle/cancel-workflow-action@0.12.1
@@ -95,7 +95,7 @@ jobs:
         path: ./build.artifacts/
 
   run_mtests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
         # Enable AddressSanitizer in the mtest build
         CFLAGS: "-fsanitize=address -fno-omit-frame-pointer"

--- a/.github/workflows/check_visual_tests.yml
+++ b/.github/workflows/check_visual_tests.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   run_vtests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Cancel Previous Runs
       uses: styfle/cancel-workflow-action@0.12.1

--- a/.github/workflows/translate_tx_pull_to_s3.yml
+++ b/.github/workflows/translate_tx_pull_to_s3.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   tx2s3:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: "Configure workflow"
       run: |

--- a/.github/workflows/update_release_info.yml
+++ b/.github/workflows/update_release_info.yml
@@ -33,7 +33,7 @@ defaults:
 
 jobs:
   update-release-info:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     environment:
       name: ${{ inputs.environment }} # can be empty/blank (if so, URL will not be shown)
       url: ${{ github.server_url }}/${{ github.repository }}/releases/${{ inputs.tag && format('tag/{0}', inputs.tag) || 'latest' }} # show on run page

--- a/build/ci/linux/setup.sh
+++ b/build/ci/linux/setup.sh
@@ -106,7 +106,7 @@ echo export QML2_IMPORT_PATH="${qt_path}/qml" >> ${ENV_FILE}
 
 # COMPILER
 
-gcc_version="7"
+gcc_version="9"
 sudo apt-get install -y --no-install-recommends "g++-${gcc_version}"
 sudo update-alternatives \
   --install /usr/bin/gcc gcc "/usr/bin/gcc-${gcc_version}" 40 \


### PR DESCRIPTION
as 20.04 will get deprecated on GitHub CI on April 1st, see https://github.com/actions/runner-images/issues/11101