### PR TITLE
[MusicXML] minor improvements for symbols

### DIFF
--- a/importexport/musicxml/exportxml.cpp
+++ b/importexport/musicxml/exportxml.cpp
@@ -5580,12 +5580,15 @@ static void directionMarker(XmlWriter& xml, const Marker* const m, const std::ve
       {
       const Marker::Type mtp = getEffectiveMarkerType(m, jumps);
       QString words;
+      QString smufl;
       QString type;
       QString sound;
 
       switch (mtp) {
-            case Marker::Type::CODA:
             case Marker::Type::VARCODA:
+                  smufl = "codaSquare";
+                  // FALLTHROUGH
+            case Marker::Type::CODA:
             case Marker::Type::CODETTA:
                   type = "coda";
                   if (m->label().isEmpty())
@@ -5593,8 +5596,10 @@ static void directionMarker(XmlWriter& xml, const Marker* const m, const std::ve
                   else
                         sound = "coda=\"" + m->label() + "\"";
                   break;
-            case Marker::Type::SEGNO:
             case Marker::Type::VARSEGNO:
+                  smufl = "segnoSerpent1";
+                  // FALLTHROUGH
+            case Marker::Type::SEGNO:
                   type = "segno";
                   if (m->label().isEmpty())
                         sound = "segno=\"1\"";
@@ -5628,6 +5633,8 @@ static void directionMarker(XmlWriter& xml, const Marker* const m, const std::ve
             xml.stag("direction-type");
             QString attrs = color2xml(m);
             attrs += positioningAttributes(m);
+            if (!smufl.isEmpty())
+                  attrs += QString(" smufl=\"%1\"").arg(smufl);
             if (!type.isEmpty())
                   xml.tagE(type + attrs);
             if (!words.isEmpty())

--- a/importexport/musicxml/importmxmlpass2.cpp
+++ b/importexport/musicxml/importmxmlpass2.cpp
@@ -3760,11 +3760,23 @@ void MusicXMLParserDirection::directionType(QList<MusicXmlSpannerDesc>& starts,
             else if (_e.name() == "wedge")
                   wedge(type, n, starts, stops);
             else if (_e.name() == "coda") {
-                  _wordsText += "<sym>coda</sym>";
+                  const QString smufl = _e.attributes().value("smufl").toString();
+                  if (!smufl.isEmpty())
+                        _wordsText += "<sym>" + smufl + "</sym>";
+                  else
+                        _wordsText += "<sym>coda</sym>";
                   _e.skipCurrentElement();
                   }
             else if (_e.name() == "segno") {
-                  _wordsText += "<sym>segno</sym>";
+                  const QString smufl = _e.attributes().value("smufl").toString();
+                  if (!smufl.isEmpty())
+                      _wordsText += "<sym>" + smufl + "</sym>";
+                  else
+                      _wordsText += "<sym>segno</sym>";
+                  _e.skipCurrentElement();
+                        }
+            else if (_e.name() == "eyeglasses") {
+                  _wordsText += "<sym>miscEyeglasses</sym>";
                   _e.skipCurrentElement();
                   }
             else if (_e.name() == "symbol") {

--- a/libmscore/realizedharmony.cpp
+++ b/libmscore/realizedharmony.cpp
@@ -161,7 +161,6 @@ const RealizedHarmony::PitchMap RealizedHarmony::generateNotes(int rootTpc, int 
                   break;
             case Voicing::FOUR_NOTE:
             case Voicing::SIX_NOTE:
-                  //FALLTHROUGH
                   {
                   //four/six note voicing, drop every other note
                   PitchMap relIntervals = getIntervals(rootTpc, literal);


### PR DESCRIPTION
Adds import for `eyeglasses` element and extends import and export for special coda and segno glyphs.

Backport of #298923
