### PR TITLE
Slur Layout: Fix slur locking up after copy/paste under certain circumstances

### DIFF
--- a/libmscore/slur.cpp
+++ b/libmscore/slur.cpp
@@ -469,7 +469,6 @@ bool SlurSegment::isEdited() const
 Slur::Slur(const Slur& s)
    : SlurTie(s)
       {
-      _sourceStemArrangement = s._sourceStemArrangement;
       }
 
 //---------------------------------------------------------
@@ -948,16 +947,6 @@ Slur::Slur(Score* s)
       }
 
 //---------------------------------------------------------
-//   calcStemArrangement
-//---------------------------------------------------------
-
-int calcStemArrangement(Element* start, Element* end)
-      {
-      return (start && toChord(start)->stem() && toChord(start)->stem()->up() ? 2 : 0)
-           + (end && end->isChord() && toChord(end)->stem() && toChord(end)->stem()->up() ? 4 : 0);
-      }
-
-//---------------------------------------------------------
 //   write
 //---------------------------------------------------------
 
@@ -970,8 +959,6 @@ void Slur::write(XmlWriter& xml) const
       if (!xml.canWrite(this))
             return;
       xml.stag(this);
-      if (xml.clipboardmode())
-            xml.tag("stemArr", calcStemArrangement(startElement(), endElement()));
       SlurTie::writeProperties(xml);
       xml.etag();
       }
@@ -983,10 +970,6 @@ void Slur::write(XmlWriter& xml) const
 bool Slur::readProperties(XmlReader& e)
       {
       const QStringRef& tag(e.name());
-      if (tag == "stemArr") {
-            _sourceStemArrangement = e.readInt();
-            return true;
-            }
       return SlurTie::readProperties(e);
       }
 
@@ -1077,15 +1060,6 @@ SpannerSegment* Slur::layoutSystem(System* system)
                               }
                         Chord* c1 = startCR()->isChord() ? toChord(startCR()) : 0;
                         Chord* c2 = endCR()->isChord()   ? toChord(endCR())   : 0;
-
-                        if (_sourceStemArrangement != -1) {
-                              if (_sourceStemArrangement != calcStemArrangement(c1, c2)) {
-                                    // copy & paste from incompatible stem arrangement, so reset bezier points
-                                    for (int g = 0; g < (int)Ms::Grip::GRIPS; ++g) {
-                                          slurSegment->ups((Ms::Grip)g) = UP();
-                                          }
-                                    }
-                              }
 
                         if (c1 && c1->beam() && c1->beam()->cross()) {
                               // TODO: stem direction is not finalized, so we cannot use it here

--- a/libmscore/slur.h
+++ b/libmscore/slur.h
@@ -54,7 +54,6 @@ class SlurSegment final : public SlurTieSegment {
 class Slur final : public SlurTie {
 
       void slurPosChord(SlurPos*);
-      int _sourceStemArrangement = -1;
 
    public:
       Slur(Score* = 0);

--- a/mtest/libmscore/selectionfilter/selectionfilter6-base-ref.xml
+++ b/mtest/libmscore/selectionfilter/selectionfilter6-base-ref.xml
@@ -8,7 +8,6 @@
       <durationType>quarter</durationType>
       <Spanner type="Slur">
         <Slur>
-          <stemArr>0</stemArr>
           <ticks_f>1/4</ticks_f>
           </Slur>
         <next>
@@ -40,7 +39,6 @@
       <durationType>quarter</durationType>
       <Spanner type="Slur">
         <Slur>
-          <stemArr>0</stemArr>
           <ticks_f>1/4</ticks_f>
           </Slur>
         <next>


### PR DESCRIPTION
Resolves: #985 

Testing appreciated. Seems to work, but not sure if there are any problemos in other circumstances. Small change though, so it should be safe: updating the _sourceStemArrangment to be what was calculated 