### PR TITLE
Fix: Use ChordRest staffIdx for midi input when selection is singular

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -2280,7 +2280,8 @@ bool Score::processMidiInput()
             if (!noteEntryMode()
                         || entryMethod == NoteEntryMethod::REALTIME_AUTO
                         || entryMethod == NoteEntryMethod::REALTIME_MANUAL) {
-                  int staffIdx = selection().staffStart();
+                  ChordRest* cr = selection().cr();
+                  int staffIdx = cr ? cr->staffIdx() : selection().staffStart();
                   Part* p;
                   if (staffIdx < 0 || staffIdx >= nstaves())
                         p = staff(0)->part();


### PR DESCRIPTION
Resolves: #1068 