### PR TITLE
Fix GH#28047: Ignore invisible fret diagrams when placing chord symbol

### DIFF
--- a/libmscore/fret.cpp
+++ b/libmscore/fret.cpp
@@ -560,7 +560,7 @@ void FretDiagram::layout()
 
       if (_harmony)
             _harmony->layout();
-      if (_harmony && _harmony->autoplace() && _harmony->parent()) {
+      if (_harmony && _harmony->autoplace() && _harmony->parent() && _harmony->parent()->visible()) {
             Segment* s = toSegment(parent());
             Measure* m = s->measure();
             int si     = staffIdx();
@@ -1366,6 +1366,14 @@ QVariant FretDiagram::propertyDefault(Pid pid) const
                   }
             }
       return Element::propertyDefault(pid);
+      }
+
+void FretDiagram::setVisible(bool f)
+      {
+      Element::setVisible(f);
+
+      if (_harmony && _harmony->isStyled(Pid::OFFSET))
+            _harmony->resetProperty(Pid::OFFSET);
       }
 
 void FretDiagram::setTrack(int val)

--- a/libmscore/fret.cpp
+++ b/libmscore/fret.cpp
@@ -1219,6 +1219,10 @@ void FretDiagram::add(Element* e)
       if (e->isHarmony()) {
             _harmony = toHarmony(e);
             _harmony->setTrack(track());
+
+            //! on the same lavel as diagram
+            _harmony->setZ(z());
+
             if (_harmony->propertyFlags(Pid::OFFSET) == PropertyFlags::STYLED)
                   _harmony->resetProperty(Pid::OFFSET);
             _harmony->setProperty(Pid::ALIGN, int(Align::HCENTER | Align::TOP));

--- a/libmscore/fret.h
+++ b/libmscore/fret.h
@@ -237,6 +237,8 @@ class FretDiagram final : public Element {
       bool setProperty(Pid propertyId, const QVariant&) override;
       QVariant propertyDefault(Pid) const override;
 
+      void setVisible(bool f) override;
+
       void setTrack(int val) override;
 
       qreal userMag() const         { return _userMag;   }

--- a/libmscore/harmony.cpp
+++ b/libmscore/harmony.cpp
@@ -1378,6 +1378,7 @@ QPoint Harmony::calculateBoundingRect()
       const qreal        standardNoteWidth = symWidth(SymId::noteheadBlack);
       qreal              newx = 0.0;
       qreal              newy = 0.0;
+      const bool alignToFretDiagram = fd && fd->visible();
 
       if (textList.empty()) {
             TextBase::layout1();
@@ -1387,7 +1388,7 @@ QPoint Harmony::calculateBoundingRect()
 
             qreal xx = 0.0;
             qreal yy = 0.0;
-            if (fd) {
+            if (alignToFretDiagram) {
                   if (align() & Align::RIGHT)
                         xx = fd->width() / 2.0;
                   yy = rypos();
@@ -1417,7 +1418,7 @@ QPoint Harmony::calculateBoundingRect()
                   yy = -bb.height() - bb.y();
 
             qreal xx = -bb.x(); // Align::LEFT
-            if (fd) {
+            if (alignToFretDiagram) {
                   if (align() & Align::RIGHT)
                         xx = fd->bbox().width() - bb.width();
                   else if (align() & Align::HCENTER)
@@ -1454,6 +1455,10 @@ QPoint Harmony::calculateBoundingRect()
                         }
 
                   }
+            }
+      if (fd && !fd->visible()) {
+            // Translate to base position around note
+            newx -= fd->pos().x();
             }
       return QPoint(newx, newy);
       }

--- a/libmscore/harmony.cpp
+++ b/libmscore/harmony.cpp
@@ -2233,11 +2233,13 @@ QVariant Harmony::propertyDefault(Pid id) const
                         }
                   }
                   break;
-            case Pid::OFFSET:
-                  if (parent() && parent()->isFretDiagram()) {
+            case Pid::OFFSET: {
+                  const FretDiagram* fd = parent() && parent()->isFretDiagram() ? toFretDiagram(parent()) : nullptr;
+                  if (fd && fd->visible()) {
                         v = QVariant(QPointF(0.0, 0.0));
                         break;
                         }
+                  }
                   // fall-through
             default:
                   v = TextBase::propertyDefault(id);
@@ -2253,7 +2255,8 @@ QVariant Harmony::propertyDefault(Pid id) const
 Sid Harmony::getPropertyStyle(Pid pid) const
       {
       if (pid == Pid::OFFSET) {
-            if (parent() && parent()->isFretDiagram())
+            const FretDiagram* fd = parent() && parent()->isFretDiagram() ? toFretDiagram(parent()) : nullptr;
+            if (fd && fd->visible())
                   return Sid::NOSTYLE;
             else if (tid() == Tid::HARMONY_A)
                   return placeAbove() ? Sid::chordSymbolAPosAbove : Sid::chordSymbolAPosBelow;

--- a/libmscore/harmony.cpp
+++ b/libmscore/harmony.cpp
@@ -1406,7 +1406,7 @@ QPoint Harmony::calculateBoundingRect()
             }
       else {
             QRectF bb;
-            for (TextSegment* ts : qAsConst(textList))
+            for (TextSegment*& ts : textList)
                   bb |= ts->tightBoundingRect().translated(ts->x, ts->y);
 
             qreal yy = -bb.y();  // Align::TOP
@@ -1437,7 +1437,7 @@ QPoint Harmony::calculateBoundingRect()
                   newy = ypos;
                   }
 
-            for (TextSegment* ts : qAsConst(textList))
+            for (TextSegment*& ts : textList)
                   ts->offset = QPointF(xx, yy);
 
             setbbox(bb.translated(xx, yy));

--- a/libmscore/harmony.cpp
+++ b/libmscore/harmony.cpp
@@ -2237,11 +2237,13 @@ QVariant Harmony::propertyDefault(Pid id) const
                         }
                   }
                   break;
-            case Pid::OFFSET:
-                  if (parent() && parent()->isFretDiagram()) {
+            case Pid::OFFSET: {
+                  const FretDiagram* fd = parent() && parent()->isFretDiagram() ? toFretDiagram(parent()) : nullptr;
+                  if (fd && fd->visible()) {
                         v = QVariant(QPointF(0.0, 0.0));
                         break;
                         }
+                  }
                   // fall-through
             default:
                   v = TextBase::propertyDefault(id);
@@ -2257,7 +2259,8 @@ QVariant Harmony::propertyDefault(Pid id) const
 Sid Harmony::getPropertyStyle(Pid pid) const
       {
       if (pid == Pid::OFFSET) {
-            if (parent() && parent()->isFretDiagram())
+            const FretDiagram* fd = parent() && parent()->isFretDiagram() ? toFretDiagram(parent()) : nullptr;
+            if (fd && fd->visible())
                   return Sid::NOSTYLE;
             else if (tid() == Tid::HARMONY_A)
                   return placeAbove() ? Sid::chordSymbolAPosAbove : Sid::chordSymbolAPosBelow;

--- a/libmscore/harmony.cpp
+++ b/libmscore/harmony.cpp
@@ -1382,6 +1382,7 @@ QPoint Harmony::calculateBoundingRect()
       const qreal        standardNoteWidth = symWidth(SymId::noteheadBlack);
       qreal              newx = 0.0;
       qreal              newy = 0.0;
+      const bool alignToFretDiagram = fd && fd->visible();
 
       if (textList.empty()) {
             TextBase::layout1();
@@ -1391,7 +1392,7 @@ QPoint Harmony::calculateBoundingRect()
 
             qreal xx = 0.0;
             qreal yy = 0.0;
-            if (fd) {
+            if (alignToFretDiagram) {
                   if (align() & Align::RIGHT)
                         xx = fd->width() / 2.0;
                   yy = rypos();
@@ -1421,7 +1422,7 @@ QPoint Harmony::calculateBoundingRect()
                   yy = -bb.height() - bb.y();
 
             qreal xx = -bb.x(); // Align::LEFT
-            if (fd) {
+            if (alignToFretDiagram) {
                   if (align() & Align::RIGHT)
                         xx = fd->bbox().width() - bb.width();
                   else if (align() & Align::HCENTER)
@@ -1458,6 +1459,10 @@ QPoint Harmony::calculateBoundingRect()
                         }
 
                   }
+            }
+      if (fd && !fd->visible()) {
+            // Translate to base position around note
+            newx -= fd->pos().x();
             }
       return QPoint(newx, newy);
       }

--- a/libmscore/harmony.cpp
+++ b/libmscore/harmony.cpp
@@ -662,7 +662,7 @@ static int convertNote(const QString& s, NoteSpellingType noteSpelling, NoteCase
 //   parseHarmony
 //    determine root and bass tpc & case
 //    compare body of chordname against chord list
-//    return true if chord is recognized
+//    return nullptr if chord is not recognized
 //---------------------------------------------------------
 
 const ChordDescription* Harmony::parseHarmony(const QString& ss, int* root, int* base, bool syntaxOnly)
@@ -670,7 +670,7 @@ const ChordDescription* Harmony::parseHarmony(const QString& ss, int* root, int*
       _id = -1;
       if (_parsedForm) {
             delete _parsedForm;
-            _parsedForm = 0;
+            _parsedForm = nullptr;
             }
       _textName.clear();
       bool useLiteral = false;
@@ -682,7 +682,7 @@ const ChordDescription* Harmony::parseHarmony(const QString& ss, int* root, int*
             _textName = ss;
             *root = Tpc::TPC_INVALID;
             *base = Tpc::TPC_INVALID;
-            return 0;
+            return nullptr;
             }
 
       // pre-process for parentheses
@@ -694,7 +694,7 @@ const ChordDescription* Harmony::parseHarmony(const QString& ss, int* root, int*
       if (_leftParen || _rightParen)
             s = s.simplified();     // in case of spaces inside parentheses
       if (s.isEmpty())
-            return 0;
+            return nullptr;
 
       // pre-process for lower case minor chords
       bool preferMinor;
@@ -725,7 +725,7 @@ const ChordDescription* Harmony::parseHarmony(const QString& ss, int* root, int*
                         qDebug("failed <%s>", qPrintable(ss));
                         _userName = s;
                         _textName = s;
-                        return 0;
+                        return nullptr;
                         }
                   }
             *root = r;
@@ -750,7 +750,7 @@ const ChordDescription* Harmony::parseHarmony(const QString& ss, int* root, int*
 
       _userName = s;
       const ChordList* cl = score()->style().chordList();
-      const ChordDescription* cd = 0;
+      const ChordDescription* cd = nullptr;
       if (useLiteral)
             cd = descr(s);
       else {

--- a/libmscore/harmony.cpp
+++ b/libmscore/harmony.cpp
@@ -1410,7 +1410,7 @@ QPoint Harmony::calculateBoundingRect()
             }
       else {
             QRectF bb;
-            for (TextSegment* ts : qAsConst(textList))
+            for (TextSegment*& ts : textList)
                   bb |= ts->tightBoundingRect().translated(ts->x, ts->y);
 
             qreal yy = -bb.y();  // Align::TOP
@@ -1441,7 +1441,7 @@ QPoint Harmony::calculateBoundingRect()
                   newy = ypos;
                   }
 
-            for (TextSegment* ts : qAsConst(textList))
+            for (TextSegment*& ts : textList)
                   ts->offset = QPointF(xx, yy);
 
             setbbox(bb.translated(xx, yy));

--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -4802,6 +4802,20 @@ void Score::layoutSystemElements(System* system, LayoutContext& lc)
             //-------------------------------------------------------------
 
             layoutHarmonies(sl);
+#if 0
+            for (Harmony* harmony : elementsToLayout.harmonies) {
+                FretDiagram* fdParent = harmony->parent()->isFretDiagram() ? toFretDiagram(harmony->parent()) : nullptr;
+                if (fdParent && !fdParent->visible()) {
+                    harmony->mutldata()->moveY(-fdParent->pos().y());
+                }
+                Autoplace::autoplaceSegmentElement(harmony, harmony->mutldata());
+            }
+
+            if (ctx.conf().styleB(Sid::verticallyAlignChordSymbols)) {
+                std::vector<EngravingItem*> harmonyItems(elementsToLayout.harmonies.begin(), elementsToLayout.harmonies.end());
+                AlignmentLayout::alignItemsForSystem(harmonyItems, system);
+            }
+#endif
             alignHarmonies(system, sl, false, styleP(Sid::maxFretShiftAbove), styleP(Sid::maxFretShiftBelow));
             }
 

--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -4837,6 +4837,20 @@ void Score::layoutSystemElements(System* system, LayoutContext& lc)
             //-------------------------------------------------------------
 
             layoutHarmonies(sl);
+#if 0
+            for (Harmony* harmony : elementsToLayout.harmonies) {
+                FretDiagram* fdParent = harmony->parent()->isFretDiagram() ? toFretDiagram(harmony->parent()) : nullptr;
+                if (fdParent && !fdParent->visible()) {
+                    harmony->mutldata()->moveY(-fdParent->pos().y());
+                }
+                Autoplace::autoplaceSegmentElement(harmony, harmony->mutldata());
+            }
+
+            if (ctx.conf().styleB(Sid::verticallyAlignChordSymbols)) {
+                std::vector<EngravingItem*> harmonyItems(elementsToLayout.harmonies.begin(), elementsToLayout.harmonies.end());
+                AlignmentLayout::alignItemsForSystem(harmonyItems, system);
+            }
+#endif
             alignHarmonies(system, sl, false, styleP(Sid::maxFretShiftAbove), styleP(Sid::maxFretShiftBelow));
             }
 

--- a/libmscore/rest.cpp
+++ b/libmscore/rest.cpp
@@ -76,7 +76,7 @@ Rest::Rest(const Rest& r, bool link)
       dotline  = r.dotline;
       _mmWidth = r._mmWidth;
       for (NoteDot* dot : r._dots)
-            add(new NoteDot(*dot));
+            Rest::add(new NoteDot(*dot));
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
Backport of #29084, commit 1 (and #29368 and #29132?) and #29639/#30026

Resolves: [musescore#28047](https://www.github.com/musescore/MuseScore/issues/28047)
Resolves: [musescore#29338](https://www.github.com/musescore/MuseScore/issues/29338)
Resolves: [musescore#29409](https://www.github.com/musescore/MuseScore/issues/29409)