### PR TITLE
Update CI Mac builds to use macOS 14 runners

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -249,7 +249,7 @@ jobs:
   #       # Use same OS versions as used in real build workflows.
   #       os:
   #       - ubuntu-22.04 # linux_x64, backend, linux_arm32, linux_arm64
-  #       - macos-13
+  #       - macos-14 # macos-14-large ?
   #       - windows-2025 # windows_x64, windows_portable
   #   runs-on: ${{ matrix.os }}
   #   steps:

--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -150,7 +150,7 @@ jobs:
     if: contains(needs.plan.outputs.platforms, 'macos_apple')
     needs:
       - plan
-    runs-on: macos-13
+    runs-on: macos-14
     steps:
     - name: Cancel Previous Runs
       uses: styfle/cancel-workflow-action@0.12.1
@@ -239,7 +239,7 @@ jobs:
     if: contains(needs.plan.outputs.platforms, 'macos_intel')
     needs:
       - plan
-    runs-on: macos-13
+    runs-on: macos-14 # macos-14-large for Intel?
     steps:
     - name: Cancel Previous Runs
       uses: styfle/cancel-workflow-action@0.12.1

--- a/.github/workflows/translate_lupdate_tx_push.yml
+++ b/.github/workflows/translate_lupdate_tx_push.yml
@@ -12,7 +12,7 @@ on:
         default: 'on'
 jobs:
   lupdate:
-    runs-on: macos-11
+    runs-on: macos-14
     steps:
     - name: Clone repository
       uses: actions/checkout@v5

--- a/build/ci/macos/setup.sh
+++ b/build/ci/macos/setup.sh
@@ -19,9 +19,11 @@ export MACOSX_DEPLOYMENT_TARGET=10.13
 
 if [ "$BUILD_ARCH" == "Apple" ]
 then
-    curl -LO https://github.com/macports/macports-base/releases/download/v2.10.7/MacPorts-2.10.7-13-Ventura.pkg
-    sudo installer -verbose -pkg MacPorts-2.10.7-13-Ventura.pkg -target /
-    rm MacPorts-2.10.7-13-Ventura.pkg
+    MACPORTSVERSION=2.11.5
+    MACOSVERSION=14-Sonoma
+    curl -LO https://github.com/macports/macports-base/releases/download/v${MACPORTSVERSION}/MacPorts-${MACPORTSVERSION}-${MACOSVERSION}.pkg
+    sudo installer -verbose -pkg MacPorts-${MACPORTSVERSION}-${MACOSVERSION}.pkg -target /
+    rm MacPorts-${MACPORTSVERSION}-${MACOSVERSION}.pkg
     export PATH="/opt/local/bin:/opt/local/sbin:$PATH"
     echo -e "universal_target ${MACOSX_DEPLOYMENT_TARGET}\nmacosx_deployment_target ${MACOSX_DEPLOYMENT_TARGET}\nmacosx_sdk_version ${MACOSX_DEPLOYMENT_TARGET}" | sudo tee -a /opt/local/etc/macports/macports.conf
     sudo port install git pkgconfig cmake


### PR DESCRIPTION
as the macOS13 runner will be retired by December 4th, 2025