### PR TITLE
Remove handling of `Excerpt` tag

### DIFF
--- a/libmscore/mscore.cpp
+++ b/libmscore/mscore.cpp
@@ -97,7 +97,6 @@ int     MScore::division    = 480; // 3840;   // pulses per quarter note (PPQ) /
 int     MScore::sampleRate  = 44100;
 int     MScore::mtcType;
 
-bool    MScore::noExcerpts = false;
 bool    MScore::noImages = false;
 bool    MScore::pdfPrinting = false;
 bool    MScore::svgPrinting = false;

--- a/libmscore/mscore.h
+++ b/libmscore/mscore.h
@@ -377,7 +377,6 @@ class MScore {
       static bool saveTemplateMode;
       static bool noGui;
 
-      static bool noExcerpts;
       static bool noImages;
 
       static bool pdfPrinting;

--- a/libmscore/read114.cpp
+++ b/libmscore/read114.cpp
@@ -2989,14 +2989,10 @@ Score::FileError MasterScore::read114(XmlReader& e)
                         }
                   }
             else if (tag == "Excerpt") {
-                  if (MScore::noExcerpts)
-                        e.skipCurrentElement();
-                  else {
-                        Excerpt* ex = new Excerpt(this);
-                        ex->read(e);
-                        _excerpts.append(ex);
+                  Excerpt* ex = new Excerpt(this);
+                  ex->read(e);
+                  _excerpts.append(ex);
                         }
-                  }
             else if (tag == "Beam") {
                   Beam* beam = new Beam(this);
                   beam->read(e);
@@ -3237,16 +3233,16 @@ Score::FileError MasterScore::read114(XmlReader& e)
       QList<Excerpt*> readExcerpts;
       readExcerpts.swap(_excerpts);
       for (Excerpt* excerpt : readExcerpts) {
-            if (excerpt->parts().isEmpty())           // ignore empty parts
+            if (excerpt->parts().isEmpty()) {           // ignore empty parts
+                  delete excerpt;
                   continue;
-            if (!excerpt->parts().isEmpty()) {
-                  _excerpts.push_back(excerpt);
-                  Score* nscore = new Score(this);
-                  nscore->setEnableVerticalSpread(false);
-                  excerpt->setPartScore(nscore);
-                  nscore->style().set(Sid::createMultiMeasureRests, true);
-                  Excerpt::createExcerpt(excerpt);
                   }
+            _excerpts.push_back(excerpt);
+            Score* nscore = new Score(this);
+            nscore->setEnableVerticalSpread(false);
+            excerpt->setPartScore(nscore);
+            nscore->style().set(Sid::createMultiMeasureRests, true);
+            Excerpt::createExcerpt(excerpt);
             }
 
       // volta offsets in older scores are hardcoded to be relative to a voltaY of -2.0sp

--- a/libmscore/read206.cpp
+++ b/libmscore/read206.cpp
@@ -3588,41 +3588,22 @@ static bool readScore(Score* score, XmlReader& e)
                         }
                   score->addSpanner(s);
                   }
-            else if (tag == "Excerpt") {
-                  if (MScore::noExcerpts)
-                        e.skipCurrentElement();
-                  else {
-                        if (score->isMaster()) {
-                              Excerpt* ex = new Excerpt(static_cast<MasterScore*>(score));
-                              ex->read(e);
-                              score->excerpts().append(ex);
-                              }
-                        else {
-                              qDebug("read206: readScore(): part cannot have parts");
-                              e.skipCurrentElement();
-                              }
-                        }
-                  }
             else if (tag == "Score") {          // recursion
-                  if (MScore::noExcerpts)
-                        e.skipCurrentElement();
-                  else {
-                        e.tracks().clear();
-                        e.clearUserTextStyles();
-                        MasterScore* m = score->masterScore();
-                        Score* s       = new Score(m, MScore::baseStyle());
-                        int defaultsVersion = m->style().defaultStyleVersion();
-                        s->setStyle(*MStyle::resolveStyleDefaults(defaultsVersion));
-                        s->style().setDefaultStyleVersion(defaultsVersion);
-                        s->setEnableVerticalSpread(false);
-                        Excerpt* ex = new Excerpt(m);
+                  e.tracks().clear();
+                  e.clearUserTextStyles();
+                  MasterScore* m = score->masterScore();
+                  Score* s       = new Score(m, MScore::baseStyle());
+                  int defaultsVersion = m->style().defaultStyleVersion();
+                  s->setStyle(*MStyle::resolveStyleDefaults(defaultsVersion));
+                  s->style().setDefaultStyleVersion(defaultsVersion);
+                  s->setEnableVerticalSpread(false);
+                  Excerpt* ex = new Excerpt(m);
 
-                        ex->setPartScore(s);
-                        e.setLastMeasure(nullptr);
-                        readScore(s, e);
-                        ex->setTracks(e.tracks());
-                        m->addExcerpt(ex);
-                        }
+                  ex->setPartScore(s);
+                  e.setLastMeasure(nullptr);
+                  readScore(s, e);
+                  ex->setTracks(e.tracks());
+                  m->addExcerpt(ex);
                   }
             else if (tag == "PageList")
                   e.skipCurrentElement();

--- a/libmscore/read302.cpp
+++ b/libmscore/read302.cpp
@@ -166,21 +166,6 @@ bool Score::read(XmlReader& e)
                   s->read(e);
                   addSpanner(s);
                   }
-            else if (tag == "Excerpt") {
-                  if (MScore::noExcerpts)
-                        e.skipCurrentElement();
-                  else {
-                        if (isMaster()) {
-                              Excerpt* ex = new Excerpt(static_cast<MasterScore*>(this));
-                              ex->read(e);
-                              excerpts().append(ex);
-                              }
-                        else {
-                              qDebug("Score::read(): part cannot have parts");
-                              e.skipCurrentElement();
-                              }
-                        }
-                  }
             else if (e.name() == "Tracklist") {
                   int strack = e.intAttribute("sTrack",   -1);
                   int dtrack = e.intAttribute("dstTrack", -1);
@@ -189,24 +174,20 @@ bool Score::read(XmlReader& e)
                   e.skipCurrentElement();
                   }
             else if (tag == "Score") {          // recursion
-                  if (MScore::noExcerpts)
-                        e.skipCurrentElement();
-                  else {
-                        e.tracks().clear();     // ???
-                        MasterScore* m = masterScore();
-                        Score* s       = new Score(m, MScore::baseStyle());
-                        int defaultsVersion = m->style().defaultStyleVersion();
-                        s->setStyle(*MStyle::resolveStyleDefaults(defaultsVersion));
-                        s->style().setDefaultStyleVersion(defaultsVersion);
-                        Excerpt* ex    = new Excerpt(m);
+                  e.tracks().clear();     // ???
+                  MasterScore* m = masterScore();
+                  Score* s       = new Score(m, MScore::baseStyle());
+                  int defaultsVersion = m->style().defaultStyleVersion();
+                  s->setStyle(*MStyle::resolveStyleDefaults(defaultsVersion));
+                  s->style().setDefaultStyleVersion(defaultsVersion);
+                  Excerpt* ex    = new Excerpt(m);
 
-                        ex->setPartScore(s);
-                        e.setLastMeasure(nullptr);
-                        s->read(e);
-                        s->linkMeasures(m);
-                        ex->setTracks(e.tracks());
-                        m->addExcerpt(ex);
-                        }
+                  ex->setPartScore(s);
+                  e.setLastMeasure(nullptr);
+                  s->read(e);
+                  s->linkMeasures(m);
+                  ex->setTracks(e.tracks());
+                  m->addExcerpt(ex);
                   }
             else if (tag == "name") {
                   QString n = e.readElementText();


### PR DESCRIPTION
This tag is never written by MuseScore > 1.3, so we don't need to read it either.

Very partial backport of #29303, only commit 1 and parts of commit 3