### PR TITLE
Fix drop down for view scaling not changing size of score

### DIFF
--- a/awl/poslabel.h
+++ b/awl/poslabel.h
@@ -40,7 +40,7 @@ class PosLabel : public QLabel {
       QSize sizeHint() const;
 
    public slots:
-      void setValue(const Ms::Pos&);
+      void setValue(const Pos&);
 
    public:
       PosLabel(QWidget* parent = 0);

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -580,7 +580,7 @@ class Score : public QObject, public ScoreElement {
       inline virtual const Movements* movements() const;
 
    signals:
-      void posChanged(Ms::POS, unsigned);
+      void posChanged(POS, unsigned);
       void playlistChanged();
 
    public:

--- a/mscore/cloud/loginmanager_p.h
+++ b/mscore/cloud/loginmanager_p.h
@@ -100,7 +100,7 @@ class ApiRequest : public QObject
       QNetworkRequest buildRequest() const;
 
    signals:
-      void replyFinished(Ms::ApiRequest*);
+      void replyFinished(ApiRequest*);
 
    public:
       ApiRequest(QObject* parent = nullptr)

--- a/mscore/debugger/debugger.h
+++ b/mscore/debugger/debugger.h
@@ -108,7 +108,7 @@ class Debugger : public AbstractDialog, public Ui::DebuggerBase {
       void layout();
 
    public slots:
-      void setElement(Ms::Element*);
+      void setElement(Element*);
       void reloadClicked();
 
    public:
@@ -159,7 +159,7 @@ class ShowElementBase : public QWidget {
       QVBoxLayout* layout;
 
    signals:
-      void elementChanged(Ms::Element*);
+      void elementChanged(Element*);
 
    public:
       ShowElementBase();
@@ -417,7 +417,7 @@ class TupletView : public ShowElementBase {
       Ui::TupletBase tb;
 
    signals:
-      void itemClicked(Ms::Element*);
+      void itemClicked(Element*);
       void scoreChanged();
 
    private slots:

--- a/mscore/drumroll.h
+++ b/mscore/drumroll.h
@@ -68,7 +68,7 @@ class DrumrollEditor : public QMainWindow {
       void cmd(QAction*);
 
    public slots:
-      void changeSelection(Ms::SelState);
+      void changeSelection(SelState);
 
    public:
       DrumrollEditor(QWidget* parent = 0);

--- a/mscore/drumview.h
+++ b/mscore/drumview.h
@@ -71,7 +71,7 @@ class DrumView : public QGraphicsView {
       void magChanged(double, double);
       void xposChanged(int);
       void pitchChanged(int);
-      void posChanged(const Ms::Pos&);
+      void posChanged(const Pos&);
 
    public slots:
       void moveLocator(int);

--- a/mscore/editstyle.h
+++ b/mscore/editstyle.h
@@ -84,7 +84,7 @@ class EditStyle : public AbstractDialog, private Ui::EditStyleBase {
    private slots:
       void selectChordDescriptionFile();
       void setChordStyle(bool);
-      void enableStyleWidget(const Ms::MSQE_Sid::Sid idx, bool enable);
+      void enableStyleWidget(const Sid idx, bool enable);
       void enableVerticalSpreadClicked(bool);
       void disableVerticalSpreadClicked(bool);
       void toggleHeaderOddEven(bool);
@@ -99,8 +99,8 @@ class EditStyle : public AbstractDialog, private Ui::EditStyleBase {
       void resetStyleValue(int);
       void valueChanged(int);
       void textStyleChanged(int);
-      void resetTextStyle(Ms::Pid);
-      void textStyleValueChanged(Ms::Pid, QVariant);
+      void resetTextStyle(Pid);
+      void textStyleValueChanged(Pid, QVariant);
       void on_comboFBFont_currentIndexChanged(int index);
       void on_buttonTogglePagelist_clicked();
       void on_resetStylesButton_clicked();

--- a/mscore/exampleview.h
+++ b/mscore/exampleview.h
@@ -56,8 +56,8 @@ class ExampleView : public QFrame, public MuseScoreView {
       virtual QSize sizeHint() const override;
 
    signals:
-      void noteClicked(Ms::Note*);
-      void beamPropertyDropped(Ms::Chord*, Ms::Icon*);
+      void noteClicked(Note*);
+      void beamPropertyDropped(Chord*, Icon*);
 
    public:
       ExampleView(QWidget* parent = 0);

--- a/mscore/excerptsdialog.h
+++ b/mscore/excerptsdialog.h
@@ -144,9 +144,9 @@ class ExcerptsDialog : public QDialog, private Ui::ExcerptsDialog {
       void instrumentChanged(QListWidgetItem* cur, QListWidgetItem* prev);
       void partChanged(QTreeWidgetItem* cur, QTreeWidgetItem* prev);
       void partDoubleClicked(QTreeWidgetItem*, int);
-      void createNewExcerpt(Ms::ExcerptItem*);
+      void createNewExcerpt(ExcerptItem*);
       void titleChanged(const QString&);
-      Ms::ExcerptItem* getExcerptItem(Ms::Excerpt* e);
+      ExcerptItem* getExcerptItem(Excerpt* e);
 
       void doubleClickedInstrument(QTreeWidgetItem*);
       void addButtonClicked();

--- a/mscore/inspector/fontStyleSelect.h
+++ b/mscore/inspector/fontStyleSelect.h
@@ -31,7 +31,7 @@ class FontStyleSelect : public QWidget, public Ui::FontStyleSelect {
       void _fontStyleChanged();
 
    signals:
-      void fontStyleChanged(Ms::FontStyle);
+      void fontStyleChanged(FontStyle);
 
    public:
       FontStyleSelect(QWidget* parent);

--- a/mscore/instrwidget.h
+++ b/mscore/instrwidget.h
@@ -187,7 +187,7 @@ class InstrumentsWidget : public QWidget, public Ui::InstrumentsWidget {
       void on_removeButton_clicked();
       void on_upButton_clicked();
       void on_downButton_clicked();
-      Ms::StaffListItem* on_addStaffButton_clicked();
+      StaffListItem* on_addStaffButton_clicked();
       void on_addLinkedStaffButton_clicked();
       void on_makeSoloistButton_clicked();
       void on_scoreOrderComboBox_activated(int index);

--- a/mscore/keyedit.h
+++ b/mscore/keyedit.h
@@ -47,7 +47,7 @@ class KeyEditor : public QWidget, Ui::KeyEdit {
       void setDirty() { _dirty = true; }
 
    signals:
-      void keySigAdded(const Ms::KeySig*);
+      void keySigAdded(const KeySig*);
 
    public:
       KeyEditor(QWidget* parent = 0);

--- a/mscore/musescore.h
+++ b/mscore/musescore.h
@@ -513,7 +513,7 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
       void windowSplit(bool);
       void musescoreWindowWasShown();
       void workspacesChanged();
-      void scoreStateChanged(Ms::ScoreState state);
+      void scoreStateChanged(ScoreState state);
 
    private slots:
       void cmd(QAction* a, const QString& cmd);
@@ -534,7 +534,7 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
       void seqStopped();
       void cmdAppendMeasures();
       void cmdInsertMeasures();
-      void zoomBoxChanged(const Ms::ZoomIndex, const qreal);
+      void zoomBoxChanged(const ZoomIndex, const qreal);
       void showPageSettings();
       void removeTab(int);
       void removeTab();
@@ -579,13 +579,13 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
 
       virtual QMenu* createPopupMenu() override;
 
-      QByteArray exportMsczAsJSON(Ms::Score*);
-      QByteArray exportPdfAsJSON(Ms::Score*);
+      QByteArray exportMsczAsJSON(Score*);
+      QByteArray exportPdfAsJSON(Score*);
 
    public slots:
+      void dirtyChanged(Score*);
+      void setPos(const Fraction& tick);
       virtual void cmd(QAction* a) override;
-      void dirtyChanged(Ms::Score*);
-      void setPos(const Ms::Fraction& tick);
       QString pluginPathFromIdx(int idx);
       void pluginTriggered(int);
       void pluginTriggered(QString path);
@@ -594,9 +594,9 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
       void oscControlPlugin(QString pluginPath, QStringList methodPath, QVariant arg);
 #endif
       void handleMessage(const QString& message);
-      void setCurrentScoreView(Ms::ScoreView*);
+      void setCurrentScoreView(ScoreView*);
       void setCurrentScoreView(int);
-      void setCurrentScores(Ms::Score* s1, Ms::Score* s2 = nullptr);
+      void setCurrentScores(Score* s1, Score* s2 = nullptr);
       void setNormalState()    { changeState(STATE_NORMAL); }
       void setPlayState()      { changeState(STATE_PLAY); }
       void setNoteEntryState() { changeState(STATE_NOTE_ENTRY); }
@@ -606,10 +606,10 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
       void midiNoteReceived(int pitch, bool ctrl, int velo);
       void instrumentChanged();
       void showMasterPalette(const QString& = 0);
-      void selectionChanged(Ms::SelState);
+      void selectionChanged(SelState);
       void createNewWorkspace();
       void editWorkspace();
-      void changeWorkspace(Ms::Workspace* p, bool first=false);
+      void changeWorkspace(Workspace* p, bool first=false);
       void mixerPreferencesChanged(bool showMidiControls);
       void checkForUpdates();
       void restartAudioEngine();

--- a/mscore/noteGroups.h
+++ b/mscore/noteGroups.h
@@ -41,8 +41,8 @@ class NoteGroups : public QGroupBox, Ui::NoteGroups {
 
    private slots:
       void resetClicked();
-      void noteClicked(Ms::Note*);
-      void beamPropertyDropped(Ms::Chord*, Ms::Icon*);
+      void noteClicked(Note*);
+      void beamPropertyDropped(Chord*, Icon*);
 
    public:
       NoteGroups(QWidget* parent);

--- a/mscore/palette/paletteworkspace.h
+++ b/mscore/palette/paletteworkspace.h
@@ -43,7 +43,7 @@ class PaletteElementEditor : public QObject {
       Q_PROPERTY(QString actionName READ actionName CONSTANT) // TODO: make NOTIFY instead of CONSTANT for retranslations
 
    private slots:
-      void onElementAdded(const Ms::Element*);
+      void onElementAdded(const Element*);
 
    public:
       PaletteElementEditor(QObject* parent = nullptr) : QObject(parent) {}

--- a/mscore/pianoroll/pianolevels.h
+++ b/mscore/pianoroll/pianolevels.h
@@ -93,11 +93,11 @@ class PianoLevels : public QWidget
       void adjustLevel(Note* note, NoteEvent* noteEvt, int value);
 
 signals:
-      void posChanged(const Ms::Pos&);
+      void posChanged(const Pos&);
       void tupletChanged(int);
       void subdivChanged(int);
       void levelsIndexChanged(int);
-      void locatorMoved(int idx, const Ms::Pos&);
+      void locatorMoved(int idx, const Pos&);
       void noteLevelsChanged();
 
 public slots:
@@ -105,7 +105,7 @@ public slots:
       void setTuplet(int);
       void setSubdiv(int);
       void setXZoom(qreal);
-      void setPos(const Ms::Pos&);
+      void setPos(const Pos&);
       void setLevelsIndex(int index);
 
 public:

--- a/mscore/pianoroll/pianoroll.h
+++ b/mscore/pianoroll/pianoroll.h
@@ -84,18 +84,18 @@ class PianorollEditor : public QMainWindow, public MuseScoreView {
       void velocityChanged(int);
       void keyPressed(int);
       void keyReleased(int);
-      void moveLocator(int, const Ms::Pos&);
+      void moveLocator(int, const Pos&);
       void cmd(QAction*);
       void rangeChanged(int min, int max);
       void setXpos(int x);
       void showWaveView(bool);
-      void posChanged(Ms::POS pos, unsigned tick);
+      void posChanged(POS pos, unsigned tick);
       void tickLenChanged(int);
       void onTimeChanged(int val);
       void playlistChanged();
 
    public slots:
-      void changeSelection(Ms::SelState);
+      void changeSelection(SelState);
       void handleAction(QAction*);
       void showNoteTweaker();
 

--- a/mscore/pianoroll/pianoruler.h
+++ b/mscore/pianoroll/pianoruler.h
@@ -57,13 +57,13 @@ class PianoRuler : public QWidget {
       void moveLocator(QMouseEvent*);
 
    signals:
-      void posChanged(const Ms::Pos&);
-      void locatorMoved(int idx, const Ms::Pos&);
+      void posChanged(const Pos&);
+      void locatorMoved(int idx, const Pos&);
 
    public slots:
       void setXpos(int);
       void setXZoom(qreal);
-      void setPos(const Ms::Pos&);
+      void setPos(const Pos&);
 
    public:
       PianoRuler(QWidget* parent = 0);

--- a/mscore/pianoroll/pianoview.h
+++ b/mscore/pianoroll/pianoview.h
@@ -200,7 +200,7 @@ private:
       void barPatternChanged(int);
       void noteHeightChanged(int);
       void pitchChanged(int);
-      void trackingPosChanged(const Ms::Pos&);
+      void trackingPosChanged(const Pos&);
       void selectionChanged();
       void showNoteTweakerRequest();
 
@@ -216,9 +216,9 @@ private:
       void setNotesToVoice(int voice);
 
       QString serializeSelectedNotes();
-      QVector<Note*> pasteNotes(const QString& copiedNotes, Ms::Fraction pasteStartTick, Ms::Fraction lengthOffset, int pitchOffset, bool xIsOffset = false);
+      QVector<Note*> pasteNotes(const QString& copiedNotes, Fraction pasteStartTick, Fraction lengthOffset, int pitchOffset, bool xIsOffset = false);
       void drawDraggedNotes(QPainter* painter);
-      void drawDraggedNote(QPainter* painter, Ms::Fraction startTick, Ms::Fraction frac, int pitch, int track, QColor color);
+      void drawDraggedNote(QPainter* painter, Fraction startTick, Fraction frac, int pitch, int track, QColor color);
 
       void cutNotes();
       void copyNotes();

--- a/mscore/plugin/api/fraction.h
+++ b/mscore/plugin/api/fraction.h
@@ -47,7 +47,7 @@ class FractionWrapper : public QObject {
 
       /// \cond MS_INTERNAL
    public slots:
-      void setFraction(Ms::Fraction _f) { f = _f; }
+      void setFraction(Fraction _f) { f = _f; }
 
    public:
       FractionWrapper() = default;

--- a/mscore/ruler.h
+++ b/mscore/ruler.h
@@ -57,13 +57,13 @@ class Ruler : public QWidget {
       void moveLocator(QMouseEvent*);
 
    signals:
-      void posChanged(const Ms::Pos&);
-      void locatorMoved(int idx, const Ms::Pos&);
+      void posChanged(const Pos&);
+      void locatorMoved(int idx, const Pos&);
 
    public slots:
       void setXpos(int);
       void setMag(double xmag, double ymag);
-      void setPos(const Ms::Pos&);
+      void setPos(const Pos&);
 
    public:
       Ruler(QWidget* parent = 0);

--- a/mscore/scorePreview.h
+++ b/mscore/scorePreview.h
@@ -33,7 +33,7 @@ class ScorePreview : public QWidget, public Ui::ScorePreview
 
    public slots:
       void setScore(const QString&);
-      void setScore(const Ms::ScoreInfo&);
+      void setScore(const ScoreInfo&);
       void unsetScore();
 
    signals:

--- a/mscore/scorecmp/scorecmp.h
+++ b/mscore/scorecmp/scorecmp.h
@@ -88,7 +88,7 @@ class ScoreComparisonTool : public QDockWidget {
       void slotWindowSplit(bool);
       void invalidateDiff();
       void updateDiff();
-      void updateScoreVersions(const Ms::Score*);
+      void updateScoreVersions(const Score*);
       };
 
 }     // namespace Ms

--- a/mscore/scorecmp/scorelistmodel.h
+++ b/mscore/scorecmp/scorelistmodel.h
@@ -90,7 +90,7 @@ class ScoreVersionListModel : public QAbstractListModel {
 
    public slots:
       void update();
-      void setScore(Ms::MasterScore* s);
+      void setScore(MasterScore* s);
       };
 
 }     // namespace Ms

--- a/mscore/scoretab.h
+++ b/mscore/scoretab.h
@@ -74,7 +74,7 @@ class ScoreTab : public QWidget {
       std::map<int, ScoreViewState> scoreViewsToInit;
 
    signals:
-      void currentScoreViewChanged(Ms::ScoreView*);
+      void currentScoreViewChanged(ScoreView*);
       void tabCloseRequested(int);
       void actionTriggered(QAction*);
       void tabInserted(int);

--- a/mscore/scoreview.h
+++ b/mscore/scoreview.h
@@ -340,7 +340,7 @@ class ScoreView : public QWidget, public MuseScoreView {
       Element* getDropTarget(EditData&);
 
    private slots:
-      void posChanged(Ms::POS pos, unsigned tick);
+      void posChanged(POS pos, unsigned tick);
       void loopToggled(bool);
       void triggerCmdRealtimeAdvance();
       void cmdRealtimeAdvance();
@@ -361,17 +361,17 @@ class ScoreView : public QWidget, public MuseScoreView {
       void normalCut();
       void normalCopy();
       void fotoModeCopy(bool includeLink = false);
-      bool normalPaste(Ms::Fraction scale = Ms::Fraction(1, 1));
+      bool normalPaste(Fraction scale = Fraction(1, 1));
       bool clonePaste();
       void normalSwap();
 
       void setControlCursorVisible(bool v);
 
-      void cloneElement(Ms::Element* e);
+      void cloneElement(Element* e);
       void doFotoDragEdit(QMouseEvent* ev);
 
       void updateContinuousPanel();
-      void ticksTab(const Ms::Fraction& ticks);     // helper function
+      void ticksTab(const Fraction& ticks);     // helper function
 
    signals:
       void viewRectChanged();

--- a/mscore/seq.h
+++ b/mscore/seq.h
@@ -218,7 +218,7 @@ class Seq : public QObject, public Sequencer {
       void stopNotes(int channel = -1, bool realTime = false);
       void start();
       void stop();
-      void setPos(Ms::POS, unsigned);
+      void setPos(POS, unsigned);
       void setMetronomeGain(float val) { metronomeVolume = val; }
 
    signals:

--- a/mscore/timedialog.h
+++ b/mscore/timedialog.h
@@ -46,7 +46,7 @@ class TimeDialog : public QWidget, Ui::TimeDialogBase {
       void setDirty() { _dirty = true; }
 
    signals:
-      void timeSigAdded(const Ms::TimeSig*);
+      void timeSigAdded(const TimeSig*);
 
    public:
       TimeDialog(QWidget* parent = 0);

--- a/mscore/timeline.h
+++ b/mscore/timeline.h
@@ -219,7 +219,7 @@ class Timeline : public QGraphicsView {
       void objectDestroyed(QObject*);
 
    public slots:
-      void changeSelection(Ms::SelState);
+      void changeSelection(SelState);
       void mouseOver(QPointF pos);
       void swapMeta(unsigned row, bool switchUp);
       virtual void contextMenuEvent(QContextMenuEvent* event) override;

--- a/mscore/zoombox.h
+++ b/mscore/zoombox.h
@@ -100,7 +100,7 @@ class ZoomBox : public QComboBox {
       void textChanged();
 
    signals:
-      void zoomChanged(const Ms::ZoomIndex zoomIndex, const qreal logicalFreeZoomLevel = 0.0);
+      void zoomChanged(const ZoomIndex zoomIndex, const qreal logicalFreeZoomLevel = 0.0);
 
    public:
       ZoomBox(QWidget* parent = 0);


### PR DESCRIPTION
by reverting the "Fully qualify types in slots and signals" part of 6a353a6

Resolves: #1097