### PR TITLE
Fix GH#26527: Crash with instrument changes and multi-measure rests (plus refactor)

### DIFF
--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -20,13 +20,13 @@
 
 #include "input.h"
 #include "instrument.h"
-#include "select.h"
-#include "synthesizerstate.h"
-#include "mscoreview.h"
-#include "spannermap.h"
 #include "layoutbreak.h"
+#include "mscoreview.h"
 #include "property.h"
+#include "select.h"
+#include "spannermap.h"
 #include "sym.h"
+#include "synthesizerstate.h"
 
 namespace Ms {
 
@@ -1317,7 +1317,9 @@ class MasterScore : public Score {
       void reorderMidiMapping();
       void rebuildExcerptsMidiMapping();
       void removeDeletedMidiMapping();
+
       int updateMidiMapping();
+      void doUpdateMidiMapping(int& maxport, Part* part, Channel* channel, bool useDrumset);
 
       QFileInfo _sessionStartBackupInfo;
       QFileInfo info;


### PR DESCRIPTION
Backport of #26736, plus fixing clazy warnings

Resolves: [musescore#26527](https://www.github.com/musescore/MuseScore/issues/26527), which is not a Mu3 issue, but a problem apparently got introduced in 4.1.