### PR TITLE
Fix MusicXML incompatibility with MuseScore 3.6.2 (and older)

### DIFF
--- a/global/settings/types/preferencekeys.h
+++ b/global/settings/types/preferencekeys.h
@@ -65,6 +65,7 @@
 #define PREF_EXPORT_MUSICXML_EXPORTBREAKS                   "export/musicXML/exportBreaks"
 #define PREF_EXPORT_MUSICXML_EXPORTLAYOUT                   "export/musicXML/exportLayout"
 #define PREF_EXPORT_MUSICXML_EXPORTINVISIBLEELEMENTS        "export/musicXML/exportInvisibleElements"
+#define PREF_EXPORT_MUSICXML_MU3_COMPAT                     "export/musicXML/exportMu3Compat"
 #define PREF_EXPORT_PDF_DPI                                 "export/pdf/dpi"
 #define PREF_EXPORT_PNG_RESOLUTION                          "export/png/resolution"
 #define PREF_EXPORT_PNG_USETRANSPARENCY                     "export/png/useTransparency"

--- a/importexport/musicxml/exportxml.cpp
+++ b/importexport/musicxml/exportxml.cpp
@@ -3184,7 +3184,7 @@ static void writeBreathMark(const Breath* const breath, XmlWriter& xml, Notation
                   tagName += " placement=\"above\"";
                   }
 
-            if (breath->isCaesura() && (type.isEmpty()/* || preferences.getBool(PREF_EXPORT_MUSICXML_MU3_COMPAT)*/)) {
+            if (breath->isCaesura() && (type.isEmpty() || preferences.getBool(PREF_EXPORT_MUSICXML_MU3_COMPAT))) {
                   // for backwards compatibility, as 3.6.2 and earlier can't import those special caesuras,
                   // but reports corruption on all subsequent measures and imports them entirely empty.
                   xml.tagE(tagName);
@@ -4351,7 +4351,7 @@ static void directionTag(XmlWriter& xml, Attributes& attr, Element const* const 
                         }
                   } // if (pel && ...
 
-            if (el->systemFlag())
+            if (el->systemFlag() && !preferences.getBool(PREF_EXPORT_MUSICXML_MU3_COMPAT))
                   tagname += " system=\"only-top\"";
             }
       xml.stag(tagname);
@@ -4623,7 +4623,7 @@ void ExportMusicXml::tempoText(TempoText const* const text, int staff)
       */
       _attr.doAttr(_xml, false);
       QString tempoAttrs = QString("direction placement=\"%1\"").arg(text->placement() == Placement::BELOW ? "below" : "above");
-      if (text->systemFlag())
+      if (text->systemFlag() && !preferences.getBool(PREF_EXPORT_MUSICXML_MU3_COMPAT))
             tempoAttrs += QString(" system=\"%1\"").arg(text->isLinked() ? "also-top" : "only-top");
       _xml.stag(tempoAttrs);
       wordsMetronome(_xml, _score, text, offset);

--- a/mscore/preferences.cpp
+++ b/mscore/preferences.cpp
@@ -168,6 +168,7 @@ void Preferences::init(bool storeInMemoryOnly)
             {PREF_EXPORT_MUSICXML_EXPORTBREAKS,                    new EnumPreference(QVariant::fromValue(MusicxmlExportBreaks::ALL), false)},
             {PREF_EXPORT_MUSICXML_EXPORTLAYOUT,                    new BoolPreference(true, false)},
             {PREF_EXPORT_MUSICXML_EXPORTINVISIBLEELEMENTS,         new BoolPreference(false)},
+            {PREF_EXPORT_MUSICXML_MU3_COMPAT,                      new BoolPreference(false)},
             {PREF_EXPORT_PDF_DPI,                                  new IntPreference(DPI, false)},
             {PREF_EXPORT_PNG_RESOLUTION,                           new DoublePreference(DPI, false)},
             {PREF_EXPORT_PNG_USETRANSPARENCY,                      new BoolPreference(true, false)},


### PR DESCRIPTION
Backport of #27764 (and a formerly omitted part of #20370's 3rd commit)

Resolves: [musescore#27763](https://www.github.com/musescore/MuseScore/issues/27763)