### PR TITLE
Fix GH#16644: Repeat last note/chord after inputting a rest

### DIFF
--- a/libmscore/segment.h
+++ b/libmscore/segment.h
@@ -103,6 +103,8 @@ class Segment final : public Element {
       Segment* next1MM(SegmentType) const;
 
       Segment* prev1() const;
+      Segment* prev1WithElemsOnStaff(int staffIdx, SegmentType segType = SegmentType::ChordRest) const;
+      Segment* prev1WithElemsOnTrack(int trackIdx, SegmentType segType = SegmentType::ChordRest) const;
       Segment* prev1enabled() const;
       Segment* prev1MM() const;
       Segment* prev1MMenabled() const;


### PR DESCRIPTION
Backport of #30319 plus fixing clazy warnings and indentation

Resolves: [musescore#16644](https://www.github.com/musescore/MuseScore/issues/16644)