### PR TITLE
Fix GH#331: Awkward single-digit entry required in Page Setup field

### DIFF
--- a/mscore/pagesettings.cpp
+++ b/mscore/pagesettings.cpp
@@ -231,7 +231,6 @@ void PageSettings::updateValues()
       pageOffsetEntry->setValue(score->pageNumberOffset() + 1);
 
       blockSignals(false);
-      _changeFlag = true;
       }
 
 //---------------------------------------------------------
@@ -589,7 +588,7 @@ void PageSettings::pageWidthChanged(double val)
 
 void PageSettings::updatePreview()
       {
-      updateValues();
+      _changeFlag = true;
       preview->score()->doLayout();
       preview->layoutChanged();
       }

--- a/mscore/pagesettings.cpp
+++ b/mscore/pagesettings.cpp
@@ -168,12 +168,12 @@ void PageSettings::updateValues()
       if (mm) {
             suffix = "mm";
             singleStepSize = 1.0;
-            singleStepScale = 0.2;
+            singleStepScale = 0.05;
             }
       else {
             suffix = "in";
             singleStepSize = 0.05;
-            singleStepScale = 0.005;
+            singleStepScale = 0.002;
             }
       for (auto w : { oddPageTopMargin, oddPageBottomMargin, oddPageLeftMargin, oddPageRightMargin, evenPageTopMargin,
          evenPageBottomMargin, evenPageLeftMargin, evenPageRightMargin, spatiumEntry, pageWidth, pageHeight } )


### PR DESCRIPTION
by making the step width for the scaling value smaller.

Partly resolves: #331 (by provideing better (i.e. smaller) defaults)

See also #27373, which does the same for upstream master

---

Resolves #331 (finally!)

See https://musescore.org/en/node/376837#comment-1286408