### PR TITLE
Fix: Time Deletion with horizontal frame etc

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -3375,7 +3375,7 @@ void Score::localTimeDelete()
       MeasureBase* ie;
 
       if (endSegment)
-            ie = endSegment->prev(SegmentType::ChordRest) ? endSegment->measure() : endSegment->measure()->prev();
+            ie = endSegment->prev(SegmentType::ChordRest) ? endSegment->measure() : endSegment->measure()->prevMeasure();
       else
             ie = lastMeasure();
 


### PR DESCRIPTION
Resolves (hopefully): [musescore#31531]( https://www.github.com/musescore/MuseScore/issues/31531)

Although this was for MSS4, it also applies to 3.7 so figured I'd send this over and maybe you can shoot it up to Mu4?

Testing appreciated first etc.

