### PR TITLE
Add .midi extension support to macOS Info.plist

### DIFF
--- a/build/MacOSXBundleInfo.plist.in
+++ b/build/MacOSXBundleInfo.plist.in
@@ -249,6 +249,7 @@
 			<key>CFBundleTypeExtensions</key>
 			<array>
 				<string>mid</string>
+				<string>midi</string>
 			</array>
 			<key>CFBundleTypeMIMETypes</key>
 			<array>


### PR DESCRIPTION
Backport of #28767

Resolves: [musescore#28744](https://wwwgithub.com/musescore/MuseScore/issues/28744)