### PR TITLE
Fix GH#987: CI nightly build failures for Linux

### DIFF
--- a/build/ci/linux/package.sh
+++ b/build/ci/linux/package.sh
@@ -73,8 +73,8 @@ if [ "$PACKTYPE" == "appimage" ]; then
     # To enable automatic updates for AppImages, set UPDATE_INFORMATION according to
     # https://github.com/AppImage/AppImageSpec/blob/master/draft.md#update-information
     case "${BUILD_MODE}" in
-    "stable")  export UPDATE_INFORMATION="gh-releases-zsync|musescore|MuseScore|latest|MuseScore-*${PACKARCH}.AppImage.zsync";;
-    "nightly") export UPDATE_INFORMATION="zsync|https://ftp.osuosl.org/pub/musescore-nightlies/linux/${MAJOR_VERSION}x/nightly/MuseScoreNightly-latest-${PACKARCH}.AppImage.zsync";;
+    #"stable")  export UPDATE_INFORMATION="gh-releases-zsync|musescore|MuseScore|latest|MuseScore-*${PACKARCH}.AppImage.zsync";;
+    #"nightly") export UPDATE_INFORMATION="zsync|https://ftp.osuosl.org/pub/musescore-nightlies/linux/${MAJOR_VERSION}x/nightly/MuseScoreNightly-latest-${PACKARCH}.AppImage.zsync";;
     *) unset UPDATE_INFORMATION;; # disable updates for other build modes
     esac
 


### PR DESCRIPTION
Resolves: #987

by a) bringing make_upimage.sh closer to upstream/master's
and b) disabling `UPDATE_INFORMATION` for "stable" and "nigthly" builds, as it doesn't work at all but also the mechanism behind it doesn't apply to my fork (like not uploading artifacts to OSUOSL).

I don't quite understand though why this seems to have worked or at least didn't cause build failures up to some 3 weeks ago.