### PR TITLE
Import page format settings from MuseScore 1.x scores 

### DIFF
--- a/libmscore/read114.cpp
+++ b/libmscore/read114.cpp
@@ -2563,7 +2563,7 @@ static void readPart(Part* part, XmlReader& e)
 //   readPageFormat
 //---------------------------------------------------------
 
-static void readPageFormat(PageFormat* pf, XmlReader& e)
+static void readPageFormat(PageFormat* pf, int& pageNumberOffset, XmlReader& e)
       {
       qreal _oddRightMargin  = 0.0;
       qreal _evenRightMargin = 0.0;
@@ -2614,7 +2614,7 @@ static void readPageFormat(PageFormat* pf, XmlReader& e)
                   pf->setSize(QSizeF(s->w, s->h));
                   }
             else if (tag == "page-offset") {
-                  e.readInt();
+                  pageNumberOffset = e.readInt();
                   }
             else
                   e.unknown();
@@ -2894,7 +2894,11 @@ Score::FileError MasterScore::read114(XmlReader& e)
                   }
             else if (tag == "page-layout") {
                   PageFormat pf;
-                  readPageFormat(&pf, e);
+                  int pageNumberOffset = 0;
+                  initPageFormat(&style(), &pf);
+                  readPageFormat(&pf, pageNumberOffset, e);
+                  setPageFormat(&style(), pf);
+                  score()->setPageNumberOffset(pageNumberOffset);
                   }
             else if (tag == "copyright" || tag == "rights") {
                   Text* text = new Text(this);

--- a/libmscore/read206.h
+++ b/libmscore/read206.h
@@ -13,6 +13,8 @@
 #ifndef __READ206_H__
 #define __READ206_H__
 
+#include "xml.h"
+
 namespace Ms {
 
 class MStyle;

--- a/mtest/libmscore/compat114/accidentals-ref.mscx
+++ b/mtest/libmscore/compat114/accidentals-ref.mscx
@@ -5,6 +5,13 @@
     <currentLayer>0</currentLayer>
     <Division>480</Division>
     <Style>
+      <pagePrintableWidth>7.48032</pagePrintableWidth>
+      <pageEvenLeftMargin>0.393701</pageEvenLeftMargin>
+      <pageOddLeftMargin>0.393701</pageOddLeftMargin>
+      <pageEvenTopMargin>0.393701</pageEvenTopMargin>
+      <pageEvenBottomMargin>0.787403</pageEvenBottomMargin>
+      <pageOddTopMargin>0.393701</pageOddTopMargin>
+      <pageOddBottomMargin>0.787403</pageOddBottomMargin>
       <frameSystemDistance>13</frameSystemDistance>
       <measureSpacing>1.14</measureSpacing>
       <voltaPosAbove x="0" y="-2"/>

--- a/mtest/libmscore/compat114/articulations-ref.mscx
+++ b/mtest/libmscore/compat114/articulations-ref.mscx
@@ -5,6 +5,13 @@
     <currentLayer>0</currentLayer>
     <Division>480</Division>
     <Style>
+      <pagePrintableWidth>7.48032</pagePrintableWidth>
+      <pageEvenLeftMargin>0.393701</pageEvenLeftMargin>
+      <pageOddLeftMargin>0.393701</pageOddLeftMargin>
+      <pageEvenTopMargin>0.393701</pageEvenTopMargin>
+      <pageEvenBottomMargin>0.787403</pageEvenBottomMargin>
+      <pageOddTopMargin>0.393701</pageOddTopMargin>
+      <pageOddBottomMargin>0.787403</pageOddBottomMargin>
       <minSystemDistance>9.2</minSystemDistance>
       <frameSystemDistance>13</frameSystemDistance>
       <bracketDistance>0.2</bracketDistance>

--- a/mtest/libmscore/compat114/chord_symbol-ref.mscx
+++ b/mtest/libmscore/compat114/chord_symbol-ref.mscx
@@ -5,6 +5,15 @@
     <currentLayer>0</currentLayer>
     <Division>480</Division>
     <Style>
+      <pageWidth>8.5</pageWidth>
+      <pageHeight>11</pageHeight>
+      <pagePrintableWidth>7.7126</pagePrintableWidth>
+      <pageEvenLeftMargin>0.393701</pageEvenLeftMargin>
+      <pageOddLeftMargin>0.393701</pageOddLeftMargin>
+      <pageEvenTopMargin>0.393701</pageEvenTopMargin>
+      <pageEvenBottomMargin>0.787403</pageEvenBottomMargin>
+      <pageOddTopMargin>0.393701</pageOddTopMargin>
+      <pageOddBottomMargin>0.787403</pageOddBottomMargin>
       <frameSystemDistance>13</frameSystemDistance>
       <measureSpacing>1.14</measureSpacing>
       <voltaPosAbove x="0" y="-2"/>

--- a/mtest/libmscore/compat114/clef_missing_first-ref.mscx
+++ b/mtest/libmscore/compat114/clef_missing_first-ref.mscx
@@ -5,6 +5,13 @@
     <currentLayer>0</currentLayer>
     <Division>480</Division>
     <Style>
+      <pagePrintableWidth>7.48032</pagePrintableWidth>
+      <pageEvenLeftMargin>0.393701</pageEvenLeftMargin>
+      <pageOddLeftMargin>0.393701</pageOddLeftMargin>
+      <pageEvenTopMargin>0.393701</pageEvenTopMargin>
+      <pageEvenBottomMargin>0.787403</pageEvenBottomMargin>
+      <pageOddTopMargin>0.393701</pageOddTopMargin>
+      <pageOddBottomMargin>0.787403</pageOddBottomMargin>
       <frameSystemDistance>13</frameSystemDistance>
       <measureSpacing>1.14</measureSpacing>
       <voltaPosAbove x="0" y="-2"/>

--- a/mtest/libmscore/compat114/clefs-ref.mscx
+++ b/mtest/libmscore/compat114/clefs-ref.mscx
@@ -5,6 +5,13 @@
     <currentLayer>0</currentLayer>
     <Division>480</Division>
     <Style>
+      <pagePrintableWidth>7.48032</pagePrintableWidth>
+      <pageEvenLeftMargin>0.393701</pageEvenLeftMargin>
+      <pageOddLeftMargin>0.393701</pageOddLeftMargin>
+      <pageEvenTopMargin>0.393701</pageEvenTopMargin>
+      <pageEvenBottomMargin>0.787403</pageEvenBottomMargin>
+      <pageOddTopMargin>0.393701</pageOddTopMargin>
+      <pageOddBottomMargin>0.787403</pageOddBottomMargin>
       <minSystemDistance>9.2</minSystemDistance>
       <frameSystemDistance>13</frameSystemDistance>
       <bracketDistance>0.2</bracketDistance>

--- a/mtest/libmscore/compat114/drumset-ref.mscx
+++ b/mtest/libmscore/compat114/drumset-ref.mscx
@@ -5,6 +5,13 @@
     <currentLayer>0</currentLayer>
     <Division>480</Division>
     <Style>
+      <pagePrintableWidth>7.48032</pagePrintableWidth>
+      <pageEvenLeftMargin>0.393701</pageEvenLeftMargin>
+      <pageOddLeftMargin>0.393701</pageOddLeftMargin>
+      <pageEvenTopMargin>0.393701</pageEvenTopMargin>
+      <pageEvenBottomMargin>0.787403</pageEvenBottomMargin>
+      <pageOddTopMargin>0.393701</pageOddTopMargin>
+      <pageOddBottomMargin>0.787403</pageOddBottomMargin>
       <frameSystemDistance>13</frameSystemDistance>
       <measureSpacing>1.14</measureSpacing>
       <voltaPosAbove x="0" y="-2"/>

--- a/mtest/libmscore/compat114/fingering-ref.mscx
+++ b/mtest/libmscore/compat114/fingering-ref.mscx
@@ -5,6 +5,13 @@
     <currentLayer>0</currentLayer>
     <Division>480</Division>
     <Style>
+      <pagePrintableWidth>7.48032</pagePrintableWidth>
+      <pageEvenLeftMargin>0.393701</pageEvenLeftMargin>
+      <pageOddLeftMargin>0.393701</pageOddLeftMargin>
+      <pageEvenTopMargin>0.393701</pageEvenTopMargin>
+      <pageEvenBottomMargin>0.787403</pageEvenBottomMargin>
+      <pageOddTopMargin>0.393701</pageOddTopMargin>
+      <pageOddBottomMargin>0.787403</pageOddBottomMargin>
       <frameSystemDistance>13</frameSystemDistance>
       <measureSpacing>1.14</measureSpacing>
       <voltaPosAbove x="0" y="-2"/>

--- a/mtest/libmscore/compat114/hairpin-ref.mscx
+++ b/mtest/libmscore/compat114/hairpin-ref.mscx
@@ -5,6 +5,13 @@
     <currentLayer>0</currentLayer>
     <Division>480</Division>
     <Style>
+      <pagePrintableWidth>7.48032</pagePrintableWidth>
+      <pageEvenLeftMargin>0.393701</pageEvenLeftMargin>
+      <pageOddLeftMargin>0.393701</pageOddLeftMargin>
+      <pageEvenTopMargin>0.393701</pageEvenTopMargin>
+      <pageEvenBottomMargin>0.787403</pageEvenBottomMargin>
+      <pageOddTopMargin>0.393701</pageOddTopMargin>
+      <pageOddBottomMargin>0.787403</pageOddBottomMargin>
       <frameSystemDistance>13</frameSystemDistance>
       <measureSpacing>1.14</measureSpacing>
       <voltaPosAbove x="0" y="-2"/>

--- a/mtest/libmscore/compat114/hor_frame_and_mmrest-ref.mscx
+++ b/mtest/libmscore/compat114/hor_frame_and_mmrest-ref.mscx
@@ -5,6 +5,13 @@
     <currentLayer>0</currentLayer>
     <Division>480</Division>
     <Style>
+      <pagePrintableWidth>7.48032</pagePrintableWidth>
+      <pageEvenLeftMargin>0.393701</pageEvenLeftMargin>
+      <pageOddLeftMargin>0.393701</pageOddLeftMargin>
+      <pageEvenTopMargin>0.393701</pageEvenTopMargin>
+      <pageEvenBottomMargin>0.787403</pageEvenBottomMargin>
+      <pageOddTopMargin>0.393701</pageOddTopMargin>
+      <pageOddBottomMargin>0.787403</pageOddBottomMargin>
       <minSystemDistance>9.2</minSystemDistance>
       <frameSystemDistance>13</frameSystemDistance>
       <bracketDistance>0.2</bracketDistance>

--- a/mtest/libmscore/compat114/keysig-ref.mscx
+++ b/mtest/libmscore/compat114/keysig-ref.mscx
@@ -5,6 +5,13 @@
     <currentLayer>0</currentLayer>
     <Division>480</Division>
     <Style>
+      <pagePrintableWidth>7.48032</pagePrintableWidth>
+      <pageEvenLeftMargin>0.393701</pageEvenLeftMargin>
+      <pageOddLeftMargin>0.393701</pageOddLeftMargin>
+      <pageEvenTopMargin>0.393701</pageEvenTopMargin>
+      <pageEvenBottomMargin>0.787403</pageEvenBottomMargin>
+      <pageOddTopMargin>0.393701</pageOddTopMargin>
+      <pageOddBottomMargin>0.787403</pageOddBottomMargin>
       <frameSystemDistance>13</frameSystemDistance>
       <measureSpacing>1.14</measureSpacing>
       <voltaPosAbove x="0" y="-2"/>

--- a/mtest/libmscore/compat114/markers-ref.mscx
+++ b/mtest/libmscore/compat114/markers-ref.mscx
@@ -5,6 +5,13 @@
     <currentLayer>0</currentLayer>
     <Division>480</Division>
     <Style>
+      <pagePrintableWidth>7.48032</pagePrintableWidth>
+      <pageEvenLeftMargin>0.393701</pageEvenLeftMargin>
+      <pageOddLeftMargin>0.393701</pageOddLeftMargin>
+      <pageEvenTopMargin>0.393701</pageEvenTopMargin>
+      <pageEvenBottomMargin>0.787403</pageEvenBottomMargin>
+      <pageOddTopMargin>0.393701</pageOddTopMargin>
+      <pageOddBottomMargin>0.787403</pageOddBottomMargin>
       <minSystemDistance>9.2</minSystemDistance>
       <lyricsMinBottomDistance>6</lyricsMinBottomDistance>
       <minMeasureWidth>4</minMeasureWidth>

--- a/mtest/libmscore/compat114/noteheads-ref.mscx
+++ b/mtest/libmscore/compat114/noteheads-ref.mscx
@@ -5,6 +5,13 @@
     <currentLayer>0</currentLayer>
     <Division>480</Division>
     <Style>
+      <pagePrintableWidth>7.48032</pagePrintableWidth>
+      <pageEvenLeftMargin>0.393701</pageEvenLeftMargin>
+      <pageOddLeftMargin>0.393701</pageOddLeftMargin>
+      <pageEvenTopMargin>0.393701</pageEvenTopMargin>
+      <pageEvenBottomMargin>0.787403</pageEvenBottomMargin>
+      <pageOddTopMargin>0.393701</pageOddTopMargin>
+      <pageOddBottomMargin>0.787403</pageOddBottomMargin>
       <frameSystemDistance>13</frameSystemDistance>
       <measureSpacing>1.14</measureSpacing>
       <voltaPosAbove x="0" y="-2"/>

--- a/mtest/libmscore/compat114/notes-ref.mscx
+++ b/mtest/libmscore/compat114/notes-ref.mscx
@@ -5,6 +5,13 @@
     <currentLayer>0</currentLayer>
     <Division>480</Division>
     <Style>
+      <pagePrintableWidth>7.48032</pagePrintableWidth>
+      <pageEvenLeftMargin>0.393701</pageEvenLeftMargin>
+      <pageOddLeftMargin>0.393701</pageOddLeftMargin>
+      <pageEvenTopMargin>0.393701</pageEvenTopMargin>
+      <pageEvenBottomMargin>0.787403</pageEvenBottomMargin>
+      <pageOddTopMargin>0.393701</pageOddTopMargin>
+      <pageOddBottomMargin>0.787403</pageOddBottomMargin>
       <frameSystemDistance>13</frameSystemDistance>
       <measureSpacing>1.14</measureSpacing>
       <voltaPosAbove x="0" y="-2"/>

--- a/mtest/libmscore/compat114/notes_useroffset-ref.mscx
+++ b/mtest/libmscore/compat114/notes_useroffset-ref.mscx
@@ -5,9 +5,7 @@
     <currentLayer>0</currentLayer>
     <Division>480</Division>
     <Style>
-      <pageWidth>8.26771</pageWidth>
-      <pageHeight>11.6929</pageHeight>
-      <pagePrintableWidth>7.48031</pagePrintableWidth>
+      <pagePrintableWidth>7.48032</pagePrintableWidth>
       <pageEvenLeftMargin>0.393701</pageEvenLeftMargin>
       <pageOddLeftMargin>0.393701</pageOddLeftMargin>
       <pageEvenTopMargin>0.393701</pageEvenTopMargin>

--- a/mtest/libmscore/compat114/ottava-ref.mscx
+++ b/mtest/libmscore/compat114/ottava-ref.mscx
@@ -5,6 +5,13 @@
     <currentLayer>0</currentLayer>
     <Division>480</Division>
     <Style>
+      <pagePrintableWidth>7.48032</pagePrintableWidth>
+      <pageEvenLeftMargin>0.393701</pageEvenLeftMargin>
+      <pageOddLeftMargin>0.393701</pageOddLeftMargin>
+      <pageEvenTopMargin>0.393701</pageEvenTopMargin>
+      <pageEvenBottomMargin>0.787403</pageEvenBottomMargin>
+      <pageOddTopMargin>0.393701</pageOddTopMargin>
+      <pageOddBottomMargin>0.787403</pageOddBottomMargin>
       <frameSystemDistance>13</frameSystemDistance>
       <measureSpacing>1.14</measureSpacing>
       <voltaPosAbove x="0" y="-2"/>

--- a/mtest/libmscore/compat114/pedal-ref.mscx
+++ b/mtest/libmscore/compat114/pedal-ref.mscx
@@ -5,6 +5,13 @@
     <currentLayer>0</currentLayer>
     <Division>480</Division>
     <Style>
+      <pagePrintableWidth>7.48032</pagePrintableWidth>
+      <pageEvenLeftMargin>0.393701</pageEvenLeftMargin>
+      <pageOddLeftMargin>0.393701</pageOddLeftMargin>
+      <pageEvenTopMargin>0.393701</pageEvenTopMargin>
+      <pageEvenBottomMargin>0.787403</pageEvenBottomMargin>
+      <pageOddTopMargin>0.393701</pageOddTopMargin>
+      <pageOddBottomMargin>0.787403</pageOddBottomMargin>
       <frameSystemDistance>13</frameSystemDistance>
       <measureSpacing>1.14</measureSpacing>
       <voltaPosAbove x="0" y="-2"/>

--- a/mtest/libmscore/compat114/slurs-ref.mscx
+++ b/mtest/libmscore/compat114/slurs-ref.mscx
@@ -5,6 +5,13 @@
     <currentLayer>0</currentLayer>
     <Division>480</Division>
     <Style>
+      <pagePrintableWidth>7.48032</pagePrintableWidth>
+      <pageEvenLeftMargin>0.393701</pageEvenLeftMargin>
+      <pageOddLeftMargin>0.393701</pageOddLeftMargin>
+      <pageEvenTopMargin>0.393701</pageEvenTopMargin>
+      <pageEvenBottomMargin>0.787403</pageEvenBottomMargin>
+      <pageOddTopMargin>0.393701</pageOddTopMargin>
+      <pageOddBottomMargin>0.787403</pageOddBottomMargin>
       <frameSystemDistance>13</frameSystemDistance>
       <measureSpacing>1.14</measureSpacing>
       <voltaPosAbove x="0" y="-2"/>

--- a/mtest/libmscore/compat114/style-ref.mscx
+++ b/mtest/libmscore/compat114/style-ref.mscx
@@ -3,8 +3,17 @@
   <Score>
     <LayerTag id="0" tag="default"></LayerTag>
     <currentLayer>0</currentLayer>
+    <page-offset>3</page-offset>
     <Division>480</Division>
     <Style>
+      <pagePrintableWidth>7.48032</pagePrintableWidth>
+      <pageEvenLeftMargin>0.393701</pageEvenLeftMargin>
+      <pageOddLeftMargin>0.393701</pageOddLeftMargin>
+      <pageEvenTopMargin>0.393701</pageEvenTopMargin>
+      <pageEvenBottomMargin>0.787403</pageEvenBottomMargin>
+      <pageOddTopMargin>0.393701</pageOddTopMargin>
+      <pageOddBottomMargin>0.787403</pageOddBottomMargin>
+      <pageTwosided>0</pageTwosided>
       <staffUpperBorder>6</staffUpperBorder>
       <staffLowerBorder>6</staffLowerBorder>
       <staffDistance>6</staffDistance>

--- a/mtest/libmscore/compat114/style.mscx
+++ b/mtest/libmscore/compat114/style.mscx
@@ -119,19 +119,13 @@
   <showFrames>1</showFrames>
   <page-layout>
     <pageFormat>A4</pageFormat>
-    <page-margins type="even">
+    <page-margins type="both">
       <left-margin>56.6929</left-margin>
       <right-margin>56.6929</right-margin>
       <top-margin>56.6929</top-margin>
       <bottom-margin>113.386</bottom-margin>
       </page-margins>
-    <page-margins type="odd">
-      <left-margin>56.6929</left-margin>
-      <right-margin>56.6929</right-margin>
-      <top-margin>56.6929</top-margin>
-      <bottom-margin>113.386</bottom-margin>
-      </page-margins>
-    <page-offset>0</page-offset>
+    <page-offset>3</page-offset>
     </page-layout>
   <siglist>
     <sig tick="0">

--- a/mtest/libmscore/compat114/tamtam-ref.mscx
+++ b/mtest/libmscore/compat114/tamtam-ref.mscx
@@ -5,6 +5,13 @@
     <currentLayer>0</currentLayer>
     <Division>480</Division>
     <Style>
+      <pagePrintableWidth>7.48032</pagePrintableWidth>
+      <pageEvenLeftMargin>0.393701</pageEvenLeftMargin>
+      <pageOddLeftMargin>0.393701</pageOddLeftMargin>
+      <pageEvenTopMargin>0.393701</pageEvenTopMargin>
+      <pageEvenBottomMargin>0.787403</pageEvenBottomMargin>
+      <pageOddTopMargin>0.393701</pageOddTopMargin>
+      <pageOddBottomMargin>0.787403</pageOddBottomMargin>
       <frameSystemDistance>13</frameSystemDistance>
       <measureSpacing>1.14</measureSpacing>
       <voltaPosAbove x="0" y="-2"/>

--- a/mtest/libmscore/compat114/text_scaling-ref.mscx
+++ b/mtest/libmscore/compat114/text_scaling-ref.mscx
@@ -5,6 +5,13 @@
     <currentLayer>0</currentLayer>
     <Division>480</Division>
     <Style>
+      <pagePrintableWidth>7.48032</pagePrintableWidth>
+      <pageEvenLeftMargin>0.393701</pageEvenLeftMargin>
+      <pageOddLeftMargin>0.393701</pageOddLeftMargin>
+      <pageEvenTopMargin>0.393701</pageEvenTopMargin>
+      <pageEvenBottomMargin>0.787403</pageEvenBottomMargin>
+      <pageOddTopMargin>0.393701</pageOddTopMargin>
+      <pageOddBottomMargin>0.787403</pageOddBottomMargin>
       <frameSystemDistance>13</frameSystemDistance>
       <measureSpacing>1.14</measureSpacing>
       <voltaPosAbove x="0" y="-2"/>

--- a/mtest/libmscore/compat114/textline-ref.mscx
+++ b/mtest/libmscore/compat114/textline-ref.mscx
@@ -5,6 +5,13 @@
     <currentLayer>0</currentLayer>
     <Division>480</Division>
     <Style>
+      <pagePrintableWidth>7.48032</pagePrintableWidth>
+      <pageEvenLeftMargin>0.393701</pageEvenLeftMargin>
+      <pageOddLeftMargin>0.393701</pageOddLeftMargin>
+      <pageEvenTopMargin>0.393701</pageEvenTopMargin>
+      <pageEvenBottomMargin>0.787403</pageEvenBottomMargin>
+      <pageOddTopMargin>0.393701</pageOddTopMargin>
+      <pageOddBottomMargin>0.787403</pageOddBottomMargin>
       <frameSystemDistance>13</frameSystemDistance>
       <measureSpacing>1.14</measureSpacing>
       <voltaPosAbove x="0" y="-2"/>

--- a/mtest/libmscore/compat114/textstyles-ref.mscx
+++ b/mtest/libmscore/compat114/textstyles-ref.mscx
@@ -5,6 +5,14 @@
     <currentLayer>0</currentLayer>
     <Division>480</Division>
     <Style>
+      <pagePrintableWidth>7.48032</pagePrintableWidth>
+      <pageEvenLeftMargin>0.393701</pageEvenLeftMargin>
+      <pageOddLeftMargin>0.393701</pageOddLeftMargin>
+      <pageEvenTopMargin>0.393701</pageEvenTopMargin>
+      <pageEvenBottomMargin>0.787403</pageEvenBottomMargin>
+      <pageOddTopMargin>0.393701</pageOddTopMargin>
+      <pageOddBottomMargin>0.787403</pageOddBottomMargin>
+      <pageTwosided>0</pageTwosided>
       <staffUpperBorder>6</staffUpperBorder>
       <staffLowerBorder>2</staffLowerBorder>
       <minSystemDistance>9.5</minSystemDistance>

--- a/mtest/libmscore/compat114/title-ref.mscx
+++ b/mtest/libmscore/compat114/title-ref.mscx
@@ -5,6 +5,13 @@
     <currentLayer>0</currentLayer>
     <Division>480</Division>
     <Style>
+      <pagePrintableWidth>7.48032</pagePrintableWidth>
+      <pageEvenLeftMargin>0.393701</pageEvenLeftMargin>
+      <pageOddLeftMargin>0.393701</pageOddLeftMargin>
+      <pageEvenTopMargin>0.393701</pageEvenTopMargin>
+      <pageEvenBottomMargin>0.787403</pageEvenBottomMargin>
+      <pageOddTopMargin>0.393701</pageOddTopMargin>
+      <pageOddBottomMargin>0.787403</pageOddBottomMargin>
       <frameSystemDistance>13</frameSystemDistance>
       <measureSpacing>1.14</measureSpacing>
       <voltaPosAbove x="0" y="-2"/>

--- a/mtest/libmscore/compat114/tremolo2notes-ref.mscx
+++ b/mtest/libmscore/compat114/tremolo2notes-ref.mscx
@@ -5,6 +5,13 @@
     <currentLayer>0</currentLayer>
     <Division>480</Division>
     <Style>
+      <pagePrintableWidth>7.48032</pagePrintableWidth>
+      <pageEvenLeftMargin>0.393701</pageEvenLeftMargin>
+      <pageOddLeftMargin>0.393701</pageOddLeftMargin>
+      <pageEvenTopMargin>0.393701</pageEvenTopMargin>
+      <pageEvenBottomMargin>0.787403</pageEvenBottomMargin>
+      <pageOddTopMargin>0.393701</pageOddTopMargin>
+      <pageOddBottomMargin>0.787403</pageOddBottomMargin>
       <frameSystemDistance>13</frameSystemDistance>
       <measureSpacing>1.14</measureSpacing>
       <voltaPosAbove x="0" y="-2"/>

--- a/mtest/libmscore/compat114/tuplets-ref.mscx
+++ b/mtest/libmscore/compat114/tuplets-ref.mscx
@@ -5,6 +5,13 @@
     <currentLayer>0</currentLayer>
     <Division>480</Division>
     <Style>
+      <pagePrintableWidth>7.48032</pagePrintableWidth>
+      <pageEvenLeftMargin>0.393701</pageEvenLeftMargin>
+      <pageOddLeftMargin>0.393701</pageOddLeftMargin>
+      <pageEvenTopMargin>0.393701</pageEvenTopMargin>
+      <pageEvenBottomMargin>0.787403</pageEvenBottomMargin>
+      <pageOddTopMargin>0.393701</pageOddTopMargin>
+      <pageOddBottomMargin>0.787403</pageOddBottomMargin>
       <frameSystemDistance>13</frameSystemDistance>
       <measureSpacing>1.14</measureSpacing>
       <voltaPosAbove x="0" y="-2"/>

--- a/mtest/libmscore/compat114/tuplets_1-ref.mscx
+++ b/mtest/libmscore/compat114/tuplets_1-ref.mscx
@@ -5,6 +5,13 @@
     <currentLayer>0</currentLayer>
     <Division>480</Division>
     <Style>
+      <pagePrintableWidth>7.48032</pagePrintableWidth>
+      <pageEvenLeftMargin>0.393701</pageEvenLeftMargin>
+      <pageOddLeftMargin>0.393701</pageOddLeftMargin>
+      <pageEvenTopMargin>0.393701</pageEvenTopMargin>
+      <pageEvenBottomMargin>0.787403</pageEvenBottomMargin>
+      <pageOddTopMargin>0.393701</pageOddTopMargin>
+      <pageOddBottomMargin>0.787403</pageOddBottomMargin>
       <frameSystemDistance>13</frameSystemDistance>
       <measureSpacing>1.14</measureSpacing>
       <voltaPosAbove x="0" y="-2"/>

--- a/mtest/libmscore/compat114/tuplets_2-ref.mscx
+++ b/mtest/libmscore/compat114/tuplets_2-ref.mscx
@@ -5,6 +5,13 @@
     <currentLayer>0</currentLayer>
     <Division>480</Division>
     <Style>
+      <pagePrintableWidth>7.48032</pagePrintableWidth>
+      <pageEvenLeftMargin>0.393701</pageEvenLeftMargin>
+      <pageOddLeftMargin>0.393701</pageOddLeftMargin>
+      <pageEvenTopMargin>0.393701</pageEvenTopMargin>
+      <pageEvenBottomMargin>0.787403</pageEvenBottomMargin>
+      <pageOddTopMargin>0.393701</pageOddTopMargin>
+      <pageOddBottomMargin>0.787403</pageOddBottomMargin>
       <frameSystemDistance>13</frameSystemDistance>
       <measureSpacing>1.14</measureSpacing>
       <voltaPosAbove x="0" y="-2"/>


### PR DESCRIPTION
Including page number offset

This fixes a regression vs. MuseScore 2.x

Resolves: [musescore#27546](https://github.com/musescore/MuseScore/issues/27546)

'Backport' of #27464 (actually this PR here existed first)