### PR TITLE
Fix GH#17838: Persist general properties of a TremoloBar

### DIFF
--- a/libmscore/tremolobar.cpp
+++ b/libmscore/tremolobar.cpp
@@ -10,12 +10,11 @@
 //  the file LICENCE.GPL
 //=============================================================================
 
-#include "tremolobar.h"
-#include "score.h"
-#include "undo.h"
-#include "staff.h"
-#include "chord.h"
 #include "note.h"
+#include "score.h"
+#include "staff.h"
+#include "tremolobar.h"
+#include "undo.h"
 #include "xml.h"
 
 namespace Ms {
@@ -94,6 +93,7 @@ void TremoloBar::write(XmlWriter& xml) const
             xml.tagE(QString("point time=\"%1\" pitch=\"%2\" vibrato=\"%3\"")
                .arg(v.time).arg(v.pitch).arg(v.vibrato));
             }
+      Element::writeProperties(xml);
       xml.etag();
       }
 
@@ -121,7 +121,7 @@ void TremoloBar::read(XmlReader& e)
                   setPlay(e.readInt());
             else if (readProperty(tag, e, Pid::LINE_WIDTH))
                   ;
-            else
+            else if (!Element::readProperties(e))
                   e.unknown();
             }
       }

--- a/mscore/chordview.cpp
+++ b/mscore/chordview.cpp
@@ -399,7 +399,7 @@ void ChordView::wheelEvent(QWheelEvent* event)
             }
       else if (event->modifiers() == Qt::ShiftModifier) {
 #if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
-            QWheelEvent we(event->position(), event->globalPosition(), event->pixelDelta(), event->angleDelta(),
+            QWheelEvent we(event->position(), event->globalPosition(), event->pixelDelta().transposed(), event->angleDelta().transposed(),
                            event->buttons(), Qt::NoModifier, Qt::ScrollPhase::NoScrollPhase, false);
 #else
             QWheelEvent we(event->pos(), event->delta(), event->buttons(), 0, Qt::Horizontal);
@@ -494,10 +494,8 @@ void ChordView::mouseMoveEvent(QMouseEvent* event)
       int pitch = y2pitch(int(p.y()));
       emit pitchChanged(pitch);
       int tick = int(p.x()) - CHORD_MAP_OFFSET;
-      if (tick < 0) {
-            tick = 0;
+      if (tick < 0)
             _pos = -1;
-            }
       else
             _pos = tick;
       emit posChanged(_pos);

--- a/mscore/drumview.cpp
+++ b/mscore/drumview.cpp
@@ -395,7 +395,7 @@ void DrumView::wheelEvent(QWheelEvent* event)
             }
       else if (event->modifiers() == Qt::ShiftModifier) {
 #if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
-            QWheelEvent we(event->position(), event->globalPosition(), event->pixelDelta(), event->angleDelta(),
+            QWheelEvent we(event->position(), event->globalPosition(), event->pixelDelta().transposed(), event->angleDelta().transposed(),
                            event->buttons(), Qt::NoModifier, Qt::ScrollPhase::NoScrollPhase, false);
 #else
             QWheelEvent we(event->pos(), event->delta(), event->buttons(), 0, Qt::Horizontal);

--- a/mscore/pianoroll/pianoview.cpp
+++ b/mscore/pianoroll/pianoview.cpp
@@ -484,7 +484,7 @@ void PianoView::drawBackground(QPainter* p, const QRectF& r)
       //      _noteList[i]->paint(p);
 
       p->setRenderHints(QPainter::Antialiasing | QPainter::SmoothPixmapTransform | QPainter::TextAntialiasing);
-      for (PianoItem* block : _noteList) {
+      for (PianoItem*& block : _noteList) {
             drawNoteBlock(p, block);
             }
 
@@ -727,7 +727,7 @@ void PianoView::wheelEvent(QWheelEvent* event)
       else if (event->modifiers() == Qt::ShiftModifier) {
             //Horizontal scroll
 #if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
-            QWheelEvent we(event->position(), event->globalPosition(), event->pixelDelta(), event->angleDelta(),
+            QWheelEvent we(event->position(), event->globalPosition(), event->pixelDelta().transposed(), event->angleDelta().transposed(),
                            event->buttons(), Qt::NoModifier, Qt::ScrollPhase::NoScrollPhase, false);
 #else
             QWheelEvent we(event->pos(), event->delta(), event->buttons(), 0, Qt::Horizontal);
@@ -1985,7 +1985,7 @@ void PianoView::setStaff(Staff* s, Pos* l)
 
 void PianoView::addChord(Chord* chrd, int voice)
       {
-      for (Chord* c : chrd->graceNotes())
+      for (Chord*& c : chrd->graceNotes())
             addChord(c, voice);
       for (Note* note : chrd->notes()) {
             if (note->tieBack())
@@ -2486,7 +2486,7 @@ void PianoView::finishNoteGroupDrag(QMouseEvent* event) {
       //Select just pasted notes
       Selection& selection = score->selection();
       selection.deselectAll();
-      for (Note* note : notes) {
+      for (Note*& note : notes) {
             selection.add(note);
             note->setSelected(true);
             }


### PR DESCRIPTION
Backport of #27184

Resolves: [musescore#17838](https://www.github.com/musescore/MuseScore/issues/17838)