### PR TITLE
Don't use Finale's braces

### DIFF
--- a/libmscore/bracket.cpp
+++ b/libmscore/bracket.cpp
@@ -80,7 +80,9 @@ qreal Bracket::width() const
       qreal w;
       switch (bracketType()) {
             case BracketType::BRACE:
-                  if (score()->styleSt(Sid::musicalSymbolFont) == "Emmentaler" || score()->styleSt(Sid::musicalSymbolFont) == "Gonville")
+                  if (score()->styleSt(Sid::musicalSymbolFont) == "Emmentaler" ||    // prevent fallback to Bravura
+                      score()->styleSt(Sid::musicalSymbolFont) == "Gonville" ||      // prevent fallback to Bravura
+                      score()->styleSt(Sid::musicalSymbolFont).startsWith("Finale")) // just like Finale itself, don't use Finale's glyphs
                         w = score()->styleP(Sid::akkoladeWidth) + score()->styleP(Sid::akkoladeBarDistance);
                   else
                         w = (symWidth(_braceSymbol) * _magx) + score()->styleP(Sid::akkoladeBarDistance);
@@ -112,8 +114,9 @@ void Bracket::setStaffSpan(int a, int b)
       _lastStaff = b;
 
       if (bracketType() == BracketType::BRACE &&
-         score()->styleSt(Sid::musicalSymbolFont) != "Emmentaler" && score()->styleSt(Sid::musicalSymbolFont) != "Gonville")
-            {
+          score()->styleSt(Sid::musicalSymbolFont) != "Emmentaler" &&       // prevent fallback to Bravura
+          score()->styleSt(Sid::musicalSymbolFont) != "Gonville" &&         // prevent fallback to Bravura
+          !score()->styleSt(Sid::musicalSymbolFont).startsWith("Finale")) { // just like Finale itself, don't use Finale's glyphs
             int v = _lastStaff - _firstStaff + 1;
 
             // if staves inner staves are hidden, decrease span
@@ -152,7 +155,9 @@ void Bracket::layout()
       _shape.clear();
       switch (bracketType()) {
             case BracketType::BRACE: {
-                  if (score()->styleSt(Sid::musicalSymbolFont) == "Emmentaler" || score()->styleSt(Sid::musicalSymbolFont) == "Gonville") {
+                  if (score()->styleSt(Sid::musicalSymbolFont) == "Emmentaler" ||      // prevent fallback to Bravura
+                      score()->styleSt(Sid::musicalSymbolFont) == "Gonville" ||        // prevent fallback to Bravura
+                      score()->styleSt(Sid::musicalSymbolFont).startsWith("Finale")) { // just like Finale itself, don't use Finale's glyphs
                         _braceSymbol = SymId::noSym;
                         qreal w = score()->styleP(Sid::akkoladeWidth);
 

--- a/libmscore/bracket.cpp
+++ b/libmscore/bracket.cpp
@@ -155,9 +155,8 @@ void Bracket::layout()
       _shape.clear();
       switch (bracketType()) {
             case BracketType::BRACE: {
-                  if (score()->styleSt(Sid::musicalSymbolFont) == "Emmentaler" ||      // prevent fallback to Bravura
-                      score()->styleSt(Sid::musicalSymbolFont) == "Gonville" ||        // prevent fallback to Bravura
-                      score()->styleSt(Sid::musicalSymbolFont).startsWith("Finale")) { // just like Finale itself, don't use Finale's glyphs
+                  if (score()->styleSt(Sid::musicalSymbolFont) == "Emmentaler" || score()->styleSt(Sid::musicalSymbolFont) == "Gonville") {
+                        // prevent fallback to Bravura
                         _braceSymbol = SymId::noSym;
                         qreal w = score()->styleP(Sid::akkoladeWidth);
 
@@ -185,6 +184,26 @@ void Bracket::layout()
                         path.cubicTo(XM( -360), YM( 4304), XM(  -8), YM( 3192), XM(   -8), YM( 2048)); // c 0
                         path.cubicTo(XM( -  8), YM( 1320), XM(-136), YM(  624), XM( -512), YM(    0)); // c 1
                         path.cubicTo(XM( -136), YM( -624), XM(  -8), YM(-1320), XM(   -8), YM(-2048)); // c 0*/
+                        setbbox(path.boundingRect());
+                        _shape.add(bbox());
+                        }
+                  else if (score()->styleSt(Sid::musicalSymbolFont).startsWith("Finale")) {
+                        // just like Finale itself, don't use Finale's glyphs, not Finale Maestro's at least
+                        // for the others prevent fallback to Bravura
+                        _braceSymbol = SymId::noSym;
+                        qreal w = score()->styleP(Sid::akkoladeWidth);
+                        qreal y = std::min(h2 * 0.125, spatium());
+
+#define XF(a) w * a
+#define YF(a, b) a + h2 + (b * y)
+
+                        path.moveTo(XF(0), YF(0, 0));
+                        path.cubicTo(XF(2.25), YF(0, 2), XF(-1.5), YF(h2, -4), XF(0.98), YF(h2, 0));
+                        path.lineTo(XF(1), YF(h2, -0.3));
+                        path.cubicTo(XF(-0.5), YF(h2, -3), XF(2.25), YF(0, 1.5), XF(0.15), YF(0, 0));
+                        path.cubicTo(XF(2.25), YF(0, -1.5), XF(-0.5), YF(-h2, 3), XF(1), YF(-h2, 0.3));
+                        path.lineTo(XF(0.98), YF(-h2, 0));
+                        path.cubicTo(XF(-1.5), YF(-h2, 4), XF(2.25), YF(0, -2), XF(0), YF(0, 0));
                         setbbox(path.boundingRect());
                         _shape.add(bbox());
                         }


### PR DESCRIPTION
just like Finale itself does not (see https://usermanuals.finalemusic.com/Finale2012Mac/Content/Finale/IDD_PIANOBRACESOPTIONS.htm), instead use the same 'hand-drawn' method as is used for Emmentaler and Gonville (which don't contain these glyphs, so would otherwise fall back to using Bravura's).

Resolves: [#383399](https://musescore.org/en/node/383399)

Also makes them respond to Format > Style > System > System Brackets > Brace thickness.

Resolves: [#383402](https://musescore.org/de/node/383402)