### PR TITLE
Fix GH#10653: Crash while converting to whole note

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -1369,6 +1369,7 @@ void Score::changeCRlen(ChordRest* cr, const Fraction& dstF, bool fillWithRest)
             return;
 
       deselectAll();
+      Element* elementToSelect = nullptr;
 
       Fraction tick  = cr->tick();
       Fraction f     = dstF;
@@ -1412,7 +1413,7 @@ void Score::changeCRlen(ChordRest* cr, const Fraction& dstF, bool fillWithRest)
                         r = setRest(tick, track, f2, false, tuplet);
                         }
                   if (first) {
-                        select(r, SelectType::SINGLE, 0);
+                        elementToSelect = r;
                         first = false;
                         }
                   tick += actualTicks(f2, tuplet, timeStretch);
@@ -1424,7 +1425,7 @@ void Score::changeCRlen(ChordRest* cr, const Fraction& dstF, bool fillWithRest)
 
                   if (((tick - etick).ticks() % dList[0].ticks().ticks()) == 0) {
                         for (TDuration du : dList) {
-                              Chord* cc;
+                              Chord* cc = nullptr;
                               if (oc) {
                                     cc = oc;
                                     oc = addChord(tick, du, cc, true, tuplet);
@@ -1435,10 +1436,7 @@ void Score::changeCRlen(ChordRest* cr, const Fraction& dstF, bool fillWithRest)
                                     oc = cc;
                                     }
                               if (oc && first) {
-                                    if (!selElement)
-                                          select(oc, SelectType::SINGLE, 0);
-                                    else
-                                          select(selElement, SelectType::SINGLE, 0);
+                                    elementToSelect = selElement ? selElement : oc;
                                     first = false;
                                     }
                               if (oc)
@@ -1458,9 +1456,7 @@ void Score::changeCRlen(ChordRest* cr, const Fraction& dstF, bool fillWithRest)
                                     oc = cc;
                                     }
                               if (first) {
-                                    // select(oc, SelectType::SINGLE, 0);
-                                    if (selElement)
-                                          select(selElement, SelectType::SINGLE, 0);
+                                    elementToSelect = selElement;
                                     first = false;
                                     }
                               tick += oc->actualTicks();
@@ -1477,6 +1473,11 @@ void Score::changeCRlen(ChordRest* cr, const Fraction& dstF, bool fillWithRest)
                   break;
             }
       connectTies();
+
+      if (elementToSelect) {
+            if (containsElement(elementToSelect))
+                  select(elementToSelect, SelectType::SINGLE, 0);
+            }
       }
 
 //---------------------------------------------------------

--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -1604,6 +1604,21 @@ void Score::removeElement(Element* element)
             }
       }
 
+bool Score::containsElement(const Element* element) const
+      {
+      if (!element)
+            return false;
+
+      Element* parent = element->parent();
+      if (!parent)
+            return false;
+
+      QVector<Element*> elements;
+      parent->scanElements(&elements, collectElements, false /*all*/);
+
+      return std::find(elements.cbegin(), elements.cend(), element) != elements.cend();
+      }
+
 //---------------------------------------------------------
 //   firstMeasure
 //---------------------------------------------------------

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -730,6 +730,7 @@ class Score : public QObject, public ScoreElement {
 
       void addElement(Element*);
       void removeElement(Element*);
+      bool containsElement(const Element* element) const;
 
       Note* addPitch(NoteVal&, bool addFlag, InputState* externalInputState = nullptr);
       void addPitch(int pitch, bool addFlag, bool insert);


### PR DESCRIPTION
Backport of #13183

Altarnative/addition to #10654's backport, 2c59015

Resolves: [#10653](https://www.github.com/musescore/MuseScore/issues/10653)

Probably isn't needed here at all...