### PR TITLE
About Dialog: provide compile-time Date & Time stamp

### DIFF
--- a/global/settings/types/preferencekeys.h
+++ b/global/settings/types/preferencekeys.h
@@ -154,6 +154,7 @@
 #define PREF_UI_APP_SHOWSTATUSBAR                           "ui/application/showStatusBar"
 #define PREF_UI_APP_USENATIVEDIALOGS                        "ui/application/useNativeDialogs"
 #define PREF_UI_APP_USENEWWIZARD                            "ui/application/useNewWizard"
+#define PREF_UI_APP_BUILD_DATE_ISO                          "ui/application/build/date/isoFormat"
 #define PREF_UI_PIANO_HIGHLIGHTCOLOR                        "ui/piano/highlightColor"
 #define PREF_UI_PIANO_SHOWPITCHHELP                         "ui/piano/showPitchHelp"
 #define PREF_UI_SCORE_NOTE_DROPCOLOR                        "ui/score/note/dropColor"

--- a/mscore/aboutbox.ui
+++ b/mscore/aboutbox.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>446</width>
+    <width>459</width>
     <height>282</height>
    </rect>
   </property>
@@ -143,6 +143,13 @@
             </spacer>
            </item>
           </layout>
+         </item>
+         <item>
+          <widget class="QLabel" name="buildDateLabel">
+           <property name="text">
+            <string notr="true">Build date:</string>
+           </property>
+          </widget>
          </item>
          <item>
           <widget class="QLabel" name="copyrightLabel">

--- a/mscore/musescoredialogs.cpp
+++ b/mscore/musescoredialogs.cpp
@@ -158,6 +158,24 @@ AboutBoxDialog::AboutBoxDialog()
       revisionLabel->setText(tr("Revision: %1").arg(revision));
       setWindowFlags(this->windowFlags() & ~Qt::WindowContextHelpButtonHint);
 
+      auto compilerDateISO = []() -> std::string {
+            // Store __DATE__ in ISO 8601 format ( e.g. 2025-04-20 )
+            int month, day, year;
+            char buffer[10];
+            static const char monthNames[] = "JanFebMarAprMayJunJulAugSepOctNovDec";
+            sscanf(__DATE__, "%s %d %d", buffer, &day, &year);
+            month = ((strstr(monthNames, buffer) - monthNames) / 3) + 1;
+            sprintf(buffer, "%d-%02d-%02d", year, month, day);
+            return std::string(buffer);
+            };
+
+      std::string dateTime;
+      dateTime += preferences.getBool(PREF_UI_APP_BUILD_DATE_ISO) ? compilerDateISO() : __DATE__;
+      dateTime += " ";
+      dateTime += __TIME__;
+
+      buildDateLabel->setText(tr("Build date: %1").arg(dateTime.c_str()));
+
       QString visitAndDonateString;
 #if !defined(FOR_WINSTORE) && 0
       visitAndDonateString = tr("Visit %1 for new versions and more information.\nGet %2help%3 with the program or %4contribute%5 to its development.")

--- a/mscore/preferences.cpp
+++ b/mscore/preferences.cpp
@@ -259,6 +259,7 @@ void Preferences::init(bool storeInMemoryOnly)
             {PREF_UI_APP_USENATIVEDIALOGS,                         new BoolPreference(false)},
 #endif
             {PREF_UI_APP_USENEWWIZARD,                             new BoolPreference(true)},
+            {PREF_UI_APP_BUILD_DATE_ISO,                           new BoolPreference(true)},
             {PREF_UI_PIANO_HIGHLIGHTCOLOR,                         new ColorPreference(QColor(0x0065BF))},
             {PREF_UI_PIANO_SHOWPITCHHELP,                          new BoolPreference(true)},
             {PREF_UI_SCORE_NOTE_DROPCOLOR,                         new ColorPreference(QColor(0x0065BF))},


### PR DESCRIPTION
Resolves: #904 

Uses ISO format 202x.mm.dd via some c style buffering stuff on preprocessor `__DATE__` and then applies the `__TIME__ `stamp to it. At least it's one way to go about doing this

![image](https://github.com/user-attachments/assets/9296b5a1-08db-48d4-85e6-4c4fd513fa85)

I'm not 100% sure that the months are all represented the same way on Mac/X11/Win, so this might not be "universal" enough, but worth testing. Works on my Linux machine. If worse came to worse, you could do away with the ISO format and just use a raw `__DATE__` without the conversion