### PR TITLE
Fix GH#27582: Fix removing timeSig from mmRests

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -936,6 +936,13 @@ void Score::cmdRemoveTimeSig(TimeSig* ts)
       if (rs)
             rScore->undoRemoveElement(rs);
 
+      // Measure can contain mmRest that can have its own timesig. We need to delete it too
+      if (rm->mmRest()) {
+            Segment* mmRestTimesig = rm->mmRest()->findSegment(SegmentType::TimeSig, s->tick());
+            if (mmRestTimesig)
+                  rScore->undoRemoveElement(mmRestTimesig);
+            }
+
       Measure* pm = m->prevMeasure();
       Fraction ns(pm ? pm->timesig() : Fraction(4,4));
 


### PR DESCRIPTION
Backport of #29726

Resolves: [musescore#27582](https://www.github.com/musescore/MuseScore/issues/27582)