### PR TITLE
Fix tuplet crash

### DIFF
--- a/importexport/musicxml/importmxmlpass2.cpp
+++ b/importexport/musicxml/importmxmlpass2.cpp
@@ -6704,11 +6704,11 @@ Note* MusicXMLParserPass2::note(const QString& partId,
                               // create a new tuplet
                               handleTupletStart(cr, tuplet, actualNotes, normalNotes, notations.tupletDesc());
                               }
-                        if (tupletAction & MxmlTupletFlag::ADD_CHORD) {
+                        if (tuplet && tupletAction & MxmlTupletFlag::ADD_CHORD) {
                               cr->setTuplet(tuplet);
                               tuplet->add(cr);
                               }
-                        if (tupletAction & MxmlTupletFlag::STOP_CURRENT) {
+                        if (tuplet && tupletAction & MxmlTupletFlag::STOP_CURRENT) {
                               if (missingCurr.isValid() && missingCurr > Fraction(0, 1)) {
                                     qDebug("add missing %s to current tuplet", qPrintable(missingCurr.print()));
                                     const int track = msTrack + msVoice;


### PR DESCRIPTION
Backport of #29957

Resolves: [musescore#29921](https://www.github.com/musescore/MuseScore/issues/29921)

The crash is caused by a nested tuplet. MuseScore's MusicXML import does not support these and never has (see  [musescore#22671](https://www.github.com/musescore/MuseScore/issues/22671)). This PR prevents the crash, though the resulting file will be corrupted. At least there is then a chance of tidying it up.
