### PR TITLE
Scoreview: Correct y-constraint

### DIFF
--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -4021,7 +4021,7 @@ void ScoreView::adjustCanvasPosition(const Element* el, bool playBack, int staff
             constraintCanvas(&cx, &cy);
             cx = (x < 0) ? x : cx + _matrix.dx();
             }
-      setOffset(cx, cy);
+      setOffset(cx, y);
       update();
       }
 


### PR DESCRIPTION
Resolves: some problemos with shaky y-constraint not going anywhere with vertical scroll + limit on, all the while should be okay with the horizontal layout as before when rewinding