### PR TITLE
Fix split, join and rewrite measure tie bugs

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -1517,87 +1517,64 @@ void Score::connectTies(bool silent)
       if (!m)
             return;
 
+      auto connectTiesForChord = [silent](Chord* c, Segment* s, int track) -> void {
+            for (Note* n : c->notes()) {
+                  // connect a tie without end note
+                  Tie* tie = n->tieFor();
+                  if (tie && !tie->endNote()) {
+                        Note* nnote;
+                        nnote = searchTieNote(n);
+                        if (nnote == 0) {
+                              if (!silent) {
+                                    qDebug("next note at %d track %d for tie not found", s->tick().ticks(), track);
+                                    delete tie;
+                                    n->setTieFor(0);
+                                    }
+                              }
+                        else {
+                              tie->setEndNote(nnote);
+                              nnote->setTieBack(tie);
+                              }
+                        }
+                  // connect a glissando without initial note (old glissando format)
+                  for (Spanner* spanner : n->spannerBack()) {
+                        if (spanner->isGlissando() && !spanner->startElement()) {
+                              Note* initialNote = Glissando::guessInitialNote(n->chord());
+                              n->removeSpannerBack(spanner);
+                              if (initialNote) {
+                                    spanner->setStartElement(initialNote);
+                                    spanner->setEndElement(n);
+                                    spanner->setTick(initialNote->chord()->tick());
+                                    spanner->setTick2(n->chord()->tick());
+                                    spanner->setTrack(n->track());
+                                    spanner->setTrack2(n->track());
+                                    spanner->setParent(initialNote);
+                                    initialNote->add(spanner);
+                                    }
+                              else
+                                    delete spanner;
+                              }
+                        }
+                  // spanner with no end element can happen during copy/paste
+                  for (Spanner* spanner : n->spannerFor()) {
+                        if (spanner->endElement() == nullptr) {
+                              n->removeSpannerFor(spanner);
+                              delete spanner;
+                              }
+                        }
+                  }
+            };
+
       SegmentType st = SegmentType::ChordRest;
       for (Segment* s = m->first(st); s; s = s->next1(st)) {
-            for (int i = 0; i < tracks; ++i) {
-                  Element* e = s->element(i);
+            for (int track = 0; track < tracks; ++track) {
+                  Element* e = s->element(track);
                   if (e == 0 || !e->isChord())
                         continue;
                   Chord* c = toChord(e);
-                  for (Note* n : c->notes()) {
-                        // connect a tie without end note
-                        Tie* tie = n->tieFor();
-                        if (tie && !tie->endNote()) {
-                              Note* nnote;
-                              if (_mscVersion <= 114)
-                                    nnote = searchTieNote114(n);
-                              else
-                                    nnote = searchTieNote(n);
-                              if (nnote == 0) {
-                                    if (!silent) {
-                                          qDebug("next note at %d track %d for tie not found (version %d)", s->tick().ticks(), i, _mscVersion);
-                                          delete tie;
-                                          n->setTieFor(0);
-                                          }
-                                    }
-                              else {
-                                    tie->setEndNote(nnote);
-                                    nnote->setTieBack(tie);
-                                    }
-                              }
-                        // connect a glissando without initial note (old glissando format)
-                        for (Spanner* spanner : n->spannerBack()) {
-                              if (spanner->isGlissando() && !spanner->startElement()) {
-                                    Note* initialNote = Glissando::guessInitialNote(n->chord());
-                                    n->removeSpannerBack(spanner);
-                                    if (initialNote) {
-                                          spanner->setStartElement(initialNote);
-                                          spanner->setEndElement(n);
-                                          spanner->setTick(initialNote->chord()->tick());
-                                          spanner->setTick2(n->chord()->tick());
-                                          spanner->setTrack(n->track());
-                                          spanner->setTrack2(n->track());
-                                          spanner->setParent(initialNote);
-                                          initialNote->add(spanner);
-                                          }
-                                    else {
-                                          delete spanner;
-                                          }
-                                    }
-                              }
-                        // spanner with no end element can happen during copy/paste
-                        for (Spanner* spanner : n->spannerFor()) {
-                              if (spanner->endElement() == nullptr) {
-                                    n->removeSpannerFor(spanner);
-                                    delete spanner;
-                                    }
-                              }
-                        }
-#if 0    // chords are set in tremolo->layout()
-                  // connect two note tremolos
-                  Tremolo* tremolo = c->tremolo();
-                  if (tremolo && tremolo->twoNotes() && !tremolo->chord2()) {
-                        for (Segment* ls = s->next1(st); ls; ls = ls->next1(st)) {
-                              Element* element = ls->element(i);
-                              if (!element)
-                                    continue;
-                              if (!element->isChord())
-                                    qDebug("cannot connect tremolo");
-                              else {
-                                    Chord* nc = toChord(element);
-                                    nc->setTremolo(tremolo);
-                                    tremolo->setChords(c, nc);
-                                    // cross-measure tremolos are not supported
-                                    // but can accidentally result from copy & paste
-                                    // remove them now
-                                    if (c->measure() != nc->measure())
-                                          c->remove(tremolo);
-                                    }
-                              break;
-                              }
-                        }
-#endif
+                  connectTiesForChord(c, s, track);
                   for (Chord* gc : qAsConst(c->graceNotes())) {
+                        connectTiesForChord(gc, s, track);
                         for (Note* n : gc->notes()) {
                               // spanner with no end element apparently happens when reading some 206 files
                               // (and possibly in other situations too)

--- a/libmscore/range.h
+++ b/libmscore/range.h
@@ -25,6 +25,7 @@ class Spanner;
 class ScoreRange;
 class ChordRest;
 class Score;
+class Tie;
 
 //---------------------------------------------------------
 //   TrackList
@@ -74,6 +75,7 @@ struct Annotation {
 
 class ScoreRange {
       QList<TrackList*> tracks;
+      QVector<Tie*> startTies;
       Segment* _first;
       Segment* _last;
 

--- a/libmscore/utils.cpp
+++ b/libmscore/utils.cpp
@@ -788,7 +788,7 @@ Note* searchTieNote(Note* note)
             // try to tie to next grace note
 
             int index = note->chord()->graceIndex();
-            for (Chord* c : chord->graceNotes()) {
+            for (Chord*& c : chord->graceNotes()) {
                   if (c->graceIndex() == index + 1) {
                         note2 = c->findNote(note->pitch());
                         if (note2) {
@@ -862,43 +862,6 @@ Note* searchTieNote(Note* note)
                                     }
                               else
                                     ++idx2;
-                              }
-                        }
-                  }
-            if (note2)
-                  break;
-            }
-      return note2;
-      }
-
-//---------------------------------------------------------
-//   searchTieNote114
-//    search Note to tie to "note", tie to next note in
-//    same voice
-//---------------------------------------------------------
-
-Note* searchTieNote114(Note* note)
-      {
-      Note* note2  = 0;
-      Chord* chord = note->chord();
-      Segment* seg = chord->segment();
-      Part* part   = chord->part();
-      int strack   = part->staves()->front()->idx() * VOICES;
-      int etrack   = strack + part->staves()->size() * VOICES;
-
-      while ((seg = seg->next1(SegmentType::ChordRest))) {
-            for (int track = strack; track < etrack; ++track) {
-                  Element* e = seg->element(track);
-                  if (e == 0 || (!e->isChord()) || (e->track() != chord->track()))
-                        continue;
-                  Chord* c = toChord(e);
-                  int staffIdx = c->staffIdx() + c->staffMove();
-                  if (staffIdx != chord->staffIdx() + chord->staffMove())  // cannot happen?
-                        continue;
-                  for (Note* n : c->notes()) {
-                        if (n->pitch() == note->pitch()) {
-                              if (note2 == 0 || c->track() == chord->track())
-                                    note2 = n;
                               }
                         }
                   }

--- a/libmscore/utils.h
+++ b/libmscore/utils.h
@@ -76,7 +76,6 @@ extern Segment* nextSeg1(Segment* s, int& track);
 extern Segment* prevSeg1(Segment* seg, int& track);
 
 extern Note* searchTieNote(Note* note);
-extern Note* searchTieNote114(Note* note);
 
 extern int absStep(int pitch);
 extern int absStep(int tpc, int pitch);


### PR DESCRIPTION
Backport of #28470 and fix clazy warnings

Resolves: [musescore#27888](https://www.github.com/musescore/MuseScore/issues/27888)
Resolves: [musescore#28029](https://github.com/www.musescore/MuseScore/issues/28029)

Not sure we need this (as it seems to fix Mu4 regressions, although ISTR to have seens such an issue in Mu3 too just recently) nor whether or how to port the unit tests