### PR TITLE
Fix GH#971: Can't create 6-lets on measures rests in 9/8

### DIFF
--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -4486,9 +4486,10 @@ void ScoreView::setControlCursorVisible(bool v)
 
 void ScoreView::cmdTuplet(int n, ChordRest* cr)
       {
-      if ((cr->durationType() < TDuration(TDuration::DurationType::V_512TH) && cr->durationType() != TDuration(TDuration::DurationType::V_MEASURE))
-          || (cr->durationType() < TDuration(TDuration::DurationType::V_256TH) && n > 3)
-          || (cr->durationType() < TDuration(TDuration::DurationType::V_128TH) && n > 7)
+      if (cr->durationType() != TDuration(TDuration::DurationType::V_MEASURE) &&
+          ((cr->durationType() < TDuration(TDuration::DurationType::V_512TH)) ||
+           (cr->durationType() < TDuration(TDuration::DurationType::V_256TH) && n > 3) ||
+           (cr->durationType() < TDuration(TDuration::DurationType::V_128TH) && n > 7))
           ) {
             mscore->noteTooShortForTupletDialog();
             return;


### PR DESCRIPTION
There's more combinations that didn't work though, basically any full measure rest in any time signature

Resolves: #971