### PR TITLE
Add 2nd zoom shortcuts

### DIFF
--- a/mscore/data/shortcuts-Mac.xml
+++ b/mscore/data/shortcuts-Mac.xml
@@ -733,10 +733,12 @@
   <SC>
     <key>zoomin</key>
     <seq>Ctrl++</seq>
+    <seq>Ctrl+=</seq>
     </SC>
   <SC>
     <key>zoomout</key>
     <seq>Ctrl+-</seq>
+    <seq>Ctrl+Shift+-</seq>
     </SC>
   <SC>
     <key>zoom100</key>

--- a/mscore/data/shortcuts.xml
+++ b/mscore/data/shortcuts.xml
@@ -733,10 +733,12 @@
   <SC>
     <key>zoomin</key>
     <seq>Ctrl++</seq>
+    <seq>Ctrl+=</seq>
     </SC>
   <SC>
     <key>zoomout</key>
     <seq>Ctrl+-</seq>
+    <seq>Ctrl+Shift+-</seq>
     </SC>
   <SC>
     <key>zoom100</key>

--- a/mscore/data/shortcuts_AZERTY.xml
+++ b/mscore/data/shortcuts_AZERTY.xml
@@ -770,10 +770,12 @@
   <SC>
     <key>zoomin</key>
     <seq>Ctrl++</seq>
+    <seq>Ctrl+=</seq>
     </SC>
   <SC>
     <key>zoomout</key>
     <seq>Ctrl+-</seq>
+    <seq>Ctrl+Shift+-</seq>
     </SC>
   <SC>
     <key>zoom100</key>


### PR DESCRIPTION
Backport of #29927

Resolves: [musescore#27086](https://www.github.com/musescore/MuseScore/issues/27086)

Add 2nd zoom shortcuts. See discussion in earlier closed PR #29589