### PR TITLE
Fix GH#26997: Limit edit leading space by drag

### DIFF
--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -2559,7 +2559,8 @@ QRectF Note::drag(EditData& ed)
             noteEditData->mode = NoteEditData::editModeByDragDirection(delta.x(), delta.y());
             }
 
-      if (noteEditData->mode == NoteEditData::EditMode_AddSpacing)
+      bool isSingleNoteSelection = score()->getSelectedElement() == this;
+      if (noteEditData->mode == NoteEditData::EditMode_AddSpacing && isSingleNoteSelection && !(ed.modifiers & Qt::ControlModifier))
             horizontalDrag(ed);
       else if (noteEditData->mode == NoteEditData::EditMode_ChangePitch)
             verticalDrag(ed);


### PR DESCRIPTION
Backport of #27037

Resolves: [musescore#26997](https://www.github.com/musescore/MuseScore/issues/26997)