### PR TITLE
Code cleanups

### DIFF
--- a/audio/drivers/jackaudio.cpp
+++ b/audio/drivers/jackaudio.cpp
@@ -382,11 +382,11 @@ int JackAudio::processAudio(jack_nframes_t frames, void* p)
             r = 0;
             }
       if (preferences.getBool(PREF_IO_JACK_USEJACKMIDI)) {
-            foreach(jack_port_t* port, audio->midiOutputPorts) {
+            for (jack_port_t* port : audio->midiOutputPorts) {
                   void* portBuffer = jack_port_get_buffer(port, frames);
                   jack_midi_clear_buffer(portBuffer);
                   }
-            foreach(jack_port_t* port, audio->midiInputPorts) {
+            for (jack_port_t* port : audio->midiInputPorts) {
                   void* portBuffer = jack_port_get_buffer(port, frames);
                   if (portBuffer) {
                         jack_nframes_t n = jack_midi_get_event_count(portBuffer);
@@ -781,7 +781,7 @@ void JackAudio::rememberAudioConnections()
       settings.setValue(QString("audio-0-connections"), 0);
       settings.setValue(QString("audio-1-connections"), 0);
       int port = 0;
-      foreach(jack_port_t* mp, ports) {
+      for (jack_port_t* mp : ports) {
             const char** cc = jack_port_get_connections(mp);
             const char** c = cc;
             int idx = 0;
@@ -859,7 +859,7 @@ void JackAudio::rememberMidiConnections()
             qDebug("Saving midi connections...");
       QSettings settings;
       int port = 0;
-      foreach(jack_port_t* mp, midiOutputPorts) {
+      for (jack_port_t* mp : midiOutputPorts) {
             const char** cc = jack_port_get_connections(mp);
             const char** c = cc;
             int idx = 0;
@@ -876,7 +876,7 @@ void JackAudio::rememberMidiConnections()
             }
 
       port = 0;
-      foreach(jack_port_t* mp, midiInputPorts) {
+      for (jack_port_t* mp : midiInputPorts) {
             const char** cc = jack_port_get_connections(mp);
             const char** c = cc;
             int idx = 0;
@@ -959,7 +959,7 @@ void JackAudio::hotPlug()
                   }
             }
       else if (!preferences.getBool(PREF_IO_JACK_USEJACKAUDIO)) {
-            foreach(jack_port_t* p, ports) {
+            for (jack_port_t* p : ports) {
                   unregisterPort(p);
                   ports.removeOne(p);
                   }

--- a/audio/drivers/mididriver.cpp
+++ b/audio/drivers/mididriver.cpp
@@ -184,7 +184,7 @@ bool AlsaMidiDriver::init()
 #if 0
       // TODO: autoconnect all output ports
       QList<PortName> ol = outputPorts();
-      foreach(PortName pn, ol) {
+      for (PortName pn : ol) {
             if (MScore::debugMode)
                   qDebug("connect to midi output <%s>", qPrintable(pn.name));
             qDebug("Output <%s>", qPrintable(pn.name));
@@ -193,7 +193,7 @@ bool AlsaMidiDriver::init()
 
       // connect all midi sources to mscore
       QList<PortName> il = inputPorts();
-      foreach(PortName pn, il) {
+      for (PortName pn : il) {
             if (MScore::debugMode)
                   qDebug("connect to midi input <%s>", qPrintable(pn.name));
             connect(pn.port, midiInPort);

--- a/audio/exports/exportmidi.cpp
+++ b/audio/exports/exportmidi.cpp
@@ -43,9 +43,9 @@ void ExportMidi::writeHeader(MidiTrack& tempoTrack)
 #if 0 // TODO
       MeasureBase* measure  = cs->first();
 
-      foreach (const Element* e, *measure->el()) {
-            if (e->type() == Element::TEXT) {
-                  const Text* text = (const Text*)(e);
+      for (const Element* e : *measure->el()) {
+            if (e->isText()) {
+                  const Text* text = toText(e);
                   QString str = text->getText();
                   int len     = str.length() + 1;
                   unsigned char* data = new unsigned char[len];

--- a/audio/midi/fluid/fluid.cpp
+++ b/audio/midi/fluid/fluid.cpp
@@ -979,7 +979,7 @@ QFileInfoList Fluid::sfFiles()
       QStringList extensionsDir = Ms::Extension::getDirectoriesByType(Ms::Extension::soundfontsDir);
       pl.append(extensionsDir);
 
-      foreach (const QString& s, pl) {
+      for (const QString& s : pl) {
             QString ss(s);
             if (!s.isEmpty() && s[0] == '~')
                   ss = QDir::homePath() + s.mid(1);

--- a/audio/midi/zerberus/zerberus.cpp
+++ b/audio/midi/zerberus/zerberus.cpp
@@ -398,7 +398,7 @@ Ms::SynthesizerGroup Zerberus::state() const
       g.setName(name());
 
       QStringList sfl = soundFonts();
-      foreach(QString sf, sfl)
+      for (QString sf : sfl)
             g.push_back(Ms::IdValue(0, sf));
       return g;
       }
@@ -461,7 +461,7 @@ bool Zerberus::loadInstrument(const QString& s)
 
       QFileInfoList l = Zerberus::sfzFiles();
       QString path;
-      foreach (const QFileInfo& fi, l) {
+      for (const QFileInfo& fi : l) {
             if (fi.fileName() == fileName) {
                   path = fi.absoluteFilePath();
                   break;

--- a/audio/midi/zerberus/zerberusgui.cpp
+++ b/audio/midi/zerberus/zerberusgui.cpp
@@ -202,7 +202,7 @@ static void collectFiles(QFileInfoList* l, const QString& path)
 //printf("collect files <%s>\n", qPrintable(path));
 
       QDir dir(path);
-      foreach (const QFileInfo& s, dir.entryInfoList(QDir::Files | QDir::Dirs | QDir::NoDotAndDotDot)) {
+      for (const QFileInfo& s : dir.entryInfoList(QDir::Files | QDir::Dirs | QDir::NoDotAndDotDot)) {
             if (path == s.absoluteFilePath())
                   return;
 
@@ -230,7 +230,7 @@ QFileInfoList Zerberus::sfzFiles()
       QStringList extensionsDir = Ms::Extension::getDirectoriesByType(Ms::Extension::sfzsDir);
       pl.append(extensionsDir);
 
-      foreach (const QString& s, pl) {
+      for (const QString& s : pl) {
             QString ss(s);
             if (!s.isEmpty() && s[0] == '~')
                   ss = QDir::homePath() + s.mid(1);

--- a/importexport/bb/bb.cpp
+++ b/importexport/bb/bb.cpp
@@ -244,7 +244,7 @@ bool BBFile::read(const QString& name)
 
 #if 0
       qDebug("================chords=======================");
-      foreach(BBChord c, _chords) {
+      for (BBChord c : _chords) {
             qDebug("chord beat %3d bass %d root %d extension %d",
                c.beat, c.bass, c.root, c.extension);
             }
@@ -428,7 +428,7 @@ Score::FileError importBB(MasterScore* score, const QString& name)
 
       if (tracks->isEmpty()) {
             for (MeasureBase* mb = score->first(); mb; mb = mb->next()) {
-                  if (mb->type() != ElementType::MEASURE)
+                  if (!mb->isMeasure())
                         continue;
                   Measure* measure = toMeasure(mb);
                   Rest* rest = new Rest(score, TDuration::DurationType::V_MEASURE);
@@ -445,7 +445,7 @@ Score::FileError importBB(MasterScore* score, const QString& name)
             }
 
       for (MeasureBase* mb = score->first(); mb; mb = mb->next()) {
-            if (mb->type() != ElementType::MEASURE)
+            if (!mb->isMeasure())
                   continue;
             Measure* measure = toMeasure(mb);
             Segment* s = measure->findSegment(SegmentType::ChordRest, measure->tick());
@@ -468,7 +468,7 @@ Score::FileError importBB(MasterScore* score, const QString& name)
       text->setPlainText(bb.title());
 
       MeasureBase* measureB = score->first();
-      if (measureB->type() != ElementType::VBOX) {
+      if (!measureB->isVBox()) {
             measureB = new VBox(score);
             measureB->setTick(Fraction(0,1));
             measureB->setNext(score->first());
@@ -516,9 +516,9 @@ Score::FileError importBB(MasterScore* score, const QString& name)
 
       int n = 0;
       for (MeasureBase* mb = score->first(); mb; mb = mb->next()) {
-            if (mb->type() != ElementType::MEASURE)
+            if (!mb->isMeasure())
                   continue;
-            Measure* measure = (Measure*)mb;
+            Measure* measure = toMeasure(mb);
             if (n && (n % 4) == 0) {
                   LayoutBreak* lb = new LayoutBreak(score);
                   lb->setLayoutBreakType(LayoutBreak::Type::LINE);

--- a/importexport/capella/capella.cpp
+++ b/importexport/capella/capella.cpp
@@ -231,7 +231,7 @@ static void processBasicDrawObj(QList<BasicDrawObj*> objects, Segment* s, int tr
                                           default:
                                                 break;
                                           }
-                                    if (cr && cr->type() == ElementType::CHORD)
+                                    if (cr && cr->isChord())
                                           switch (code) {
 #if 0 // TODO-ws
                                                 case 't':   //  trill
@@ -493,7 +493,7 @@ static bool findChordRests(BasicDrawObj const* const o, Score* score, const int 
       // Now we have the tick (tick) and the level of grace note (graceNumber1, if "no" is a grace note) for the first ChordRest
       // and the tick (tick2) and the level of grace note (graceNumber, if the target is a grace note) for the 2nd ChordRest
       for (Segment* seg = score->tick2segment(tick); seg; seg = seg->next1()) {
-            if (seg->segmentType() != SegmentType::ChordRest)
+            if (!seg->isChordRestType())
                   continue;
             ChordRest* cr = toChordRest(seg->element(track));
             if (cr) {
@@ -510,7 +510,7 @@ static bool findChordRests(BasicDrawObj const* const o, Score* score, const int 
                   }
             }
       for (Segment* seg = score->tick2segment(tick2); seg; seg = seg->next1()) {
-            if (seg->segmentType() != SegmentType::ChordRest)
+            if (!seg->isChordRestType())
                   continue;
             ChordRest* cr = toChordRest(seg->element(track));
             if (cr) {
@@ -1033,7 +1033,7 @@ static Fraction readCapVoice(Score* score, CapVoice* cvoice, int staffIdx, const
                               //    to->relPos.x(), to->relPos.y(), to->width, to->yxRatio, qPrintable(ss));
                               s->setXmlText(ss);
                               MeasureBase* measure = score->measures()->first();
-                              if (measure->type() != ElementType::VBOX) {
+                              if (!measure->isVBox()) {
                                     MeasureBase* mb = new VBox(score);
                                     mb->setTick(Fraction(0, 1));
                                     score->addMeasure(mb, measure);
@@ -1321,8 +1321,8 @@ void convertCapella(Score* score, Capella* cap, bool capxMode)
       if (cap->topDist) {
             VBox* mb = 0;
             MeasureBaseList* mbl = score->measures();
-            if (mbl->size() && mbl->first()->type() == ElementType::VBOX)
-                  mb = static_cast<VBox*>(mbl->first());
+            if (mbl->size() && mbl->first()->isVBox())
+                  mb = toVBox(mbl->first());
             else {
                   VBox* vb = new VBox(score);
                   vb->setTick(Fraction(0,1));

--- a/importexport/guitarpro/importgtp-gp4.cpp
+++ b/importexport/guitarpro/importgtp-gp4.cpp
@@ -484,7 +484,7 @@ bool GuitarPro4::readNote(int string, int staffIdx, Note* note)
                   if (e) {
                         if (e->isChord()) {
                               Chord* chord2 = toChord(e);
-                              foreach (Note* note2, chord2->notes()) {
+                              for (Note* note2 : chord2->notes()) {
                                     if (note2->string() == string) {
                                           if (chords.empty()) {
                                                 Tie* tie = new Tie(score);
@@ -1019,7 +1019,7 @@ bool GuitarPro4::read(QFile* fp)
                                     while ((seg = seg->prev()) || (mes = mes->prevMeasure())) {
                                           if (!seg)
                                                 break;//seg = mes->last();
-                                          if (seg->segmentType() == SegmentType::ChordRest
+                                          if (seg->isChordRestType()
                                               && seg->cr(chord->track())->isChord()) {
                                                 bool br = false;
                                                 Chord* cr1 = toChord(seg->cr(chord->track()));

--- a/importexport/guitarpro/importgtp-gp5.cpp
+++ b/importexport/guitarpro/importgtp-gp5.cpp
@@ -89,11 +89,11 @@ int GuitarPro5::readBeatEffects(int track, Segment* segment)
       uchar fxBits1 = readUChar();
       uchar fxBits2 = readUChar();
       if (fxBits1 & BEAT_FADE)
-             effects = 4; // fade in
+            effects = 4; // fade in
       if (fxBits1 & BEAT_EFFECT) {
             int k = readUChar();
-		effects = k + effects * 100;// &effects;
-	      }
+            effects = k + effects * 100;// &effects;
+            }
       if (fxBits1 & BEAT_VIBRATO_TREMOLO) {
             effects = 7 + effects * 100;
             }
@@ -101,11 +101,11 @@ int GuitarPro5::readBeatEffects(int track, Segment* segment)
             readTremoloBar(track, segment);       // readBend();
       if (fxBits2 & 0x01) { // Rasgueado effect
             StaffText* st = new StaffText(score);
-		st->setXmlText("rasg.");
-		st->setParent(segment);
-		st->setTrack(track);
-		score->addElement(st);
-	      }
+            st->setXmlText("rasg.");
+            st->setParent(segment);
+            st->setTrack(track);
+            score->addElement(st);
+            }
       if (fxBits1 & BEAT_ARPEGGIO) {
             int strokeup = readUChar();            // up stroke length
             int strokedown = readUChar();            // down stroke length
@@ -158,7 +158,7 @@ void GuitarPro5::readPageSetup()
 //---------------------------------------------------------
 
 Fraction GuitarPro5::readBeat(const Fraction& tick, int voice, Measure* measure, int staffIdx, Tuplet** tuplets,
-   bool /*mixChange*/)
+                              bool /*mixChange*/)
       {
       uchar beatBits = readUChar();
       bool dotted    = beatBits & BEAT_DOTTED;
@@ -184,26 +184,26 @@ Fraction GuitarPro5::readBeat(const Fraction& tick, int voice, Measure* measure,
             skip(17);
 #if 0
             uchar header = readUChar(); //1
-		uchar sharp = readUChar(); //2
-		skip(3); //5
-		char root = readChar(); //6
-		uchar chordtype = readUChar();//7
-		uchar nines = readUChar();//8
-		int bass = readInt();//12
-		int aug = readInt(); //16
-		char add = readChar(); //17
+            uchar sharp = readUChar(); //2
+            skip(3); //5
+            char root = readChar(); //6
+            uchar chordtype = readUChar();//7
+            uchar nines = readUChar();//8
+            int bass = readInt();//12
+            int aug = readInt(); //16
+            char add = readChar(); //17
 #endif
             QString name;
             {
-		      /*auto len =*/ readUChar();
-			char c[21];
-			f->read(c, 21);
-			// if (len > 20)
-			//      skip(len - 20);
-                  //skip(len - 20);
-			c[20] = 0;
-			name = c;
-			}
+            /*auto len =*/ readUChar();
+            char c[21];
+            f->read(c, 21);
+            // if (len > 20)
+            //      skip(len - 20);
+            //skip(len - 20);
+            c[20] = 0;
+            name = c;
+            }
             //QString name = readPascalString(21);
             skip(4);
             // no header to be read in the GP5 format - default to true.
@@ -214,48 +214,48 @@ Fraction GuitarPro5::readBeat(const Fraction& tick, int voice, Measure* measure,
       QString free_text;
       if (beatBits & BEAT_LYRICS) {
             //free_text = readDelphiString();
-		QString qs = readDelphiString();
+            QString qs = readDelphiString();
             std::string txt = qs.toUtf8().constData();
-     	      txt.erase(std::remove_if(txt.begin(), txt.end(), [](char c) {return c == '_'; }), txt.end());
-//		auto pos = txt.find('-');
-		auto buffer = txt;
-		txt.resize(0);
-		const char* c = buffer.c_str();
+            txt.erase(std::remove_if(txt.begin(), txt.end(), [](char c) {return c == '_'; }), txt.end());
+            //		auto pos = txt.find('-');
+            auto buffer = txt;
+            txt.resize(0);
+            const char* c = buffer.c_str();
             while (*c) {
                   if (*c == ' ') {
                         while (*c == ' ')
                               ++c;
                         if (*c == '-') {
-				      txt += '-';
+                              txt += '-';
                               ++c;
-					while (*c == ' ')
+                              while (*c == ' ')
                                     ++c;
-				      }
+                              }
                         else if (*c)
                               txt += '-';
-			      }
+                        }
                   else
                         txt += *(c++);
-		      }
+                  }
             if (gpLyrics.lyrics.size() == 0 || (gpLyrics.lyrics.size() == 1 && gpLyrics.lyrics[0].isEmpty())) {
-//			gpLyrics.lyrics.resize(0);
+                  //			gpLyrics.lyrics.resize(0);
                   gpLyrics.lyrics.clear();
-			gpLyrics.fromBeat = _beat_counter;
-			gpLyrics.lyricTrack = track;
-		      }
+                  gpLyrics.fromBeat = _beat_counter;
+                  gpLyrics.lyricTrack = track;
+                  }
             while (txt.size() && txt[txt.size() - 1] == '-')
                   txt.resize(txt.size() - 1);
-//		  gpLyrics.lyrics.append(txt);
+            //		  gpLyrics.lyrics.append(txt);
             gpLyrics.lyrics.append(QString::fromUtf8(txt.data(), int(txt.size())));
-		gpLyrics.segments.push_back(segment);
+            gpLyrics.segments.push_back(segment);
             }
 #if 0
       gpLyrics.beatCounter++;
       if (false && gpLyrics.beatCounter >= gpLyrics.fromBeat && gpLyrics.lyricTrack == staffIdx+1) {
             int index = gpLyrics.beatCounter - gpLyrics.fromBeat;
             if (index < gpLyrics.lyrics.size()) {
-		      lyrics = new Lyrics(score);
-			lyrics->setPlainText(gpLyrics.lyrics[index]);
+                  lyrics = new Lyrics(score);
+                  lyrics->setPlainText(gpLyrics.lyrics[index]);
                   }
             }
 #endif
@@ -328,12 +328,12 @@ Fraction GuitarPro5::readBeat(const Fraction& tick, int voice, Measure* measure,
             Staff* staff = cr->staff();
             int numStrings = staff->part()->instrument()->stringData()->strings();
             bool hasSlur = false;
-		Note* _note{ nullptr };
-		std::vector<Note*> delnote;
+            Note* _note{ nullptr };
+            std::vector<Note*> delnote;
             for (int i = 6; i >= 0; --i) {
                   if (strings & (1 << i) && ((6-i) < numStrings)) {
                         Note* note = new Note(score);
-				_note = note;
+                        _note = note;
                         if (dotted) {
                               // there is at most one dotted note in this guitar pro version
                               NoteDot* dot = new NoteDot(score);
@@ -347,23 +347,23 @@ Fraction GuitarPro5::readBeat(const Fraction& tick, int voice, Measure* measure,
                         hasSlur = (readNote(6-i, note) || hasSlur);
                         if (slideList.size() && slideList.back() == nullptr) {
                               slideList.back() = note;
-					hasSlur = true;
-					}
+                              hasSlur = true;
+                              }
                         if (note->fret() == -20) {
                               delnote.push_back(note);
 #if 0
-					Chord* chord = toChord(cr);
-					chord->remove(note);
+                              Chord* chord = toChord(cr);
+                              chord->remove(note);
                               delete note;
-					if (chord->notes().empty()) {
+                              if (chord->notes().empty()) {
                                     chord->segment()->remove(chord);
-						delete chord;
-						cr = nullptr;
-						}
+                                    delete chord;
+                                    cr = nullptr;
+                                    }
 #endif
-				      }
-			      else
-				      note->setTpcFromPitch();
+                              }
+                        else
+                              note->setTpcFromPitch();
                         }
                   }
             if (delnote.size()) {
@@ -377,16 +377,16 @@ Fraction GuitarPro5::readBeat(const Fraction& tick, int voice, Measure* measure,
                               chord->tuplet()->remove(chord);
                         chord->segment()->remove(chord);
                         delete chord;
-				cr = nullptr;
-				}
+                        cr = nullptr;
+                        }
                   delnote.clear();
-			}
+                  }
             createSlur(hasSlur, staffIdx, cr);
             if (lyrics)
                   cr->add(lyrics);
-			if (free_text.length() && _note) {
-				addTextToNote(free_text, Align::CENTER, _note);
-			      }
+            if (free_text.length() && _note) {
+                  addTextToNote(free_text, Align::CENTER, _note);
+                  }
 
             }
       int rr = readChar();
@@ -394,7 +394,7 @@ Fraction GuitarPro5::readBeat(const Fraction& tick, int voice, Measure* measure,
             Chord* chord = toChord(cr);
             do {
                   applyBeatEffects(chord, beatEffects % 100);
-            } while (beatEffects /= 100);
+                  } while (beatEffects /= 100);
             if (rr == ARPEGGIO_DOWN)
                   chord->setStemDirection(Direction::DOWN);
             else if (rr == ARPEGGIO_UP)
@@ -403,17 +403,17 @@ Fraction GuitarPro5::readBeat(const Fraction& tick, int voice, Measure* measure,
       int r = readChar();
       if (r & 0x8) {
             int rrr = readChar();
-qDebug("  3beat read 0x%02x", rrr);
-           }
+            qDebug("  3beat read 0x%02x", rrr);
+            }
       if (cr && cr->isChord()) {
-	      if (toChord(cr)->notes().size() == 0) {
+            if (toChord(cr)->notes().size() == 0) {
                   segment->remove(cr);
                   delete cr;
-			cr = 0;
-		      }
+                  cr = 0;
+                  }
             else if (slide > 0)
                   createSlide(slide, cr, staffIdx);
-	      }
+            }
       restsForEmptyBeats(segment, measure, cr, l, track, tick);
       return cr ? cr->actualTicks() : measure->ticks();
       }
@@ -432,7 +432,7 @@ void GuitarPro5::readMeasure(Measure* measure, int staffIdx, Tuplet** tuplets, b
                   return;
             for (int beat = 0; beat < beats; ++beat) {
                   Fraction ticks = readBeat(tick, voice, measure, staffIdx, tuplets, mixChange);
-			++_beat_counter;
+                  ++_beat_counter;
                   tick += ticks;
                   measureLen += ticks;
                   }
@@ -476,8 +476,8 @@ bool GuitarPro5::readMixChange(Measure* measure)
       if (temp >= 0) {
             if (last_segment) {
                   score->setTempo(last_segment->tick(), double(temp) / 60.0);
-			last_segment = nullptr;
-		      }
+                  last_segment = nullptr;
+                  }
             if (temp != previousTempo) {
                   previousTempo = temp;
                   setTempo(temp, measure);
@@ -485,7 +485,7 @@ bool GuitarPro5::readMixChange(Measure* measure)
                   }
             readChar();
             if (version > 500)
-                 readChar();
+                  readChar();
             }
       readChar();
       readChar();
@@ -518,7 +518,7 @@ bool GuitarPro5::readTracks()
 
             int strings  = readInt();
             if (strings <= 0 || strings > GP_MAX_STRING_NUMBER)
-                return false;
+                  return false;
             for (int j = 0; j < strings; ++j) {
                   tuning[j] = readInt();
                   }
@@ -538,12 +538,12 @@ bool GuitarPro5::readTracks()
                   readDelphiString();
                   readDelphiString();
                   }
-			std::vector<int> tuning2(strings);
+            std::vector<int> tuning2(strings);
             //int tuning2[strings];
             for (int k = 0; k < strings; ++k)
                   tuning2[strings-k-1] = tuning[k];
             StringData stringData(frets, strings, &tuning2[0]);
-			createTuningString(strings, &tuning2[0]);
+            createTuningString(strings, &tuning2[0]);
             Instrument* instr = part->instrument();
             instr->setStringData(stringData);
             instr->setSingleNoteDynamics(false);
@@ -620,7 +620,7 @@ void GuitarPro5::readMeasures(int /*startingTempo*/)
                   segment->add(s);
                   }
 
-			std::vector<Tuplet*> tuplets(staves * 2);
+            std::vector<Tuplet*> tuplets(staves * 2);
             //Tuplet* tuplets[staves * 2];     // two voices
             for (int track = 0; track < staves*2; ++track)
                   tuplets[track] = 0;
@@ -639,26 +639,26 @@ void GuitarPro5::readMeasures(int /*startingTempo*/)
 
       if (gpLyrics.segments.size()) {
             auto size = std::min(int(gpLyrics.segments.size()), int(gpLyrics.lyrics.size()));
-		for (int i = 0; i < size; ++i) {
+            for (int i = 0; i < size; ++i) {
                   std::string str = gpLyrics.lyrics[i].toUtf8().constData();
-			auto seg = gpLyrics.segments[i];
-			auto mes = seg->measure();
-			while (str.size() && seg && seg->segmentType() == SegmentType::ChordRest) {
+                  auto seg = gpLyrics.segments[i];
+                  auto mes = seg->measure();
+                  while (str.size() && seg && seg->isChordRestType()) {
                         auto cr = seg->cr(gpLyrics.lyricTrack);
-				if (cr) {
+                        if (cr) {
                               if (str[0] != '-') {
                                     auto lyr = new Lyrics(score);
 
-						std::string text;
-						auto pos = str.find('-');
-						auto pos2 = str.find('\n');
-						if (pos2 < pos)
+                                    std::string text;
+                                    auto pos = str.find('-');
+                                    auto pos2 = str.find('\n');
+                                    if (pos2 < pos)
                                           pos = pos2;
-					      if (pos != std::string::npos) {
+                                    if (pos != std::string::npos) {
                                           const char* c = &str.c_str()[pos + 1];
-							if (*c == 0) {
+                                          if (*c == 0) {
                                                 pos = std::string::npos;
-								text = str;
+                                                text = str;
                                                 }
                                           else {
                                                 text = str.substr(0, pos);
@@ -687,25 +687,25 @@ void GuitarPro5::readMeasures(int /*startingTempo*/)
                   }
             }
       else {
-//            int counter = 0;
-//            int index = 0;
-//TODO-ws ???		gpLyrics.lyricTrack -= 1;
-		auto mes = score->firstMeasure();
-		auto beg = mes->first();
+            //            int counter = 0;
+            //            int index = 0;
+            //TODO-ws ???		gpLyrics.lyricTrack -= 1;
+            auto mes = score->firstMeasure();
+            auto beg = mes->first();
 
-		do {
-		      if (beg->isChordRestType() && beg->cr(gpLyrics.lyricTrack)) {
+            do {
+                  if (beg->isChordRestType() && beg->cr(gpLyrics.lyricTrack)) {
                         ChordRest* cr = beg->cr(gpLyrics.lyricTrack);
-//				++counter;
-				if (!cr->isChord())
+                        //				++counter;
+                        if (!cr->isChord())
                               continue;
                         bool is_tied = false;
-				Chord* chord = toChord(cr);
-				for (auto n : chord->notes()) {
-				      if (n->tiedNotes().size() > 1 && n->tiedNotes()[0] != n) {
+                        Chord* chord = toChord(cr);
+                        for (auto n : chord->notes()) {
+                              if (n->tiedNotes().size() > 1 && n->tiedNotes()[0] != n) {
                                     is_tied = true;
-						break;
-					      }
+                                    break;
+                                    }
                               }
                         if (is_tied)
                               continue;
@@ -715,44 +715,44 @@ void GuitarPro5::readMeasures(int /*startingTempo*/)
                                     auto lyr = new Lyrics(score);
 
                                     std::string text;
-						auto pos  = gpLyrics.lyrics[index].find('-');
-						auto pos2 = gpLyrics.lyrics[index].find('\n');
-						if (pos2 < pos)
+                                    auto pos  = gpLyrics.lyrics[index].find('-');
+                                    auto pos2 = gpLyrics.lyrics[index].find('\n');
+                                    if (pos2 < pos)
                                           pos = pos2;
-						if (pos != std::string::npos) {
+                                    if (pos != std::string::npos) {
                                           const char* c = &gpLyrics.lyrics[index].c_str()[pos + 1];
-							if (*c == 0) {
+                                          if (*c == 0) {
                                                 pos = std::string::npos;
-								text = gpLyrics.lyrics[index];
-							      }
+                                                text = gpLyrics.lyrics[index];
+                                                }
                                           else {
                                                 text = gpLyrics.lyrics[index].substr(0, pos);
-								auto str = gpLyrics.lyrics[index].substr(pos + 1);
-								gpLyrics.lyrics[index] = str;
-								if (str.length())
-								      gpLyrics.lyrics[index][0] = str[0];
-							      }
-						      }
-						else
+                                                auto str = gpLyrics.lyrics[index].substr(pos + 1);
+                                                gpLyrics.lyrics[index] = str;
+                                                if (str.length())
+                                                      gpLyrics.lyrics[index][0] = str[0];
+                                                }
+                                          }
+                                    else
                                           text = gpLyrics.lyrics[index];
                                     if (pos == std::string::npos)
                                           ++index;
                                     lyr->setPlainText(text);
-						cr->add(lyr);
-						if (index >= gpLyrics.lyrics.size())
-							  break;
-					      }
+                                    cr->add(lyr);
+                                    if (index >= gpLyrics.lyrics.size())
+                                          break;
+                                    }
                               else {
                                     //TODO: Need studio new release, bug here
-						std::string s = &gpLyrics.lyrics[index].c_str()[1];
-						gpLyrics.lyrics[index] = s;
-						if (s.length())
+                                    std::string s = &gpLyrics.lyrics[index].c_str()[1];
+                                    gpLyrics.lyrics[index] = s;
+                                    if (s.length())
                                           gpLyrics.lyrics[index][0] = s[0];
-					      }
-				      }
+                                    }
+                              }
 #endif
-			      }
-		      } while ((beg = beg->next()) || ((mes = toMeasure(mes->next())) && (beg = mes->first())));
+                        }
+                  } while ((beg = beg->next()) || ((mes = toMeasure(mes->next())) && (beg = mes->first())));
             }
       }
 
@@ -785,18 +785,18 @@ bool GuitarPro5::read(QFile* fp)
       readChannels();
 
       std::vector<unsigned int> articulations;
-	articulations.resize(19);
-	{
-            unsigned int r; unsigned char x;
-		for (int i = 0; i < 19; ++i) {
-                  x = readUChar();
-			r = x;
-			x = readUChar();
-			r += x << 8;
+      articulations.resize(19);
+      {
+      unsigned int r; unsigned char x;
+      for (int i = 0; i < 19; ++i) {
+            x = readUChar();
+            r = x;
+            x = readUChar();
+            r += x << 8;
 
-			articulations[i] = r;
-		      }
-	      }
+            articulations[i] = r;
+            }
+      }
 
       //skip(42);
       skip(4);
@@ -804,9 +804,9 @@ bool GuitarPro5::read(QFile* fp)
       measures = readInt();
       staves  = readInt();
 
-	for (int str = 0; str < 7; ++str) {
-	      for (int staff = 0; staff < staves; ++staff)
-		      dead_end[{staff, str}] = true;
+      for (int str = 0; str < 7; ++str) {
+            for (int staff = 0; staff < staves; ++staff)
+                  dead_end[{staff, str}] = true;
             }
 
       slurs = new Slur*[staves];
@@ -858,7 +858,7 @@ bool GuitarPro5::read(QFile* fp)
                   }
             if ((barBits & 0x10) == 0) {
                   skip(1);
-			}
+                  }
 
             readChar();             // triple feel  (none, 8, 16)
             bar.timesig = Fraction(tnumerator, tdenominator);
@@ -883,127 +883,127 @@ bool GuitarPro5::read(QFile* fp)
             }
       readMeasures(tempo);
       for (auto n : slideList) {
-//		Note* next = nullptr;
+            //		Note* next = nullptr;
             auto segment = n->chord()->segment();
-		auto measure = segment->measure();
-		while ((segment = segment->next1(SegmentType::ChordRest)) || ((measure = measure->nextMeasure() ) && (segment = measure->first()))) {
-                  if (segment->segmentType() != SegmentType::ChordRest)
-			      continue;
+            auto measure = segment->measure();
+            while ((segment = segment->next1(SegmentType::ChordRest)) || ((measure = measure->nextMeasure() ) && (segment = measure->first()))) {
+                  if (!segment->isChordRestType())
+                        continue;
                   bool br = false;
-			ChordRest* cr = toChordRest(segment->cr(n->track()));
-			if (cr && cr->isChord()) {
+                  ChordRest* cr = toChordRest(segment->cr(n->track()));
+                  if (cr && cr->isChord()) {
                         Chord* c = toChord(cr);
-			      for (auto nt : c->notes()) {
-				      if (nt->string() == n->string()) {
+                        for (auto nt : c->notes()) {
+                              if (nt->string() == n->string()) {
                                     for (auto e : nt->el())
-						      if (e->isChordLine()) {
+                                          if (e->isChordLine()) {
                                                 ChordLine* cl = toChordLine(e);
-								if (cl->chordLineType() == ChordLineType::PLOP || cl->chordLineType() == ChordLineType::SCOOP) {
+                                                if (cl->chordLineType() == ChordLineType::PLOP || cl->chordLineType() == ChordLineType::SCOOP) {
                                                       br = true;
-									break;
-								      }
-							      }
-				            if (br)
+                                                      break;
+                                                      }
+                                                }
+                                    if (br)
                                           break;
                                     Glissando* s = new Glissando(score);
-						s->setAnchor(Spanner::Anchor::NOTE);
-						s->setStartElement(n);
-						s->setTick(n->chord()->segment()->tick());
-						s->setTrack(n->track());
-						s->setParent(n);
-						s->setGlissandoType(GlissandoType::STRAIGHT);
-						s->setEndElement(nt);
-						s->setTick2(nt->chord()->segment()->tick());
-						s->setTrack2(n->track());
-						score->addElement(s);
-						br = true;
-						break;
+                                    s->setAnchor(Spanner::Anchor::NOTE);
+                                    s->setStartElement(n);
+                                    s->setTick(n->chord()->segment()->tick());
+                                    s->setTrack(n->track());
+                                    s->setParent(n);
+                                    s->setGlissandoType(GlissandoType::STRAIGHT);
+                                    s->setEndElement(nt);
+                                    s->setTick2(nt->chord()->segment()->tick());
+                                    s->setTrack2(n->track());
+                                    score->addElement(s);
+                                    br = true;
+                                    break;
                                     }
                               }
                         }
-			if (br)
+                  if (br)
                         break;
-		      }
+                  }
             }
 
-	  std::map<int, int> counter;
-	  for (int i = 0; i < 19; ++i) {
-		  if (articulations[i] != 0xFFFF) {
+      std::map<int, int> counter;
+      for (int i = 0; i < 19; ++i) {
+            if (articulations[i] != 0xFFFF) {
                   Measure* measure = toMeasure(score->measure(articulations[i] - 1));
-			if (i < 4) {
+                  if (i < 4) {
                         Segment* segment = measure->getSegment(SegmentType::BarLine, measure->tick());
                         Symbol* sym = new Symbol(score);
-				if (i == 0)
+                        if (i == 0)
                               sym->setSym(SymId::coda);
                         else if (i == 1) {
 #if 0
-				      sym->setSym(SymId::coda);
-					Symbol* s2 = new Symbol(score);
-					s2->setSym(SymId::coda);
-					s2->setXoffset(5.5f);
-					auto iter = counter.find(articulations[i]);
-					if (iter != counter.end())
-					      s2->setElYOffset(-7.0f * iter->second);
-                              s2->setParent(measure);
-				      s2->setTrack(0);
-					segment->add(s2);
-#endif
-					sym->setSym(SymId::codaSquare);
-				      }
-				else if (i == 2)
-                              sym->setSym(SymId::segno);
-				else {
-#if 0
-					sym->setSym(SymId::segno);
+                              sym->setSym(SymId::coda);
                               Symbol* s2 = new Symbol(score);
-					s2->setSym(SymId::segno);
-					s2->setXoffset(5.5f);
-					auto iter = counter.find(articulations[i]);
-					if (iter != counter.end())
-						  s2->setElYOffset(-7.0f * iter->second);
-					s2->setParent(measure);
-					s2->setTrack(0);
-					segment->add(s2);
+                              s2->setSym(SymId::coda);
+                              s2->setXoffset(5.5f);
+                              auto iter = counter.find(articulations[i]);
+                              if (iter != counter.end())
+                                    s2->setElYOffset(-7.0f * iter->second);
+                              s2->setParent(measure);
+                              s2->setTrack(0);
+                              segment->add(s2);
 #endif
-					sym->setSym(SymId::segnoSerpent2);
-				      }
+                              sym->setSym(SymId::codaSquare);
+                              }
+                        else if (i == 2)
+                              sym->setSym(SymId::segno);
+                        else {
+#if 0
+                              sym->setSym(SymId::segno);
+                              Symbol* s2 = new Symbol(score);
+                              s2->setSym(SymId::segno);
+                              s2->setXoffset(5.5f);
+                              auto iter = counter.find(articulations[i]);
+                              if (iter != counter.end())
+                                    s2->setElYOffset(-7.0f * iter->second);
+                              s2->setParent(measure);
+                              s2->setTrack(0);
+                              segment->add(s2);
+#endif
+                              sym->setSym(SymId::segnoSerpent2);
+                              }
 
 
                         sym->setParent(measure);
-				sym->setTrack(0);
-				segment->add(sym);
-				auto iter = counter.find(articulations[i]);
-				if (iter == counter.end())
-				      counter[articulations[i]] = 1;
+                        sym->setTrack(0);
+                        segment->add(sym);
+                        auto iter = counter.find(articulations[i]);
+                        if (iter == counter.end())
+                              counter[articulations[i]] = 1;
                         else {
-//TODO-ws		            sym->setElYOffset(-7.0f * counter[articulations[i]]);
-					counter[articulations[i]] += 1;
-				      }
+                              //TODO-ws		            sym->setElYOffset(-7.0f * counter[articulations[i]]);
+                              counter[articulations[i]] += 1;
+                              }
                         }
                   else {
                         Segment* s = measure->getSegment(SegmentType::KeySig, measure->tick());
-				StaffText* st = new StaffText(score);
-				static constexpr char text[][22] = {
-					"fine", "Da Capo", "D.C. al Coda", "D.C. al Double Coda",
-					"D.C. al Fine", "Da Segno", "D.S. al Coda", "D.S. al Double Coda",
-					"D.S. al Fine", "Da Segno Segno", "D.S.S. al Coda", "D.S.S. al Double Coda",
-					"D.S.S. al Fine", "Da Coda", "Da Double Coda"
-				      };
-			      st->setPlainText(text[i - 4]);
-				st->setParent(s);
-				st->setTrack(0);
-//TODO-ws			st->_measureEnd = true;
-				auto iter = counter.find(articulations[i]);
-				if (iter == counter.end())
-				      counter[articulations[i]] = 1;
+                        StaffText* st = new StaffText(score);
+                        static constexpr char text[][22] = {
+                              "fine", "Da Capo", "D.C. al Coda", "D.C. al Double Coda",
+                              "D.C. al Fine", "Da Segno", "D.S. al Coda", "D.S. al Double Coda",
+                              "D.S. al Fine", "Da Segno Segno", "D.S.S. al Coda", "D.S.S. al Double Coda",
+                              "D.S.S. al Fine", "Da Coda", "Da Double Coda"
+                        };
+                        st->setPlainText(text[i - 4]);
+                        st->setParent(s);
+                        st->setTrack(0);
+                        //TODO-ws			st->_measureEnd = true;
+                        auto iter = counter.find(articulations[i]);
+                        if (iter == counter.end())
+                              counter[articulations[i]] = 1;
                         else {
-//TODO-ws                     st->setElYOffset(-7.0f * counter[articulations[i]]);
-					counter[articulations[i]] += 1;
-				      }
+                              //TODO-ws                     st->setElYOffset(-7.0f * counter[articulations[i]]);
+                              counter[articulations[i]] += 1;
+                              }
                         score->addElement(st);
-			      }
-		      }
-	      }
+                        }
+                  }
+            }
       return true;
       }
 
@@ -1023,15 +1023,15 @@ bool GuitarPro5::readNoteEffects(Note* note)
       if (modMask1 & EFFECT_HAMMER) {
             slur = true;
 #if 0
-		Symbol* s = new Symbol(score);
-		s->setSym(SymId::articLaissezVibrerBelow);
-		s->setParent(note);
-		note->add(s);
+            Symbol* s = new Symbol(score);
+            s->setSym(SymId::articLaissezVibrerBelow);
+            s->setParent(note);
+            note->add(s);
 #endif
-	      }
+            }
       if (modMask1 & EFFECT_LET_RING)
-	      addLetRing(note);
-		//note->setLetRing(true);
+            addLetRing(note);
+      //note->setLetRing(true);
 
       if (modMask1 & EFFECT_GRACE) {
             int fret = readUChar();            // grace fret
@@ -1040,7 +1040,7 @@ bool GuitarPro5::readNoteEffects(Note* note)
             /*int duration =*/ readUChar();            // grace duration
             int gflags = readUChar();
 
-		NoteType note_type = NoteType::ACCIACCATURA;
+            NoteType note_type = NoteType::ACCIACCATURA;
 
             if (gflags & NOTE_APPOGIATURA) //on beat
                   note_type = NoteType::APPOGGIATURA;
@@ -1083,29 +1083,29 @@ bool GuitarPro5::readNoteEffects(Note* note)
             note->chord()->add(gc);
             addDynamic(gn, dynamic);
 #endif
-		auto gnote = score->setGraceNote(note->chord(), grace_pitch, note_type, MScore::division / 2);
-		gnote->setString(note->string());
-		auto sd = note->part()->instrument()->stringData();
-		gnote->setFret(grace_pitch - sd->stringList().at(sd->stringList().size() - note->string() - 1).pitch);
+            auto gnote = score->setGraceNote(note->chord(), grace_pitch, note_type, MScore::division / 2);
+            gnote->setString(note->string());
+            auto sd = note->part()->instrument()->stringData();
+            gnote->setFret(grace_pitch - sd->stringList().at(sd->stringList().size() - note->string() - 1).pitch);
             if (transition == 0) {
                   // no transition
                   }
             else if (transition == 1) {
-			}
-	      else if (transition == 3) {
-		      Slur* slur1 = new Slur(score);
-			slur1->setAnchor(Spanner::Anchor::CHORD);
-			slur1->setStartElement(gnote->chord());
-			slur1->setEndElement(note->chord());
-			slur1->setParent(0);
-			slur1->setTrack(note->staffIdx());
-			slur1->setTrack2(note->staffIdx());
-			slur1->setTick(gnote->chord()->tick());
-			slur1->setTick2(note->chord()->tick());
-//TODO-ws		note->chord()->has_slur = true;
-			score->addElement(slur1);
+                  }
+            else if (transition == 3) {
+                  Slur* slur1 = new Slur(score);
+                  slur1->setAnchor(Spanner::Anchor::CHORD);
+                  slur1->setStartElement(gnote->chord());
+                  slur1->setEndElement(note->chord());
+                  slur1->setParent(0);
+                  slur1->setTrack(note->staffIdx());
+                  slur1->setTrack2(note->staffIdx());
+                  slur1->setTick(gnote->chord()->tick());
+                  slur1->setTick2(note->chord()->tick());
+                  //TODO-ws		note->chord()->has_slur = true;
+                  score->addElement(slur1);
                   //TODO: Add a 'slide' guitar effect when implemented
-			//note->setSlideNote(gn);
+                  //note->setSlideNote(gn);
                   }
 #if 0
             else if (transition == 2 && note->fret()>=0 && note->fret()<=255 && note->fret()!=gn->fret()) {
@@ -1118,44 +1118,44 @@ bool GuitarPro5::readNoteEffects(Note* note)
                   b->setTrack(gn->track());
                   gn->add(b);
                   }
-             else if (transition == 3) {
-                   // TODO:
-                   //     major: replace with a 'hammer-on' guitar effect when implemented
-                   //     minor: make slurs for parts
+            else if (transition == 3) {
+                  // TODO:
+                  //     major: replace with a 'hammer-on' guitar effect when implemented
+                  //     minor: make slurs for parts
 
-                   ChordRest* cr1 = toChord(gc);
-                   ChordRest* cr2 = toChord(note->chord());
+                  ChordRest* cr1 = toChord(gc);
+                  ChordRest* cr2 = toChord(note->chord());
 
-                   Slur* slur = new Slur(score);
-                   slur->setAnchor(Spanner::Anchor::CHORD);
-                   slur->setStartElement(cr1);
-                   slur->setEndElement(cr2);
-                   slur->setTick(cr1->tick());
-                   slur->setTick2(cr2->tick());
-                   slur->setTrack(cr1->track());
-                   slur->setTrack2(cr2->track());
-                   // this case specifies only two-note slurs, don't set a parent
-                   score->undoAddElement(slur);
-                   }
+                  Slur* slur = new Slur(score);
+                  slur->setAnchor(Spanner::Anchor::CHORD);
+                  slur->setStartElement(cr1);
+                  slur->setEndElement(cr2);
+                  slur->setTick(cr1->tick());
+                  slur->setTick2(cr2->tick());
+                  slur->setTrack(cr1->track());
+                  slur->setTrack2(cr2->track());
+                  // this case specifies only two-note slurs, don't set a parent
+                  score->undoAddElement(slur);
+                  }
 #endif
             }
       if (modMask2 & EFFECT_STACATTO) {
             Chord* chord = note->chord();
             Articulation* a = new Articulation(chord->score());
             a->setSymId(SymId::articStaccatoAbove);
-		bool add = true;
-		for (auto& a1 : chord->articulations()) {
-		      if (a1->symId() == SymId::articStaccatoAbove) {
-			      add = false;
-				break;
-				}
+            bool add = true;
+            for (auto& a1 : chord->articulations()) {
+                  if (a1->symId() == SymId::articStaccatoAbove) {
+                        add = false;
+                        break;
+                        }
                   }
             if (add)
                   chord->add(a);
             }
       if (modMask2 & EFFECT_PALM_MUTE)
-	      addPalmMute(note);
-		//note->setPalmMute(true);
+            addPalmMute(note);
+      //note->setPalmMute(true);
 
       if (modMask2 & EFFECT_TREMOLO) {    // tremolo picking length
             int tremoloDivision = readUChar();
@@ -1178,81 +1178,81 @@ bool GuitarPro5::readNoteEffects(Note* note)
                   qDebug("Unknown tremolo value");
                   }
             }
-//      bool skip = false;
+      //      bool skip = false;
       if (modMask2 & EFFECT_SLIDE) {
             int slideKind = readUChar();
-		if (slideKind & SLIDE_OUT_DOWN) {
-		      slideKind &= ~SLIDE_OUT_DOWN;
-			ChordLine* cl = new ChordLine(score);
-			cl->setChordLineType(ChordLineType::FALL);
-			cl->setStraight(true);
-			note->add(cl);
-//			skip = true;
-			}
-	      // slide out upwards (doit)
-		if (slideKind & SLIDE_OUT_UP) {
-		      slideKind &= ~SLIDE_OUT_UP;
-			ChordLine* cl = new ChordLine(score);
-			cl->setChordLineType(ChordLineType::DOIT);
-			cl->setStraight(true);
-			note->add(cl);
-//			skip = true;
-			}
+            if (slideKind & SLIDE_OUT_DOWN) {
+                  slideKind &= ~SLIDE_OUT_DOWN;
+                  ChordLine* cl = new ChordLine(score);
+                  cl->setChordLineType(ChordLineType::FALL);
+                  cl->setStraight(true);
+                  note->add(cl);
+                  //			skip = true;
+                  }
+            // slide out upwards (doit)
+            if (slideKind & SLIDE_OUT_UP) {
+                  slideKind &= ~SLIDE_OUT_UP;
+                  ChordLine* cl = new ChordLine(score);
+                  cl->setChordLineType(ChordLineType::DOIT);
+                  cl->setStraight(true);
+                  note->add(cl);
+                  //			skip = true;
+                  }
             // slide in from below (plop)
-		if (slideKind & SLIDE_IN_BELOW) {
-		      slideKind &= ~SLIDE_IN_BELOW;
-			ChordLine* cl = new ChordLine(score);
-			cl->setChordLineType(ChordLineType::PLOP);
-			cl->setStraight(true);
-			note->add(cl);
-//			skip = true;
-			}
-	      // slide in from above (scoop)
-		if (slideKind & SLIDE_IN_ABOVE) {
-		      slideKind &= ~SLIDE_IN_ABOVE;
-			ChordLine* cl = new ChordLine(score);
-			cl->setChordLineType(ChordLineType::SCOOP);
-			cl->setStraight(true);
-			note->add(cl);
-//			skip = true;
-			}
+            if (slideKind & SLIDE_IN_BELOW) {
+                  slideKind &= ~SLIDE_IN_BELOW;
+                  ChordLine* cl = new ChordLine(score);
+                  cl->setChordLineType(ChordLineType::PLOP);
+                  cl->setStraight(true);
+                  note->add(cl);
+                  //			skip = true;
+                  }
+            // slide in from above (scoop)
+            if (slideKind & SLIDE_IN_ABOVE) {
+                  slideKind &= ~SLIDE_IN_ABOVE;
+                  ChordLine* cl = new ChordLine(score);
+                  cl->setChordLineType(ChordLineType::SCOOP);
+                  cl->setStraight(true);
+                  note->add(cl);
+                  //			skip = true;
+                  }
 
-	      if (false && !slideList.empty() && slideList.back()->chord()->segment() != note->chord()->segment()) {
+            if (false && !slideList.empty() && slideList.back()->chord()->segment() != note->chord()->segment()) {
                   Note* start = slideList.front();
-			slideList.pop_front();
-			bool skip = false;
-			for (auto e : start->el()) {
-			      if (e->isChordLine())
+                  slideList.pop_front();
+                  bool skip = false;
+                  for (auto e : start->el()) {
+                        if (e->isChordLine())
                               skip = true;
                         }
                   if (!skip) {
-			      Glissando* s = new Glissando(score);
-				s->setAnchor(Spanner::Anchor::NOTE);
-				s->setStartElement(start);
-				s->setTick(start->chord()->segment()->tick());
-				s->setTrack(start->staffIdx());
-				s->setParent(start);
-				s->setGlissandoType(GlissandoType::STRAIGHT);
-				s->setEndElement(note);
-				s->setTick2(note->chord()->segment()->tick());
-				s->setTrack2(note->staffIdx());
-				score->addElement(s);
-				}
-			}
+                        Glissando* s = new Glissando(score);
+                        s->setAnchor(Spanner::Anchor::NOTE);
+                        s->setStartElement(start);
+                        s->setTick(start->chord()->segment()->tick());
+                        s->setTrack(start->staffIdx());
+                        s->setParent(start);
+                        s->setGlissandoType(GlissandoType::STRAIGHT);
+                        s->setEndElement(note);
+                        s->setTick2(note->chord()->segment()->tick());
+                        s->setTrack2(note->staffIdx());
+                        score->addElement(s);
+                        }
+                  }
             if (slideKind & LEGATO_SLIDE) {
                   slideKind &= ~LEGATO_SLIDE;
-			slideList.push_back(nullptr);
-			createSlur(true, note->staffIdx(), note->chord());
-			}
-	      if (slideKind & SHIFT_SLIDE) {
+                  slideList.push_back(nullptr);
+                  createSlur(true, note->staffIdx(), note->chord());
+                  }
+            if (slideKind & SHIFT_SLIDE) {
 #if 0
                   slideKind &= ~SHIFT_SLIDE;
 #endif
-			slideList.push_back(note);
-			}
+                  slideList.push_back(note);
+                  }
 #if 0
             if (slideKind)
-		      int k = 1;
+                  int k = 1;
             if (slideKind > 4)
                   int k = 1;
             // if slide >= 4 then we are not dealing with legato slide nor shift slide
@@ -1265,45 +1265,45 @@ bool GuitarPro5::readNoteEffects(Note* note)
 
       if (modMask2 & EFFECT_ARTIFICIAL_HARMONIC) {
             int type = readArtificialHarmonic();
-		if (type == 2) {
+            if (type == 2) {
                   auto harmNote = readUChar();
-			/*auto sharp =*/ readChar();
-			auto octave = readUChar();
+                  /*auto sharp =*/ readChar();
+                  auto octave = readUChar();
 
-			auto harmonicNote = new Note(score);
-//TODO-ws		harmonicNote->setHarmonic(true);
-			note->chord()->add(harmonicNote);
-			auto staff = note->staff();
-//			int string = staff->part()->instrument()->stringData()->strings() - 1 - note->string();
-			int fret = note->fret();
-			switch (harmNote) {
+                  auto harmonicNote = new Note(score);
+                  //TODO-ws		harmonicNote->setHarmonic(true);
+                  note->chord()->add(harmonicNote);
+                  auto staff = note->staff();
+                  //			int string = staff->part()->instrument()->stringData()->strings() - 1 - note->string();
+                  int fret = note->fret();
+                  switch (harmNote) {
                         case 0: fret += 24; break;
-			      case 2: fret += 34; break;
-			      case 4: fret += 38; break;
-			      case 5: fret += 12; break;
-			      case 7: fret += 32; break;
-			      case 9: fret += 28; break;
-			      default: fret += octave * 12;
-			      }
-		      harmonicNote->setString(note->string());
-			harmonicNote->setFret(fret);
-			harmonicNote->setPitch(staff->part()->instrument()->stringData()->getPitch(note->string(), fret, nullptr, Fraction(0,1)));
-			harmonicNote->setTpcFromPitch();
-			addTextToNote("A.H.", Align::CENTER, harmonicNote);
-		      }
+                        case 2: fret += 34; break;
+                        case 4: fret += 38; break;
+                        case 5: fret += 12; break;
+                        case 7: fret += 32; break;
+                        case 9: fret += 28; break;
+                        default: fret += octave * 12;
+                        }
+                  harmonicNote->setString(note->string());
+                  harmonicNote->setFret(fret);
+                  harmonicNote->setPitch(staff->part()->instrument()->stringData()->getPitch(note->string(), fret, nullptr, Fraction(0,1)));
+                  harmonicNote->setTpcFromPitch();
+                  addTextToNote("A.H.", Align::CENTER, harmonicNote);
+                  }
             if (type == 1 || type == 4 || type == 5) {
                   //TextStyle textStyle;
-			//textStyle.setAlign(Align::CENTER);
-			//addTextToNote("N.H.", textStyle, note);
-//TODO-ws		note->setHarmonic(true);
-		      }
-	      }
+                  //textStyle.setAlign(Align::CENTER);
+                  //addTextToNote("N.H.", textStyle, note);
+                  //TODO-ws		note->setHarmonic(true);
+                  }
+            }
 
-            if (modMask2 & 0x40)
-                  addVibrato(note);
+      if (modMask2 & 0x40)
+            addVibrato(note);
 
       if (modMask2 & EFFECT_TRILL) {
-//TODO-ws            note->setTrillFret(readUChar());      // trill fret
+            //TODO-ws            note->setTrillFret(readUChar());      // trill fret
             readUChar();      // trill fret
 
             int period = readUChar();      // trill length
@@ -1378,7 +1378,7 @@ bool GuitarPro5::readNote(int string, Note* note)
 
       int fretNumber = 0;
       if (noteBits & NOTE_FRET) {
-	      fretNumber = readChar();
+            fretNumber = readChar();
             }
 
       if (noteBits & NOTE_FINGERING) {
@@ -1431,7 +1431,7 @@ bool GuitarPro5::readNote(int string, Note* note)
       if (noteBits & NOTE_SFORZATO) {
             Articulation* art = new Articulation(note->score());
             art->setSymId(SymId::articAccentAbove);
-			note->add(art);
+            note->add(art);
             // if (!note->score()->addArticulation(note, art))
             //      delete art;
             }
@@ -1453,40 +1453,40 @@ bool GuitarPro5::readNote(int string, Note* note)
       bool slur = false;
       if (noteBits & NOTE_SLUR) {
             slur = readNoteEffects(note);
-	      }
+            }
 
       if (tieNote) {
             auto staffIdx = note->staffIdx();
-		if (dead_end[{staffIdx, string}]) {
-		      note->setFret(-20);
-			return false;
-		      }
+            if (dead_end[{staffIdx, string}]) {
+                  note->setFret(-20);
+                  return false;
+                  }
             if (slurs[staffIdx]) {
                   score->removeSpanner(slurs[staffIdx]);
-			delete slurs[staffIdx];
-			slurs[staffIdx] = 0;
-		      }
+                  delete slurs[staffIdx];
+                  slurs[staffIdx] = 0;
+                  }
             bool found = false;
             Chord* chord     = note->chord();
             Segment* segment = chord->segment()->prev1(SegmentType::ChordRest);
             int track        = note->track();
-		std::vector<ChordRest*> chords;
-		Note* true_note = nullptr;
+            std::vector<ChordRest*> chords;
+            Note* true_note = nullptr;
             while (segment) {
                   Element* e = segment->element(track);
                   if (e) {
                         if (e->isChord()) {
                               Chord* chord2 = toChord(e);
-                              foreach (Note* note2, chord2->notes()) {
+                              for (Note* note2 : chord2->notes()) {
                                     if (note2->string() == string) {
-					            if (chords.empty()) {
+                                          if (chords.empty()) {
                                                 Tie* tie = new Tie(score);
-	      						tie->setEndNote(note);
-		      					note2->add(tie);
-			      				}
+                                                tie->setEndNote(note);
+                                                note2->add(tie);
+                                                }
                                           note->setFret(note2->fret());
                                           note->setPitch(note2->pitch());
-						      true_note = note2;
+                                          true_note = note2;
                                           found = true;
                                           break;
                                           }
@@ -1495,7 +1495,7 @@ bool GuitarPro5::readNote(int string, Note* note)
                         if (found)
                               break;
                         else {
-				      if (e)
+                              if (e)
                                     chords.push_back(toChordRest(e));
                               }
                         }
@@ -1503,54 +1503,54 @@ bool GuitarPro5::readNote(int string, Note* note)
                   }
             if (true_note && chords.size()) {
                   Note* end_note = note;
-			for (unsigned int i = 0; i < chords.size(); ++i) {
+                  for (unsigned int i = 0; i < chords.size(); ++i) {
                         Chord* chord1 = nullptr;
-				auto cr = chords.at(i);
-				if (cr->isChord())
+                        auto cr = chords.at(i);
+                        if (cr->isChord())
                               chord1 = toChord(cr);
                         else {
-				      auto rest = toRest(cr);
-					auto dur = rest->ticks();
-					auto dut = rest->durationType();
-					auto seg = rest->segment();
-					seg->remove(rest);
-					auto tuplet = rest->tuplet();
-					if (tuplet)
+                              auto rest = toRest(cr);
+                              auto dur = rest->ticks();
+                              auto dut = rest->durationType();
+                              auto seg = rest->segment();
+                              seg->remove(rest);
+                              auto tuplet = rest->tuplet();
+                              if (tuplet)
                                     tuplet->remove(rest);
-					delete rest;
-					chord1 = new Chord(score);
-					chord1->setTrack(note->track());
-					chord1->setTicks(dur);
-					chord1->setDurationType(dut);
-					seg->add(chord1);
-					if (tuplet)
+                              delete rest;
+                              chord1 = new Chord(score);
+                              chord1->setTrack(note->track());
+                              chord1->setTicks(dur);
+                              chord1->setDurationType(dut);
+                              seg->add(chord1);
+                              if (tuplet)
                                     tuplet->add(chord1);
-					}
+                              }
 
-			      Note* note2 = new Note(score);
-				note2->setString(true_note->string());
-				note2->setFret(true_note->fret());
-				note2->setPitch(true_note->pitch());
-				note2->setTpcFromPitch();
-				chord1->setNoteType(true_note->noteType());
-				chord1->add(note2);
-				Tie* tie = new Tie(score);
-				tie->setEndNote(end_note);
-//TODO-ws			end_note->setHarmonic(true_note->harmonic());
-				end_note = note2;
-				note2->add(tie);
-				}
-		      Tie* tie = new Tie(score);
-			tie->setEndNote(end_note);
-//TODO-ws		end_note->setHarmonic(true_note->harmonic());
-			true_note->add(tie);
-			}
+                        Note* note2 = new Note(score);
+                        note2->setString(true_note->string());
+                        note2->setFret(true_note->fret());
+                        note2->setPitch(true_note->pitch());
+                        note2->setTpcFromPitch();
+                        chord1->setNoteType(true_note->noteType());
+                        chord1->add(note2);
+                        Tie* tie = new Tie(score);
+                        tie->setEndNote(end_note);
+                        //TODO-ws			end_note->setHarmonic(true_note->harmonic());
+                        end_note = note2;
+                        note2->add(tie);
+                        }
+                  Tie* tie = new Tie(score);
+                  tie->setEndNote(end_note);
+                  //TODO-ws		end_note->setHarmonic(true_note->harmonic());
+                  true_note->add(tie);
+                  }
             if (!found) {
-		      note->setFret(-20);
-			dead_end[{staffIdx, string}] = true;
-			qDebug("tied note not found, pitch %d fret %d string %d", note->pitch(), note->fret(), note->string());
-			return false;
-			}
+                  note->setFret(-20);
+                  dead_end[{staffIdx, string}] = true;
+                  qDebug("tied note not found, pitch %d fret %d string %d", note->pitch(), note->fret(), note->string());
+                  return false;
+                  }
             }
       dead_end[{note->staffIdx(), string}] = false;
       return slur;
@@ -1577,7 +1577,7 @@ int GuitarPro5::readArtificialHarmonic()
             case 5:           // semi
                   break;
             }
-	  return type;
+      return type;
       }
 
 }

--- a/importexport/guitarpro/importgtp-gp6.cpp
+++ b/importexport/guitarpro/importgtp-gp6.cpp
@@ -801,9 +801,9 @@ void GuitarPro6::makeTie(Note* note)
       while (segment) {
             Element* e = segment->element(track);
             if (e) {
-                  if (e->type() == ElementType::CHORD) {
-                        Chord* chord2 = static_cast<Chord*>(e);
-                        foreach(Note* note2, chord2->notes()) {
+                  if (e->isChord()) {
+                        Chord* chord2 = toChord(e);
+                        for (Note* note2 : chord2->notes()) {
                               if (note2->string() == note->string()) {
                                     Tie* tie = new Tie(score);
                                     tie->setEndNote(note);
@@ -959,7 +959,7 @@ Fraction GuitarPro6::readBeats(QString beats, GPPartInfo* partInfo, Measure* mea
                                                 note->add(dot);
                                                 }
 
-                                          Chord* chord = static_cast<Chord*>(cr);
+                                          Chord* chord = toChord(cr);
                                           chord->add(note);
                                           QString harmonicText = "";
                                           bool use_harmonic    = true;
@@ -1487,8 +1487,8 @@ Fraction GuitarPro6::readBeats(QString beats, GPPartInfo* partInfo, Measure* mea
                                                 int strack = staffIdx * VOICES;
                                                 int etrack = staffIdx * VOICES + VOICES;
                                                 for (const Element* e : segment->annotations()) {
-                                                      if (e->type() == ElementType::STAFF_TEXT && e->track() >= strack && e->track() < etrack) {
-                                                            const StaffText* st = static_cast<const StaffText*>(e);
+                                                      if (e->isStaffText() && e->track() >= strack && e->track() < etrack) {
+                                                            const StaffText* st = toStaffText(e);
                                                             if (!st->xmlText().compare(text)) {
                                                                   t = true;
                                                                   break;
@@ -1537,7 +1537,7 @@ Fraction GuitarPro6::readBeats(QString beats, GPPartInfo* partInfo, Measure* mea
                                                       addVibrato(note, Vibrato::Type::GUITAR_VIBRATO_WIDE);
                                                 }
 
-                                          if (cr && (cr->type() == ElementType::CHORD) && sl > 0)
+                                          if (cr && (cr->isChord()) && sl > 0)
                                                 createSlide(sl, cr, staffIdx);
                                           note->setTpcFromPitch();
 
@@ -1597,7 +1597,7 @@ Fraction GuitarPro6::readBeats(QString beats, GPPartInfo* partInfo, Measure* mea
                                                       lyrNote = nullptr;
                                                       }
                                                 }
-                                          else if (!graceNode.toElement().text().compare("BeforeBeat") && chord->type() == ElementType::CHORD) {
+                                          else if (!graceNode.toElement().text().compare("BeforeBeat") && chord->isChord()) {
                                                 auto gNote = score->setGraceNote(chord, lyrNote->pitch(), NoteType::ACCIACCATURA, MScore::division / 2);
                                                 auto iter1  = slideMap.end();
                                                 for (auto beg = slideMap.begin(); beg != slideMap.end(); ++beg) {
@@ -1778,7 +1778,7 @@ Fraction GuitarPro6::readBeats(QString beats, GPPartInfo* partInfo, Measure* mea
                         tuplet->add(cr);
                         }
                   cr->setTicks(l);
-                  if (cr->type() == ElementType::REST && l >= measure->ticks()) {
+                  if (cr->isRest() && l >= measure->ticks()) {
                         cr->setDurationType(TDuration::DurationType::V_MEASURE);
                         cr->setTicks(measure->ticks());
                         }
@@ -1979,8 +1979,8 @@ bool checkForHold(Segment* segment, QList<PitchValue> points)
       Segment* prevSeg = segment->prev1(SegmentType::ChordRest);
       if (!prevSeg)
             return false;
-      foreach (Element* e, prevSeg->annotations()) {
-            if (e->type() == ElementType::TREMOLOBAR) {
+      for (Element* e : prevSeg->annotations()) {
+            if (e->isTremoloBar()) {
                   QList<PitchValue> prevPoints = ((TremoloBar*)e)->points();
                   if (prevPoints.length() != points.length())
                         break;
@@ -2047,8 +2047,8 @@ void GuitarPro6::addTremoloBar(Segment* segment, int track, int whammyOrigin, in
             Segment* prevSeg = segment->prev1(SegmentType::ChordRest);
             if (!prevSeg)
                   return;
-            foreach (Element* e, prevSeg->annotations()) {
-                  if (e->type() == ElementType::TREMOLOBAR) {
+            for (Element* e : prevSeg->annotations()) {
+                  if (e->isTremoloBar()) {
                         QList<PitchValue> prevPoints = ((TremoloBar*)e)->points();
                         QList<PitchValue> points;
                         points.append(PitchValue(0, prevPoints[prevPoints.length() - 1].pitch, false));
@@ -2390,7 +2390,7 @@ void GuitarPro6::readMasterBars(GPPartInfo* partInfo)
                                                 for (const Segment* seg = measure->prevMeasure()->last(); seg; seg = seg->prev1()) {
                                                       Element* el = seg->element(i);
                                                       if (el && el->isChord()) {
-                                                            c = static_cast<Chord*>(el);
+                                                            c = toChord(el);
                                                             break;
                                                             }
                                                       }
@@ -2496,7 +2496,7 @@ void GuitarPro6::readGpif(QByteArray* data)
                   for (const Segment* seg = score->lastSegment(); seg; seg = seg->prev1()) {
                         Element* el = seg->element(i);
                         if (el && el->isChord()) {
-                              c = static_cast<Chord*>(el);
+                              c = toChord(el);
                               break;
                               }
                         }

--- a/importexport/guitarpro/importptb.cpp
+++ b/importexport/guitarpro/importptb.cpp
@@ -1332,7 +1332,7 @@ Score::FileError PowerTab::read()
             // create excerpt title
             //
             MeasureBase* measure = pscore->first();
-            if (!measure || (measure->type() != ElementType::VBOX)) {
+            if (!measure || !measure->isVBox()) {
                   MeasureBase* mb = new VBox(pscore);
                   mb->setTick(Fraction(0,1));
                   pscore->addMeasure(mb, measure);

--- a/importexport/midiimport/importmidi_clef.cpp
+++ b/importexport/midiimport/importmidi_clef.cpp
@@ -120,7 +120,7 @@ AveragePitch findAverageSegPitch(const Segment *seg, int strack)
       {
       AveragePitch averagePitch;
       for (int voice = 0; voice < VOICES; ++voice) {
-            ChordRest *cr = static_cast<ChordRest *>(seg->element(strack + voice));
+            ChordRest *cr = toChordRest(seg->element(strack + voice));
             if (cr && cr->isChord()) {
                   Chord *chord = toChord(cr);
                   const auto &notes = chord->notes();
@@ -135,7 +135,7 @@ MinMaxPitch findMinMaxSegPitch(const Segment *seg, int strack)
       {
       MinMaxPitch minMaxPitch;
       for (int voice = 0; voice < VOICES; ++voice) {
-            ChordRest *cr = static_cast<ChordRest *>(seg->element(strack + voice));
+            ChordRest *cr = toChordRest(seg->element(strack + voice));
             if (cr && cr->isChord()) {
                   Chord *chord = toChord (cr);
                   const auto &notes = chord->notes();
@@ -156,13 +156,13 @@ bool doesClefBreakTie(const Staff *staff)
       for (int voice = 0; voice < VOICES; ++voice) {
             bool currentTie = false;
             for (Segment *seg = staff->score()->firstSegment(SegmentType::All); seg; seg = seg->next1()) {
-                  if (seg->segmentType() == SegmentType::ChordRest) {
+                  if (seg->isChordRestType()) {
                         if (MidiTie::isTiedBack(seg, strack, voice))
                               currentTie = false;
                         if (MidiTie::isTiedFor(seg, strack, voice))
                               currentTie = true;
                         }
-                  else if (seg->segmentType() == SegmentType::Clef && seg->element(strack)) {
+                  else if (seg->isClefType() && seg->element(strack)) {
                         if (currentTie) {
                               qDebug() << "Clef breaks tie; measure number (from 1):"
                                        << seg->measure()->no() + 1
@@ -223,7 +223,7 @@ findChordRest(const Segment *seg, int strack)
       ElementType elType = ElementType::INVALID;
       ReducedFraction newRestLen(0, 1);
       for (int voice = 0; voice < VOICES; ++voice) {
-            ChordRest *cr = static_cast<ChordRest *>(seg->element(strack + voice));
+            ChordRest *cr = toChordRest(seg->element(strack + voice));
             if (!cr)
                   continue;
             if (cr->isChord()) {

--- a/importexport/midiimport/importmidi_swing.cpp
+++ b/importexport/midiimport/importmidi_swing.cpp
@@ -93,7 +93,7 @@ void SwingDetector::checkNormalSwing()
       {
       if (elements.size() == 2
                   && areAllTuplets()
-                  && (elements[0]->isChord() || elements[1]->type() == ElementType::CHORD)
+                  && (elements[0]->isChord() || elements[1]->isChord())
                   && elements[0]->ticks().reduced() == Fraction(1, 4)
                   && elements[1]->ticks().reduced() == Fraction(1, 8))
             {
@@ -217,7 +217,7 @@ void detectSwing(Staff *staff, MidiOperations::Swing swingType)
       for (Segment *seg = score->firstSegment(SegmentType::ChordRest); seg;
                                       seg = seg->next1(SegmentType::ChordRest)) {
             for (int voice = 0; voice < VOICES; ++voice) {
-                  ChordRest *cr = static_cast<ChordRest *>(seg->element(strack + voice));
+                  ChordRest *cr = toChordRest(seg->element(strack + voice));
                   if (!cr)
                         continue;
                   swingDetector.add(cr);

--- a/importexport/midiimport/importmidi_tie.cpp
+++ b/importexport/midiimport/importmidi_tie.cpp
@@ -31,7 +31,7 @@ namespace MidiTie {
 bool isTied(const Segment *seg, int strack, int voice,
             Ms::Tie*(Note::*tieFunc)() const)
       {
-      ChordRest *cr = static_cast<ChordRest *>(seg->element(strack + voice));
+      ChordRest *cr = toChordRest(seg->element(strack + voice));
       if (cr && cr->isChord()) {
             Chord *chord = toChord(cr);
             const auto &notes = chord->notes();
@@ -58,7 +58,7 @@ void TieStateMachine::addSeg(const Segment *seg, int strack)
       {
       bool isChord = false;
       for (int voice = 0; voice < VOICES; ++voice) {
-            ChordRest *cr = static_cast<ChordRest *>(seg->element(strack + voice));
+            ChordRest *cr = toChordRest(seg->element(strack + voice));
             if (!cr || !cr->isChord())
                   continue;
             if (!isChord)
@@ -108,8 +108,8 @@ bool areTiesConsistent(const Staff *staff)
       for (int voice = 0; voice < VOICES; ++voice) {
             bool isTie = false;
             for (Segment *seg = staff->score()->firstSegment(SegmentType::All); seg; seg = seg->next1()) {
-                  if (seg->segmentType() == SegmentType::ChordRest) {
-                        ChordRest *cr = static_cast<ChordRest *>(seg->element(strack + voice));
+                  if (seg->isChordRestType()) {
+                        ChordRest *cr = toChordRest(seg->element(strack + voice));
 
                         if (cr && cr->isRest() && isTie) {
                               printInconsistentTieLocation(seg->measure()->no(), staff->idx());

--- a/importexport/midiimport/importmidi_tuplet_tonotes.cpp
+++ b/importexport/midiimport/importmidi_tuplet_tonotes.cpp
@@ -88,7 +88,7 @@ bool haveTupletsEnoughElements(const Staff *staff)
 
       for (int voice = 0; voice < VOICES; ++voice) {
             for (Segment *seg = staff->score()->firstSegment(SegmentType::All); seg; seg = seg->next1()) {
-                  if (seg->segmentType() == SegmentType::ChordRest) {
+                  if (seg->isChordRestType()) {
                         const ChordRest *cr = static_cast<ChordRest *>(seg->element(strack + voice));
                         if (!cr)
                               continue;

--- a/importexport/musedata/musedata.cpp
+++ b/importexport/musedata/musedata.cpp
@@ -52,7 +52,7 @@ void MuseData::musicalAttribute(QString s, Part* part)
 #else
       QStringList al = s.mid(3).split(" ", QString::SkipEmptyParts);
 #endif
-      foreach(QString item, al) {
+      for (QString item : al) {
             if (item.startsWith("K:")) {
                   int key = item.midRef(2).toInt();
                   KeySigEvent ke;
@@ -424,7 +424,7 @@ void MuseData::readNote(Part* part, const QString& s)
       if (!txt.isEmpty()) {
             QStringList sl = txt.split("|");
             int no = 0;
-            foreach(QString w, sl) {
+            for (QString w : sl) {
                   w = diacritical(w);
                   Lyrics* l = new Lyrics(score);
                   l->setPlainText(w);
@@ -527,9 +527,9 @@ void MuseData::readBackup(const QString& s)
 Measure* MuseData::createMeasure()
       {
       for (MeasureBase* mb = score->first(); mb; mb = mb->next()) {
-            if (mb->type() != ElementType::MEASURE)
+            if (!mb->isMeasure())
                   continue;
-            Measure* m = (Measure*)mb;
+            Measure* m = toMeasure(mb);
             Fraction st = m->tick();
             Fraction l  = m->ticks();
             if (curTick == st)
@@ -552,7 +552,7 @@ Measure* MuseData::createMeasure()
       mes->setTick(curTick);
 
 #if 0
-      foreach(Staff* s, score->staves()) {
+      for (Staff* s : score->staves()) {
             if (s->isTop()) {
                   BarLine* barLine = new BarLine(score);
                   barLine->setStaff(s);

--- a/importexport/musicxml/exportxml.cpp
+++ b/importexport/musicxml/exportxml.cpp
@@ -5730,7 +5730,7 @@ static void directionMarker(XmlWriter& xml, const Marker* const m, const std::ve
 
 static int findTrackForAnnotations(int track, Segment* seg)
       {
-      if (seg->segmentType() != SegmentType::ChordRest)
+      if (!seg->isChordRestType())
             return -1;
 
       if (seg->element(track))
@@ -6137,7 +6137,7 @@ static void writeMusicXML(const FiguredBass* item, XmlWriter& xml, bool isOrigin
 static void figuredBass(XmlWriter& xml, int strack, int etrack, int track, const ChordRest* cr, FigBassMap& fbMap, int divisions)
       {
       Segment* seg = cr->segment();
-      if (seg->segmentType() == SegmentType::ChordRest) {
+      if (seg->isChordRestType()) {
             for (const Element* e : seg->annotations()) {
                   int wtrack = -1; // track to write annotation
 
@@ -6211,7 +6211,7 @@ static void figuredBass(XmlWriter& xml, int strack, int etrack, int track, const
 
 static void spannerStart(ExportMusicXml* exp, int strack, int etrack, int track, int sstaff, Segment* seg)
       {
-      if (seg->segmentType() == SegmentType::ChordRest) {
+      if (seg->isChordRestType()) {
             Fraction stick = seg->tick();
             for (auto it = exp->score()->spanner().lower_bound(stick.ticks()); it != exp->score()->spanner().upper_bound(stick.ticks()); ++it) {
                   Spanner* e = it->second;
@@ -6907,7 +6907,7 @@ void ExportMusicXml::findAndExportClef(const Measure* const m, const int staves,
                         clefDebug("exportxml: clef at start measure ti=%d ct=%d gen=%d", tick, int(cle->clefType()), cle->generated());
                         // output only clef changes, not generated clefs at line beginning
                         // exception: at tick=0, export clef anyway
-                        if ((tick.isZero() || !cle->generated()) && ((seg->measure() != m) || ((seg->segmentType() == SegmentType::HeaderClef) && !cle->otherClef()))) {
+                        if ((tick.isZero() || !cle->generated()) && ((seg->measure() != m) || ((seg->isHeaderClefType()) && !cle->otherClef()))) {
                               clefDebug("exportxml: clef exported");
                               QString clefAttr = color2xml(cle);
                               if (!cle->visible())
@@ -7170,7 +7170,7 @@ void ExportMusicXml::writeElement(Element* el, const Measure* m, int sstaff, boo
                   }
             else if (!el->generated() && tickIsInMiddleOfMeasure(ti, m))
                   clef(sstaff, cle->clefType(), color2xml(cle) + visible);
-            else if (!el->generated() && (ti == m->tick()) && (cle->segment()->segmentType() != SegmentType::HeaderClef))
+            else if (!el->generated() && (ti == m->tick()) && !cle->segment()->isHeaderClefType())
                   clef(sstaff, cle->clefType(), color2xml(cle) + visible + QString(" after-barline=\"yes\""));
             else
                   clefDebug("exportxml: clef not exported");
@@ -7393,7 +7393,7 @@ void ExportMusicXml::writeInstrumentDetails(const Instrument* instrument, const 
 static void annotationsWithoutNote(ExportMusicXml* exp, const int strack, const int staves, const Measure* const measure)
       {
       for (Segment* segment = measure->first(); segment; segment = segment->next()) {
-            if (segment->segmentType() == SegmentType::ChordRest) {
+            if (segment->isChordRestType()) {
                   for (const Element* element : segment->annotations()) {
                         if (!element->isFiguredBass() && !element->isHarmony()) {       // handled elsewhere
                               const int wtrack = findTrackForAnnotations(element->track(), segment); // track to write annotation

--- a/importexport/musicxml/importmxmlpass1.cpp
+++ b/importexport/musicxml/importmxmlpass1.cpp
@@ -250,7 +250,7 @@ bool MusicXMLParserPass1::determineMeasureLength(QVector<Fraction>& ml) const
 
       // determine number of measures: max number of measures in any part
       int nMeasures = 0;
-      foreach (const MusicXmlPart &part, _parts) {
+      for (const MusicXmlPart &part : _parts) {
             if (part.nMeasures() > nMeasures)
                   nMeasures = part.nMeasures();
             }
@@ -258,7 +258,7 @@ bool MusicXMLParserPass1::determineMeasureLength(QVector<Fraction>& ml) const
       // determine max length of a specific measure in all parts
       for (int i = 0; i < nMeasures; ++i) {
             Fraction maxMeasDur;
-            foreach (const MusicXmlPart &part, _parts) {
+            for (const MusicXmlPart &part : _parts) {
                   if (i < part.nMeasures()) {
                         Fraction measDurPartJ = part.measureDuration(i);
                         if (measDurPartJ > maxMeasDur)
@@ -2983,7 +2983,7 @@ void MusicXMLParserPass1::direction(const QString& partId, const Fraction cTime)
             }
 
       // handle the stops first
-      foreach (auto desc, stops) {
+      for (auto desc : stops) {
             if (_octaveShifts.contains(desc.num)) {
                   MxmlOctaveShiftDesc prevDesc = _octaveShifts.value(desc.num);
                   if (prevDesc.tp == MxmlOctaveShiftDesc::Type::UP
@@ -3001,7 +3001,7 @@ void MusicXMLParserPass1::direction(const QString& partId, const Fraction cTime)
             }
 
       // then handle the starts
-      foreach (auto desc, starts) {
+      for (auto desc : starts) {
             if (_octaveShifts.contains(desc.num)) {
                   MxmlOctaveShiftDesc prevDesc = _octaveShifts.value(desc.num);
                   if (prevDesc.tp == MxmlOctaveShiftDesc::Type::STOP) {

--- a/importexport/musicxml/musicxmlfonthandler.cpp
+++ b/importexport/musicxml/musicxmlfonthandler.cpp
@@ -98,7 +98,7 @@ QString MScoreTextToMXML::toPlainText(const QString& text)
       {
       QString res;
       bool inElem = false;
-      foreach(QChar ch, text) {
+      for (QChar ch : text) {
             if (ch == '<')
                   inElem = true;
             else if (ch == '>')

--- a/importexport/ove/importove.cpp
+++ b/importexport/ove/importove.cpp
@@ -717,9 +717,9 @@ void OveToMScore::convertTrackElements(int track) {
 
 void OveToMScore::convertLineBreak(){
       for (MeasureBase* mb = score_->measures()->first(); mb; mb = mb->next()) {
-            if (mb->type() != ElementType::MEASURE)
+            if (!mb->isMeasure())
                   continue;
-            Measure* measure = static_cast<Measure*> (mb);
+            Measure* measure = toMeasure(mb);
 
             for (int i = 0; i < ove_->getLineCount(); ++i) {
                   OVE::Line* line = ove_->getLine(i);
@@ -1138,9 +1138,9 @@ OVE::ClefType getClefType(OVE::MeasureData* measure, int tick) {
 
 void OveToMScore::convertMeasures() {
       for (MeasureBase* mb = score_->measures()->first(); mb; mb = mb->next()) {
-            if (mb->type() != ElementType::MEASURE)
+            if (!mb->isMeasure())
                   continue;
-            Measure* measure = static_cast<Measure*>(mb);
+            Measure* measure = toMeasure(mb);
             int tick = measure->tick().ticks();
             measure->setTicks(score_->sigmap()->timesig(tick).timesig());
             measure->setTimesig(score_->sigmap()->timesig(tick).timesig()); //?
@@ -1149,9 +1149,9 @@ void OveToMScore::convertMeasures() {
 
       //  convert based on notes
       for (MeasureBase* mb = score_->measures()->first(); mb; mb = mb->next()) {
-            if (mb->type() != ElementType::MEASURE)
+            if (!mb->isMeasure())
                   continue;
-            Measure* measure = static_cast<Measure*>(mb);
+            Measure* measure = toMeasure(mb);
 
             convertLines(measure);
             }

--- a/libmscore/ambitus.cpp
+++ b/libmscore/ambitus.cpp
@@ -631,7 +631,7 @@ void Ambitus::updateRange()
 
 void Ambitus::remove(Element* e)
       {
-      if (e->type() == ElementType::ACCIDENTAL) {
+      if (e->isAccidental()) {
             //! NOTE Do nothing (removing _topAccid or _bottomAccid)
             return;
             }

--- a/libmscore/arpeggio.cpp
+++ b/libmscore/arpeggio.cpp
@@ -461,7 +461,7 @@ void Arpeggio::spatiumChanged(qreal oldValue, qreal newValue)
 
 bool Arpeggio::acceptDrop(EditData& data) const
       {
-      return data.dropElement->type() == ElementType::ARPEGGIO;
+      return data.dropElement->isArpeggio();
       }
 
 //---------------------------------------------------------

--- a/libmscore/bagpembell.cpp
+++ b/libmscore/bagpembell.cpp
@@ -337,7 +337,7 @@ noteList BagpipeEmbellishment::getNoteList() const
       if (_embelType >= 0 && _embelType < nEmbellishments()) {
             QStringList notes = BagpipeEmbellishmentList[_embelType].notes.split(' ');
             int noteInfoSize = sizeof(BagpipeNoteInfoList) / sizeof(*BagpipeNoteInfoList);
-            foreach (const QString note, notes) {
+            for (QString& note : notes) {
                   // search for note in BagpipeNoteInfoList
                   for (int i = 0; i < noteInfoSize; ++i) {
                         if (BagpipeNoteInfoList[i].name == note) {
@@ -501,7 +501,7 @@ void BagpipeEmbellishment::layout()
 
       // draw the notes including stem, (optional) flag and (optional) ledger line
       qreal x = dx.xl;
-      foreach (int note, nl) {
+      for (int& note : nl) {
             int line = BagpipeNoteInfoList[note].line;
             BEDrawingDataY dy(line, score()->spatium());
 
@@ -607,7 +607,7 @@ void BagpipeEmbellishment::draw(QPainter* painter) const
 
       // draw the notes including stem, (optional) flag and (optional) ledger line
       qreal x = dx.xl;
-      foreach (int note, nl) {
+      for (int& note : nl) {
             int line = BagpipeNoteInfoList[note].line;
             BEDrawingDataY dy(line, score()->spatium());
             drawGraceNote(painter, dx, dy, flagsym, x, drawFlag);

--- a/libmscore/barline.cpp
+++ b/libmscore/barline.cpp
@@ -46,7 +46,7 @@ static void undoChangeBarLineType(BarLine* bl, BarLineType barType, bool allStav
 
       bool keepStartRepeat = false;
 
-      if (barType == BarLineType::START_REPEAT && bl->segment()->segmentType() != SegmentType::BeginBarLine) {
+      if (barType == BarLineType::START_REPEAT && !bl->segment()->isBeginBarLineType()) {
             m = m->nextMeasure();
             if (!m) // we were in last measure
                   return;
@@ -92,8 +92,7 @@ static void undoChangeBarLineType(BarLine* bl, BarLineType barType, bool allStav
                         keepStartRepeat = true;
 
                   Segment* segment = bl->segment();
-                  SegmentType segmentType = segment->segmentType();
-                  if (segmentType == SegmentType::EndBarLine) {
+                  if (segment->isEndBarLineType()) {
                         bool generated = false;
                         if (bl->barLineType() == barType)
                               generated = bl->generated();  // no change: keep current status
@@ -172,7 +171,7 @@ static void undoChangeBarLineType(BarLine* bl, BarLineType barType, bool allStav
                                     }
                               }
                         }
-                  else if (segmentType == SegmentType::BeginBarLine) {
+                  else if (segment->isBeginBarLineType()) {
                         for (Score*& lscore : m2->score()->scoreList()) {
                               Measure* lmeasure = lscore->tick2measure(m2->tick());
                               Segment* segment1 = lmeasure->undoGetSegmentR(SegmentType::BeginBarLine, Fraction(0, 1));
@@ -1390,8 +1389,8 @@ void BarLine::layout()
       setPos(QPointF());
       // barlines hidden on this staff
       if (staff() && segment()) {
-            if ((!staff()->staffTypeForElement(this)->showBarlines() && segment()->segmentType() == SegmentType::EndBarLine)
-                || (staff()->hideSystemBarLine() && segment()->segmentType() == SegmentType::BeginBarLine)) {
+            if ((!staff()->staffTypeForElement(this)->showBarlines() && segment()->isEndBarLineType())
+                || (staff()->hideSystemBarLine() && segment()->isBeginBarLineType())) {
                   setbbox(QRectF());
                   return;
                   }
@@ -1458,8 +1457,8 @@ void BarLine::layout2()
       {
       // barlines hidden on this staff
       if (staff() && segment()) {
-            if ((!staff()->staffTypeForElement(this)->showBarlines() && segment()->segmentType() == SegmentType::EndBarLine)
-                || (staff()->hideSystemBarLine() && segment()->segmentType() == SegmentType::BeginBarLine)) {
+            if ((!staff()->staffTypeForElement(this)->showBarlines() && segment()->isEndBarLineType())
+                || (staff()->hideSystemBarLine() && segment()->isBeginBarLineType())) {
                   setbbox(QRectF());
                   return;
                   }
@@ -1752,9 +1751,9 @@ QString BarLine::accessibleExtraInfo() const
             //jumps
             for (const Element* e : m->el()) {
                   if (!score()->selectionFilter().canSelect(e)) continue;
-                  if (e->type() == ElementType::JUMP)
+                  if (e->isJump())
                         rez= QString("%1 %2").arg(rez, e->screenReaderInfo());
-                  if (e->type() == ElementType::MARKER) {
+                  if (e->isMarker()) {
                         const Marker* m1 = toMarker(e);
                         if (m1->markerType() == Marker::Type::FINE)
                               rez = QString("%1 %2").arg(rez, e->screenReaderInfo());
@@ -1783,7 +1782,7 @@ QString BarLine::accessibleExtraInfo() const
             Spanner* s = interval.value;
             if (!score()->selectionFilter().canSelect(s))
                   continue;
-            if (s->type() == ElementType::VOLTA) {
+            if (s->isVolta()) {
                   if (s->tick() == tick)
                         rez = QObject::tr("%1 Start of %2").arg(rez, s->screenReaderInfo());
                   if (s->tick2() == tick)

--- a/libmscore/beam.cpp
+++ b/libmscore/beam.cpp
@@ -1720,7 +1720,7 @@ void Beam::layout2(std::vector<ChordRest*>crl, SpannerSegmentType, int frag)
                   ChordRest* cr1 = crl[i];
                   int l1 = cr1->durationType().hooks() - 1;
 
-                  if ((cr1->type() == ElementType::REST && i) || l1 < beamLevel) {
+                  if ((cr1->isRest() && i) || l1 < beamLevel) {
                         ++i;
                         continue;
                         }
@@ -1740,7 +1740,7 @@ void Beam::layout2(std::vector<ChordRest*>crl, SpannerSegmentType, int frag)
                         b64 = (beamLevel >= 2) && (bm == Mode::BEGIN64);
 
                         if ((l >= beamLevel && (b32 || b64)) || (l < beamLevel)) {
-                              if (i > 1 && crl[i-1]->type() == ElementType::REST) {
+                              if (i > 1 && crl[i-1]->isRest()) {
                                     --i;
                                     }
                               break;
@@ -1818,7 +1818,7 @@ void Beam::layout2(std::vector<ChordRest*>crl, SpannerSegmentType, int frag)
                         }
                   else {
                         // create broken segment / fractional beams
-                        if (cr1->type() == ElementType::REST)
+                        if (cr1->isRest())
                               continue;
 
                         size_t sizeChordRests = crl.size();
@@ -2289,7 +2289,7 @@ void Beam::triggerLayout() const
 
 bool Beam::acceptDrop(EditData& data) const
       {
-      return (data.dropElement->type() == ElementType::ICON)
+      return (data.dropElement->isIcon())
          && ((toIcon(data.dropElement)->iconType() == IconType::FBEAM1)
          || (toIcon(data.dropElement)->iconType() == IconType::FBEAM2));
       }

--- a/libmscore/box.cpp
+++ b/libmscore/box.cpp
@@ -569,7 +569,7 @@ Element* Box::drop(EditData& data)
                               break;
                               }
                         for (Element* elem : el()) {
-                              if (elem->type() == ElementType::LAYOUT_BREAK) {
+                              if (elem->isLayoutBreak()) {
                                     score()->undoChangeElement(elem, e);
                                     break;
                                     }
@@ -648,7 +648,7 @@ QRectF HBox::drag(EditData& data)
       QRectF r(canvasBoundingRect());
       qreal diff = data.evtDelta.x();
       qreal x1   = offset().x() + diff;
-      if (parent()->type() == ElementType::VBOX) {
+      if (parent()->isVBox()) {
             VBox* vb = toVBox(parent());
             qreal x2 = parent()->width() - width() - (vb->leftMargin() + vb->rightMargin()) * DPMM;
             if (x1 < 0.0)

--- a/libmscore/bracket.cpp
+++ b/libmscore/bracket.cpp
@@ -386,7 +386,7 @@ void Bracket::endEditDrag(EditData&)
 
 bool Bracket::acceptDrop(EditData& data) const
       {
-      return data.dropElement->type() == ElementType::BRACKET;
+      return data.dropElement->isBracket();
       }
 
 //---------------------------------------------------------

--- a/libmscore/bsymbol.cpp
+++ b/libmscore/bsymbol.cpp
@@ -120,7 +120,7 @@ void BSymbol::remove(Element* e)
 void BSymbol::scanElements(void* data, void (*func)(void*, Element*), bool all)
       {
       func(data, this);
-      foreach (Element* e, _leafs)
+      for (Element* e : _leafs)
             e->scanElements(data, func, all);
       }
 
@@ -175,7 +175,7 @@ void BSymbol::layout()
 QRectF BSymbol::drag(EditData& ed)
       {
       QRectF r(canvasBoundingRect());
-      foreach(const Element* e, _leafs)
+      for (const Element* e : _leafs)
             r |= e->canvasBoundingRect();
 
       qreal x = ed.delta.x();
@@ -196,7 +196,7 @@ QRectF BSymbol::drag(EditData& ed)
       setOffset(QPointF(x, y));
 
       r |= canvasBoundingRect();
-      foreach(const Element* e, _leafs)
+      for (const Element* e : _leafs)
             r |= e->canvasBoundingRect();
       return r;
       }
@@ -216,7 +216,7 @@ QVector<QLineF> BSymbol::dragAnchorLines() const
 
 QPointF BSymbol::pagePos() const
       {
-      if (parent() && (parent()->type() == ElementType::SEGMENT)) {
+      if (parent() && parent()->isSegment()) {
             QPointF p(pos());
             System* system = segment()->measure()->system();
             if (system) {
@@ -235,7 +235,7 @@ QPointF BSymbol::pagePos() const
 
 QPointF BSymbol::canvasPos() const
       {
-      if (parent() && (parent()->type() == ElementType::SEGMENT)) {
+      if (parent() && parent()->isSegment()) {
             QPointF p(pos());
             Segment* s = toSegment(parent());
 

--- a/libmscore/check.cpp
+++ b/libmscore/check.cpp
@@ -32,17 +32,17 @@ namespace Ms {
 void Score::checkSlurs()
       {
 #if 0 //TODO1
-      foreach(Element* e, _gel) {
-            if (e->type() != SLUR)
+      for (Element* e : _gel) {
+            if (!e->isSlur())
                   continue;
-            Slur* s = (Slur*)e;
+            Slur* s = toSlur(e);
             Element* n1 = s->startElement();
             Element* n2 = s->endElement();
             if (n1 == 0 || n2 == 0 || n1 == n2) {
                   qDebug("unconnected slur: removing");
                   if (n1) {
-                        ((ChordRest*)n1)->removeSlurFor(s);
-                        ((ChordRest*)n1)->removeSlurBack(s);
+                        toChordRest(n1)->removeSlurFor(s);
+                        toChordRest(n1)->removeSlurBack(s);
                         }
                   if (n1 == 0)
                         qDebug("  start at %d(%d) not found", s->tick(), s->track());
@@ -72,9 +72,9 @@ void Score::checkScore()
       for (Segment* s = firstMeasure()->first(); s;) {
             Segment* ns = s->next1();
 
-            if (s->segmentType() & (SegmentType::ChordRest)) {
+            if (s->isType(SegmentType::ChordRest)) {
                   bool empty = true;
-                  foreach(Element* e, s->elist()) {
+                  for (Element* e : s->elist()) {
                         if (e) {
                               empty = false;
                               break;

--- a/libmscore/chordrest.cpp
+++ b/libmscore/chordrest.cpp
@@ -211,7 +211,7 @@ bool ChordRest::readProperties(XmlReader& e)
       if (tag == "durationType") {
             setDurationType(e.readElementText());
             if (actualDurationType().type() != TDuration::DurationType::V_MEASURE) {
-                  if (score()->mscVersion() < 112 && (type() == ElementType::REST) &&
+                  if (score()->mscVersion() < 112 && isRest() &&
                               // for backward compatibility, convert V_WHOLE rests to V_MEASURE
                               // if long enough to fill a measure.
                               // OTOH, freshly created (un-initialized) rests have numerator == 0 (< 4/4)
@@ -275,7 +275,7 @@ bool ChordRest::readProperties(XmlReader& e)
             int i = e.readInt();
             if (i == 0)
                   i = mticks;
-            if ((type() == ElementType::REST) && (mticks == i)) {
+            if (isRest() && (mticks == i)) {
                   setDurationType(TDuration::DurationType::V_MEASURE);
                   setTicks(Fraction::fromTicks(i));
                   }
@@ -363,7 +363,7 @@ void ChordRest::readAddConnector(ConnectorInfoReader* info, bool pasteMode)
                                           ChordRest* cr = toChordRest(linkedCR);
                                           if (cr->score() == linkedSpanner->score() && cr->staffIdx() == ls->staffIdx()) {
                                                 ls->setTrack2(cr->track());
-                                                if (ls->type() == ElementType::SLUR)
+                                                if (ls->isSlur())
                                                       ls->setEndElement(cr);
                                                 break;
                                                 }
@@ -1211,11 +1211,11 @@ QString ChordRest::accessibleExtraInfo() const
                   Spanner* s = interval.value;
                   if (!score()->selectionFilter().canSelect(s))
                         continue;
-                  if (s->type() == ElementType::VOLTA || //voltas are added for barlines
-                      s->type() == ElementType::TIE    ) //ties are added in notes
+                  if (s->isVolta() || //voltas are added for barlines
+                      s->isTie())     //ties are added in notes
                         continue;
 
-                  if (s->type() == ElementType::SLUR) {
+                  if (s->isSlur()) {
                         if (s->tick() == tick() && s->track() == track())
                               rez = QObject::tr("%1 Start of %2").arg(rez, s->screenReaderInfo());
                         if (s->tick2() == tick() && s->track2() == track())

--- a/libmscore/clef.cpp
+++ b/libmscore/clef.cpp
@@ -220,8 +220,8 @@ void Clef::draw(QPainter* painter) const
 
 bool Clef::acceptDrop(EditData& data) const
       {
-      return (data.dropElement->type() == ElementType::CLEF
-         || (/*!generated() &&*/ data.dropElement->type() == ElementType::AMBITUS) );
+      return (data.dropElement->isClef()
+         || (/*!generated() &&*/ data.dropElement->isAmbitus()) );
       }
 
 //---------------------------------------------------------
@@ -427,7 +427,7 @@ Clef* Clef::otherClef()
       Segment* otherSegm = nullptr;
       Fraction segmTick  = segm->tick();
       SegmentType type = SegmentType::Clef;
-      if (segmTick == meas->tick() && segm->segmentType() == SegmentType::HeaderClef) // if clef segm is measure-initial
+      if (segmTick == meas->tick() && segm->isHeaderClefType()) // if clef segm is measure-initial
             otherMeas = meas->prevMeasure();                                          // look for a previous measure
       else if (segmTick == meas->tick() + meas->ticks()) {                            // if clef segm is measure-final
             otherMeas = meas->nextMeasure();                                          // look for a next measure

--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -362,7 +362,7 @@ void Score::cmdAddSpanner(Spanner* spanner, const QPointF& pos, bool firstStaffO
       if (firstStaffOnly)
             staffIdx = 0;
       // ignore if we do not have a measure
-      if (mb == 0 || mb->type() != ElementType::MEASURE) {
+      if (mb == 0 || !mb->isMeasure()) {
             qDebug("cmdAddSpanner: cannot put object here");
             delete spanner;
             return;
@@ -760,7 +760,7 @@ void Score::createCRSequence(const Fraction& f, ChordRest* cr, const Fraction& t
 
 Segment* Score::setNoteRest(Segment* segment, int track, NoteVal nval, Fraction sd, Direction stemDirection, bool forceAccidental, bool rhythmic, InputState* externalInputState)
       {
-      Q_ASSERT(segment->segmentType() == SegmentType::ChordRest);
+      Q_ASSERT(segment->isChordRestType());
       InputState& is = externalInputState ? (*externalInputState) : _is;
 
       bool isRest   = nval.pitch == -1;
@@ -885,7 +885,7 @@ Segment* Score::setNoteRest(Segment* segment, int track, NoteVal nval, Fraction 
       if (tie)
             connectTies();
       if (nr) {
-            if (is.slur() && nr->type() == ElementType::NOTE) {
+            if (is.slur() && nr->isNote()) {
                   // If the start element was the same as the end element when the slur was created,
                   // the end grip of the front slur segment was given an x-offset of 3.0 * spatium().
                   // Now that the slur is about to be given a new end element, this should be reset.
@@ -1159,7 +1159,7 @@ bool Score::makeGapVoice(Segment* seg, int track, Fraction len, const Fraction& 
             if (n > 1) {
                   Fraction crtick = cr1->tick() + cr1->actualTicks();
                   Measure* measure = tick2measure(crtick);
-                  if (cr1->type() == ElementType::CHORD) {
+                  if (cr1->isChord()) {
                         // split Chord
                         Chord* c = toChord(cr1);
                         for (size_t i = 1; i < n; ++i) {
@@ -1327,7 +1327,7 @@ void Score::changeCRlen(ChordRest* cr, const Fraction& dstF, bool fillWithRest)
                         if (tremolo->twoNotes())
                               undoRemoveElement(tremolo);
                         }
-                  foreach (Note* n, c->notes()) {
+                  for (Note* n : c->notes()) {
                         if (n->tieFor())
                               undoRemoveElement(n->tieFor());
                         }
@@ -1819,7 +1819,7 @@ void Score::toggleAccidental(AccidentalType at, const EditData& ed)
 
 void Score::changeAccidental(AccidentalType idx)
       {
-      foreach(Note* note, selection().noteList())
+      for (Note* note : selection().noteList())
             changeAccidental(note, idx);
       }
 
@@ -2116,11 +2116,11 @@ void Score::cmdResetBeamMode()
                   ChordRest* cr = toChordRest(seg->element(track));
                   if (!cr)
                         continue;
-                  if (cr->type() == ElementType::CHORD) {
+                  if (cr->isChord()) {
                         if (cr->beamMode() != Beam::Mode::AUTO)
                               cr->undoChangeProperty(Pid::BEAM_MODE, int(Beam::Mode::AUTO));
                         }
-                  else if (cr->type() == ElementType::REST) {
+                  else if (cr->isRest()) {
                         if (cr->beamMode() != Beam::Mode::NONE)
                               cr->undoChangeProperty(Pid::BEAM_MODE, int(Beam::Mode::NONE));
                         }
@@ -2434,7 +2434,7 @@ Element* Score::move(const QString& cmd)
             // if something found and command is forward, the element found is the destination
             if (trg && cmd == "next-chord") {
                   // if chord, go to topmost note
-                  if (trg->type() == ElementType::CHORD)
+                  if (trg->isChord())
                         trg = toChord(trg)->upNote();
                   setPlayNote(true);
                   select(trg, SelectType::SINGLE, 0);
@@ -2599,7 +2599,7 @@ Element* Score::move(const QString& cmd)
             }
 
       if (el) {
-            if (el->type() == ElementType::CHORD)
+            if (el->isChord())
                   el = toChord(el)->upNote();       // originally downNote
             setPlayNote(true);
             if (noteEntryMode()) {
@@ -2798,7 +2798,7 @@ void Score::cmdIncDecDuration(int nSteps, bool stepDotted)
 void Score::cmdAddBracket()
       {
       for (Element* el : selection().elements()) {
-            if (el->type() == ElementType::ACCIDENTAL) {
+            if (el->isAccidental()) {
                   Accidental* acc = toAccidental(el);
                   acc->undoChangeProperty(Pid::ACCIDENTAL_BRACKET, int(AccidentalBracket::BRACKET));
                   }
@@ -2812,21 +2812,21 @@ void Score::cmdAddBracket()
 void Score::cmdAddParentheses()
       {
       for (Element* el : selection().elements()) {
-            if (el->type() == ElementType::NOTE) {
+            if (el->isNote()) {
                   Note* n = toNote(el);
                   n->addParentheses();
                   }
-            else if (el->type() == ElementType::ACCIDENTAL) {
+            else if (el->isAccidental()) {
                   Accidental* acc = toAccidental(el);
                   acc->undoChangeProperty(Pid::ACCIDENTAL_BRACKET, int(AccidentalBracket::PARENTHESIS));
                   }
-            else if (el->type() == ElementType::HARMONY) {
+            else if (el->isHarmony()) {
                   Harmony* h = toHarmony(el);
                   h->setLeftParen(true);
                   h->setRightParen(true);
                   h->render();
                   }
-            else if (el->type() == ElementType::TIMESIG) {
+            else if (el->isTimeSig()) {
                   TimeSig* ts = toTimeSig(el);
                   ts->setLargeParentheses(true);
                   }
@@ -2840,7 +2840,7 @@ void Score::cmdAddParentheses()
 void Score::cmdAddBraces()
       {
       for (Element* el : selection().elements()) {
-            if (el->type() == ElementType::ACCIDENTAL) {
+            if (el->isAccidental()) {
                   Accidental* acc = toAccidental(el);
                   acc->undoChangeProperty(Pid::ACCIDENTAL_BRACKET, int(AccidentalBracket::BRACE));
                   }
@@ -2902,7 +2902,7 @@ void Score::cmdAddGrace (NoteType graceType, int duration)
       {
       const QList<Element*> copyOfElements = selection().elements();
       for (Element* e : copyOfElements) {
-            if (e->type() == ElementType::NOTE) {
+            if (e->isNote()) {
                   Note* n = toNote(e);
                   setGraceNote(n->chord(), n->pitch(), graceType, duration);
                   }
@@ -2958,7 +2958,7 @@ void Score::cmdExplode()
                   int n = 0;
                   for (Segment* s = startSegment; s && s != endSegment; s = s->next1()) {
                         Element* e = s->element(srcTrack);
-                        if (e && e->type() == ElementType::CHORD) {
+                        if (e && e->isChord()) {
                               Chord* c = toChord(e);
                               n = qMax(n, int(c->notes().size()));
                               for (Chord*& graceChord : c->graceNotes())
@@ -3001,7 +3001,7 @@ void Score::cmdExplode()
                   int track = (srcStaff + i) * VOICES;
                   for (Segment* s = startSegment; s && s != endSegment; s = s->next1()) {
                         Element* e = s->element(track);
-                        if (e && e->type() == ElementType::CHORD) {
+                        if (e && e->isChord()) {
                               Chord* c = toChord(e); //chord, laststaff, srcstaff
                               doExplode(c, lastStaff, srcStaff, i);
                               for (Chord*& graceChord : c->graceNotes())
@@ -3232,7 +3232,7 @@ void Score::cmdSlashFill()
             int voice = -1;
             // loop through segments adding slashes on each beat
             for (Segment* s = startSegment; s && s->tick() < endTick; s = s->next1()) {
-                  if (s->segmentType() != SegmentType::ChordRest)
+                  if (!s->isChordRestType())
                         continue;
                   // determine beat type based on time signature
                   int d = s->measure()->timesig().denominator();
@@ -3252,7 +3252,7 @@ void Score::cmdSlashFill()
                               if (!cr)
                                     needGap[voice] = true;
                               // chord == keep looking for an available voice
-                              else if (cr->type() == ElementType::CHORD)
+                              else if (cr->isChord())
                                     continue;
                               // full measure rest == OK to use voice
                               else if (cr->durationType() == TDuration::DurationType::V_MEASURE)
@@ -3262,7 +3262,7 @@ void Score::cmdSlashFill()
                               bool ok = true;
                               for (Segment* ns = s->next(SegmentType::ChordRest); ns && ns != endSegment; ns = ns->next(SegmentType::ChordRest)) {
                                     ChordRest* ncr = toChordRest(ns->element(track + voice));
-                                    if (ncr && ncr->type() == ElementType::CHORD) {
+                                    if (ncr && ncr->isChord()) {
                                           ok = false;
                                           break;
                                           }
@@ -3336,7 +3336,7 @@ void Score::cmdSlashRhythm()
       {
       QList<Chord*> chords;
       // loop through all notes in selection
-      foreach (Element* e, selection().elements()) {
+      for (Element* e : selection().elements()) {
             if (e->voice() >= 2 && e->isRest()) {
                   Rest* r = toRest(e);
                   if (r->links()) {
@@ -3437,7 +3437,7 @@ void Score::cmdRealizeChordSymbols(bool literal, Voicing voicing, HDuration dura
 //---------------------------------------------------------
 Segment* Score::setChord(Segment* segment, int track, Chord* chordTemplate, Fraction dur, Direction stemDirection)
       {
-      Q_ASSERT(segment->segmentType() == SegmentType::ChordRest);
+      Q_ASSERT(segment->isChordRestType());
 
       Fraction tick = segment->tick();
       Chord* nr     = 0; //current added chord used so we can select the last added chord and so we can apply ties
@@ -3459,7 +3459,7 @@ Segment* Score::setChord(Segment* segment, int track, Chord* chordTemplate, Frac
             //we need to get a correct subduration so that makeGap can function properly
             //since makeGap() takes "normal" duration rather than actual length
             while (seg) {
-                  if (seg->segmentType() == SegmentType::ChordRest) {
+                  if (seg->isChordRestType()) {
                         //design choice made to keep multiple notes across a tuplet as tied single notes rather than combining them
                         //since it's arguably more readable, but the other code is still here (commented)
                         ChordRest* testCr = toChordRest(seg->element(track));
@@ -3606,7 +3606,7 @@ void Score::cmdResequenceRehearsalMarks()
       RehearsalMark* last = 0;
       for (Segment* s = selection().startSegment(); s && s != selection().endSegment(); s = s->next1()) {
             for (Element* e : s->annotations()) {
-                  if (e->type() == ElementType::REHEARSAL_MARK) {
+                  if (e->isRehearsalMark()) {
                         RehearsalMark* rm = toRehearsalMark(e);
                         if (last) {
                               QString rmText = nextRehearsalMarkText(last, rm);

--- a/libmscore/element.cpp
+++ b/libmscore/element.cpp
@@ -860,7 +860,7 @@ Compound::Compound(const Compound& c)
    : Element(c)
       {
       elements.clear();
-      foreach(Element* e, c.elements)
+      for (Element* e : c.elements)
             elements.append(e->clone());
       }
 
@@ -870,7 +870,7 @@ Compound::Compound(const Compound& c)
 
 void Compound::draw(QPainter* painter) const
       {
-      foreach(Element* e, elements) {
+      for (Element* e : elements) {
             QPointF pt(e->pos());
             painter->translate(pt);
             e->draw(painter);
@@ -935,7 +935,7 @@ void Compound::setVisible(bool f)
 
 void Compound::clear()
       {
-      foreach(Element* e, elements) {
+      for (Element*& e : elements) {
             if (e->selected())
                   score()->deselect(e);
             delete e;
@@ -2616,18 +2616,18 @@ std::pair<int, float> Element::barbeat() const
       TimeSigMap* tsm = this->score()->sigmap();
       const Element* p = this;
       int ticksB = ticks_beat(tsm->timesig(0).timesig().denominator());
-      while(p && p->type() != ElementType::SEGMENT && p->type() != ElementType::MEASURE)
+      while(p && !p->isSegment() && !p->isMeasure())
             p = p->parent();
 
       if (!p) {
             return std::pair<int, float>(0, 0.0F);
             }
-      else if (p->type() == ElementType::SEGMENT) {
+      else if (p->isSegment()) {
             const Segment* seg = static_cast<const Segment*>(p);
             tsm->tickValues(seg->tick().ticks(), &bar, &beat, &ticks);
             ticksB = ticks_beat(tsm->timesig(seg->tick().ticks()).timesig().denominator());
             }
-      else if (p->type() == ElementType::MEASURE) {
+      else if (p->isMeasure()) {
             const Measure* m = static_cast<const Measure*>(p);
             bar = m->no();
             beat = -1;

--- a/libmscore/elementmap.cpp
+++ b/libmscore/elementmap.cpp
@@ -24,7 +24,7 @@ namespace Ms {
 
 Tuplet* TupletMap::findNew(Tuplet* o)
       {
-      foreach(const Tuplet2& t2, map) {
+      for (Tuplet2& t2 : map) {
             if (t2.o == o)
                   return t2.n;
             }

--- a/libmscore/excerpt.cpp
+++ b/libmscore/excerpt.cpp
@@ -153,7 +153,7 @@ void Excerpt::createExcerpt(Excerpt* excerpt)
             }
       score->setCurrentLayer(oscore->currentLayer());
       score->layer().clear();
-      foreach (const Layer& l, oscore->layer())
+      for (const Layer& l : oscore->layer())
             score->layer().append(l);
 
       score->setPageNumberOffset(oscore->pageNumberOffset());
@@ -562,7 +562,7 @@ void Excerpt::cloneStaves(Score* oscore, Score* score, const QList<int>& map, QM
 
                                     Element* oe = oseg->element(srcTrack);
                                     int adjustedBarlineSpan = 0;
-                                    if (srcTrack % VOICES == 0 && oseg->segmentType() == SegmentType::BarLine) {
+                                    if (srcTrack % VOICES == 0 && oseg->isBarLineType()) {
                                           // mid-measure barline segment
                                           // may need to clone barline from a previous staff and/or adjust span
                                           int oIdx = srcTrack / VOICES;
@@ -913,7 +913,7 @@ void Excerpt::cloneStaff(Staff* srcStaff, Staff* dstStaff)
 
                               // remove lyrics from chord
                               // since only one set of lyrics is used with linked staves
-                              foreach (Lyrics* l, ncr->lyrics()) {
+                              for (Lyrics* l : ncr->lyrics()) {
                                     if (l)
                                           l->unlink();
                                     }

--- a/libmscore/figuredbass.cpp
+++ b/libmscore/figuredbass.cpp
@@ -1230,7 +1230,7 @@ FiguredBass* FiguredBass::nextFiguredBass() const
 
       // scan segment annotations for an existing FB element in the this' staff
       for (Element* e : nextSegm->annotations())
-            if (e->type() == ElementType::FIGURED_BASS && e->track() == track())
+            if (e->isFiguredBass() && e->track() == track())
                   return toFiguredBass(e);
 
       return 0;
@@ -1321,7 +1321,7 @@ FiguredBass* FiguredBass::addFiguredBassToSegment(Segment * seg, int track, cons
       // scan segment annotations for an existing FB element in the same staff
       FiguredBass* fb = 0;
       for (Element* e : seg->annotations()) {
-            if (e->type() == ElementType::FIGURED_BASS && (e->track() / VOICES) == staff) {
+            if (e->isFiguredBass() && (e->track() / VOICES) == staff) {
                   // an FB already exists in segment: re-use it
                   fb = toFiguredBass(e);
                   *pNew = false;
@@ -1351,7 +1351,7 @@ FiguredBass* FiguredBass::addFiguredBassToSegment(Segment * seg, int track, cons
             // set onNote status
             fb->setOnNote(false);               // assume not onNote
             for (int i = track; i < track + VOICES; i++)         // if segment has chord in staff, set onNote
-                  if (seg->element(i) && seg->element(i)->type() == ElementType::CHORD) {
+                  if (seg->element(i) && seg->element(i)->isChord()) {
                         fb->setOnNote(true);
                         break;
                   }
@@ -1365,7 +1365,7 @@ FiguredBass* FiguredBass::addFiguredBassToSegment(Segment * seg, int track, cons
             FiguredBass*      prevFB = 0;
             for(prevSegm = seg->prev1(SegmentType::ChordRest); prevSegm; prevSegm = prevSegm->prev1(SegmentType::ChordRest)) {
                   for (Element* e : prevSegm->annotations()) {
-                        if (e->type() == ElementType::FIGURED_BASS && (e->track() ) == track) {
+                        if (e->isFiguredBass() && (e->track() ) == track) {
                               prevFB = toFiguredBass(e);   // previous FB found
                               break;
                               }
@@ -1526,7 +1526,7 @@ bool FiguredBass::readConfigFile(const QString& fileName)
 QList<QString> FiguredBass::fontNames()
       {
       QList<QString> names;
-      foreach(const FiguredBassFont& f, g_FBFonts)
+      for (FiguredBassFont& f : g_FBFonts)
             names.append(f.displayName);
       return names;
       }

--- a/libmscore/figuredbass.h
+++ b/libmscore/figuredbass.h
@@ -270,7 +270,7 @@ class FiguredBass final : public TextBase {
 //                                                }
 //      QDeclarativeListProperty<FiguredBassItem> qmlItems()
 //                                                {     QList<FiguredBassItem*> list;
-//                                                      foreach(FiguredBassItem item, _items)
+//                                                      for (FiguredBassItem item : _items)
 //                                                            list.append(&item);
 //                                                      return QDeclarativeListProperty<FiguredBassItem>(this, &_items, qmlItemsAppend);
 //                                                }

--- a/libmscore/fret.cpp
+++ b/libmscore/fret.cpp
@@ -1247,7 +1247,7 @@ void FretDiagram::remove(Element* e)
 
 bool FretDiagram::acceptDrop(EditData& data) const
       {
-      return data.dropElement->type() == ElementType::HARMONY;
+      return data.dropElement->isHarmony();
       }
 
 //---------------------------------------------------------

--- a/libmscore/glissando.cpp
+++ b/libmscore/glissando.cpp
@@ -508,7 +508,7 @@ Note* Glissando::guessInitialNote(Chord* chord)
             segm = segm->prev1();
       while (segm) {
             // if previous segment is a ChordRest segment
-            if (segm->segmentType() == SegmentType::ChordRest) {
+            if (segm->isChordRestType()) {
                   Chord* target = nullptr;
                   // look for a Chord in the same track
                   if (segm->element(chordTrack) && segm->element(chordTrack)->isChord())
@@ -601,7 +601,7 @@ Note* Glissando::guessFinalNote(Chord* chord)
       Part*       part        = chord->part();
       while (segm) {
             // if next segment is a ChordRest segment
-            if (segm->segmentType() == SegmentType::ChordRest) {
+            if (segm->isChordRestType()) {
                   Chord* target = nullptr;
 
                   // look for a Chord in the same track

--- a/libmscore/harmony.cpp
+++ b/libmscore/harmony.cpp
@@ -1563,7 +1563,7 @@ qreal TextSegment::width() const
       return fm.width(text);
 #else
       qreal w = 0.0;
-      foreach(QChar c, text) {
+      for (QChar c : text) {
             // if we calculate width by character, at least skip high surrogates
             if (c.isHighSurrogate())
                   continue;

--- a/libmscore/imageStore.cpp
+++ b/libmscore/imageStore.cpp
@@ -55,7 +55,7 @@ void ImageStoreItem::reference(Image* image)
 
 bool ImageStoreItem::isUsed(Score* score) const
       {
-      foreach(Image* image, _references) {
+      for (Image* image : _references) {
             if (image->score() == score && image->isUsed())
                   return true;
             }

--- a/libmscore/instrtemplate.cpp
+++ b/libmscore/instrtemplate.cpp
@@ -584,16 +584,16 @@ bool saveInstrumentTemplates(const QString& instrTemplates)
       XmlWriter xml(0, &qf);
       xml << "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n";
       xml.stag("museScore");
-      foreach(const InstrumentGenre* genre, instrumentGenres)
+      for (const InstrumentGenre* genre : instrumentGenres)
             genre->write(xml);
       xml << "\n";
-      foreach(const InstrumentFamily* fam, instrumentFamilies)
+      for (const InstrumentFamily* fam : instrumentFamilies)
             fam->write(xml);
       xml << "\n";
-      foreach(const MidiArticulation& a, articulation)
+      for (const MidiArticulation& a : articulation)
             a.write(xml);
       xml << "\n";
-      foreach(InstrumentGroup* group, instrumentGroups) {
+      for (InstrumentGroup* group : instrumentGroups) {
             xml.stag(QString("InstrumentGroup id=\"%1\"").arg(group->id));
             xml.tag("name", group->name);
             if (group->extended)
@@ -624,12 +624,12 @@ bool saveInstrumentTemplates1(const QString& instrTemplates)
       XmlWriter xml(0, &qf);
       xml << "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n";
       xml.stag("museScore");
-      foreach(const InstrumentGenre* genre, instrumentGenres)
+      for (const InstrumentGenre* genre : instrumentGenres)
             genre->write1(xml);
-      foreach(const InstrumentFamily* fam, instrumentFamilies)
+      for (const InstrumentFamily* fam : instrumentFamilies)
             fam->write1(xml);
       xml << "\n";
-      foreach(InstrumentGroup* group, instrumentGroups) {
+      for (InstrumentGroup* group : instrumentGroups) {
             xml.stag(QString("InstrumentGroup id=\"%1\"").arg(group->id));
             xml.tag("name", group->name);
             for (InstrumentTemplate* it : qAsConst(group->instrumentTemplates)) {
@@ -868,7 +868,7 @@ void InstrumentTemplate::linkGenre(const QString& genre)
 bool InstrumentTemplate::genreMember(const QString& name)
       {
             bool rVal=false;
-            foreach(InstrumentGenre *instrumentGenre, genres ) {
+            for (InstrumentGenre *instrumentGenre : genres ) {
                 if(instrumentGenre->id == name) {
                       rVal = true;
                       break;

--- a/libmscore/instrument.cpp
+++ b/libmscore/instrument.cpp
@@ -491,12 +491,12 @@ NamedEventList* Instrument::midiAction(const QString& s, int channelIdx) const
       {
       // first look in channel list
 
-      foreach(const NamedEventList& a, _channel[channelIdx]->midiActions) {
+      for (const NamedEventList& a : _channel[channelIdx]->midiActions) {
             if (s == a.name)
                   return const_cast<NamedEventList*>(&a);
             }
 
-      foreach(const NamedEventList& a, _midiActions) {
+      for (const NamedEventList& a : _midiActions) {
             if (s == a.name)
                   return const_cast<NamedEventList*>(&a);
             }

--- a/libmscore/keysig.cpp
+++ b/libmscore/keysig.cpp
@@ -318,7 +318,7 @@ void KeySig::draw(QPainter* p) const
 
 bool KeySig::acceptDrop(EditData& data) const
       {
-      return data.dropElement->type() == ElementType::KEYSIG;
+      return data.dropElement->isKeySig();
       }
 
 //---------------------------------------------------------
@@ -328,7 +328,7 @@ bool KeySig::acceptDrop(EditData& data) const
 Element* KeySig::drop(EditData& data)
       {
       KeySig* ks = toKeySig(data.dropElement);
-      if (ks->type() != ElementType::KEYSIG) {
+      if (!ks->isKeySig()) {
             delete ks;
             return 0;
             }
@@ -341,7 +341,7 @@ Element* KeySig::drop(EditData& data)
             }
       else {
             // apply to all staves:
-            foreach(Staff* s, score()->masterScore()->staves())
+            for (Staff* s : score()->masterScore()->staves())
                   score()->undoChangeKeySig(s, tick(), k);
             }
       return this;
@@ -551,7 +551,7 @@ bool KeySig::isChange() const
       {
       if (!staff())
             return false;
-      if (!segment() || segment()->segmentType() != SegmentType::KeySig)
+      if (!segment() || !segment()->isKeySigType())
             return false;
       Fraction keyTick = tick();
       return staff()->currentKeyTick(keyTick) == keyTick;

--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -4406,14 +4406,14 @@ void Score::layoutSystemElements(System* system, LayoutContext& lc)
                         if (!s.enabled())
                               continue;
                         QPointF p(s.pos() + m->pos());
-                        if (s.segmentType() & (SegmentType::BarLine | SegmentType::EndBarLine | SegmentType::StartRepeatBarLine | SegmentType::BeginBarLine)) {
+                        if (s.isType(SegmentType::BarLineType)) {
                               BarLine* bl = toBarLine(s.element(staffIdx * VOICES));
                               if (bl && bl->addToSkyline()) {
                                     QRectF r = bl->layoutRect();
                                     skyline.add(r.translated(bl->pos() + p));
                                     }
                               }
-                        else if (s.segmentType() & SegmentType::TimeSig) {
+                        else if (s.isType(SegmentType::TimeSig)) {
                               TimeSig* ts = toTimeSig(s.element(staffIdx * VOICES));
                               if (ts && ts->addToSkyline()) {
                                     skyline.add(ts->shape().translated(ts->pos() + p));

--- a/libmscore/layoutbreak.cpp
+++ b/libmscore/layoutbreak.cpp
@@ -232,7 +232,7 @@ void LayoutBreak::spatiumChanged(qreal, qreal)
 
 bool LayoutBreak::acceptDrop(EditData& data) const
       {
-      return data.dropElement->type() == ElementType::LAYOUT_BREAK
+      return data.dropElement->isLayoutBreak()
          && toLayoutBreak(data.dropElement)->layoutBreakType() != layoutBreakType();
       }
 

--- a/libmscore/letring.cpp
+++ b/libmscore/letring.cpp
@@ -247,7 +247,7 @@ QPointF LetRing::linePos(Grip grip, System** sys) const
                   if (seg) {
                         seg = seg->next();
                         for ( ; seg; seg = seg->next()) {
-                              if (seg->segmentType() == SegmentType::ChordRest) {
+                              if (seg->isChordRestType()) {
                                     // look for a chord/rest in any voice on this staff
                                     bool crFound = false;
                                     int track = staffIdx() * VOICES;
@@ -260,7 +260,7 @@ QPointF LetRing::linePos(Grip grip, System** sys) const
                                     if (crFound)
                                           break;
                                     }
-                              else if (seg->segmentType() == SegmentType::EndBarLine) {
+                              else if (seg->isEndBarLineType()) {
                                     break;
                                     }
                               }

--- a/libmscore/line.cpp
+++ b/libmscore/line.cpp
@@ -781,7 +781,7 @@ QPointF SLine::linePos(Grip grip, System** sys) const
                   ChordRest* cr;
                   if (grip == Grip::START) {
                         cr = toChordRest(startElement());
-                        if (cr && type() == ElementType::OTTAVA) {
+                        if (cr && isOttava()) {
                               // some sources say to center the text over the notehead
                               // others say to start the text just to left of notehead
                               // some say to include accidental, others don't
@@ -871,7 +871,7 @@ QPointF SLine::linePos(Grip grip, System** sys) const
                               // (for LYRICSLINE, this is hyphen; melisma line is handled above)
                               // lay out to just before next chordrest on this staff, or barline
                               // tick2 actually tells us the right chordrest to look for
-                              if (cr && endElement()->parent() && endElement()->parent()->type() == ElementType::SEGMENT) {
+                              if (cr && endElement()->parent() && endElement()->parent()->isSegment()) {
                                     qreal x2 = cr->x() /* TODO + cr->space().rw() */;
                                     Segment* currentSeg = toSegment(endElement()->parent());
                                     Segment* seg = score()->tick2segmentMM(tick2(), false, SegmentType::ChordRest);
@@ -892,7 +892,7 @@ QPointF SLine::linePos(Grip grip, System** sys) const
                                                 seg = currentSeg->measure()->last();
                                           // allow lyrics hyphen to extend to barline
                                           // other lines stop 1sp short
-                                          qreal gap = (type() == ElementType::LYRICSLINE) ? 0.0 : sp;
+                                          qreal gap = isLyricsLine() ? 0.0 : sp;
                                           qreal x3 = seg->enabled() ? seg->x() : seg->measure()->width();
                                           x2 = qMax(x2, x3 - gap);
                                           }
@@ -953,7 +953,7 @@ QPointF SLine::linePos(Grip grip, System** sys) const
 
                         // back up to barline (skip courtesy elements)
                         Segment* seg = m->last();
-                        while (seg && seg->segmentType() != SegmentType::EndBarLine)
+                        while (seg && !seg->isEndBarLineType())
                               seg = seg->prev();
                         if (!seg || !seg->enabled()) {
                               // no end bar line; look for BeginBarLine or StartRepeatBarLine of next measure
@@ -964,9 +964,9 @@ QPointF SLine::linePos(Grip grip, System** sys) const
                         qreal mwidth = seg && seg->measure() == m ? seg->x() : m->bbox().right();
                         x = m->pos().x() + mwidth;
                         // align to barline
-                        if (seg && (seg->segmentType() & SegmentType::BarLineType)) {
+                        if (seg && (seg->isType(SegmentType::BarLineType))) {
                               Element* e = seg->element(0);
-                              if (e && e->type() == ElementType::BAR_LINE) {
+                              if (e && e->isBarLine()) {
                                     BarLineType blt = toBarLine(e)->barLineType();
                                     switch (blt) {
                                           case BarLineType::END_REPEAT:
@@ -1179,7 +1179,7 @@ void SLine::layout()
                   qreal len = p2.x() - p1.x();
                   // enforcing a minimum length would be possible but inadvisable
                   // the line length calculations are tuned well enough that this should not be needed
-                  //if (anchor() == Anchor::SEGMENT && type() != ElementType::PEDAL)
+                  //if (anchor() == Anchor::SEGMENT && !isPedal())
                   //      len = qMax(1.0 * spatium(), len);
                   lineSegm->setPos(p1);
                   lineSegm->setPos2(QPointF(len, p2.y() - p1.y()));

--- a/libmscore/lyricsline.cpp
+++ b/libmscore/lyricsline.cpp
@@ -11,17 +11,13 @@
 //=============================================================================
 
 #include "lyrics.h"
-
-#include "chord.h"
-#include "score.h"
-#include "sym.h"
-#include "system.h"
-#include "xml.h"
-#include "staff.h"
-#include "segment.h"
-#include "undo.h"
-#include "textedit.h"
 #include "measure.h"
+#include "score.h"
+#include "segment.h"
+#include "staff.h"
+#include "system.h"
+#include "undo.h"
+#include "xml.h"
 
 namespace Ms {
 
@@ -113,7 +109,7 @@ void LyricsLine::layout()
                   }
             Element* se = s->element(lyricsTrack);
             // everything is OK if we have reached a chord at right tick on right track
-            if (s->tick() == lyricsEndTick && se && se->type() == ElementType::CHORD) {
+            if (s->tick() == lyricsEndTick && se && se->isChord()) {
                   // advance to next CR, or last segment if no next CR
                   s = s->nextCR(lyricsTrack, true);
                   if (!s)
@@ -130,7 +126,7 @@ void LyricsLine::layout()
                   while (ps && ps != lyricsSegment) {
                         Element* pe = ps->element(lyricsTrack);
                         // we're looking for an actual chord on this track
-                        if (pe && pe->type() == ElementType::CHORD)
+                        if (pe && pe->isChord())
                               break;
                         s = ps;
                         ps = ps->prev1(SegmentType::ChordRest);
@@ -141,7 +137,7 @@ void LyricsLine::layout()
                         s = ps->nextCR(lyricsTrack, true);
                         Element* e = s ? s->element(lyricsTrack) : nullptr;
                         // check to make sure we have a chord
-                        if (!e || e->type() != ElementType::CHORD) {
+                        if (!e || !e->isChord()) {
                               // nothing to do but set ticks to 0
                               // this will result in melisma being deleted later
                               lyrics()->undoChangeProperty(Pid::LYRIC_TICKS, 0);
@@ -290,7 +286,7 @@ bool LyricsLine::setProperty(Pid propertyId, const QVariant& v)
             case Pid::SPANNER_TICKS:
                   {
                   // if parent lyrics has a melisma, change its length too
-                  if (parent() && parent()->type() == ElementType::LYRICS
+                  if (parent() && parent()->isLyrics()
                               && isEndMelisma()) {
                         Fraction newTicks   = toLyrics(parent())->ticks() + v.value<Fraction>() - ticks();
                         parent()->undoChangeProperty(Pid::LYRIC_TICKS, newTicks);

--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -357,7 +357,7 @@ AccidentalVal Measure::findAccidental(Note* note) const
                         continue;
                   tversatz.init(vStaff->keySigEvent(segment->tick()), chord->staff()->clef(segment->tick()));
                   }
-            else if (segment->segmentType() == SegmentType::ChordRest) {
+            else if (segment->isChordRestType()) {
                   int endTrack   = startTrack + VOICES;
                   for (int track = startTrack; track < endTrack; ++track) {
                         Element* e = segment->element(track);
@@ -750,7 +750,7 @@ Segment* Measure::tick2segment(const Fraction& _t, SegmentType st)
       Fraction t = _t - tick();
       for (Segment& s : _segments) {
             if (s.rtick() == t) {
-                  if (s.segmentType() & st)
+                  if (s.isType(st))
                         return &s;
                   }
             if (s.rtick() > t)
@@ -781,7 +781,7 @@ Segment* Measure::findSegmentR(SegmentType st, const Fraction& t) const
                   ;
             }
       for (; s && s->rtick() == t; s = s->next()) {
-            if (s->segmentType() & st)
+            if (s->isType(st))
                   return s;
             }
       return 0;
@@ -1095,7 +1095,7 @@ void Measure::moveTicks(const Fraction& diff)
       std::set<Tuplet*> tuplets;
       setTick(tick() + diff);
       for (Segment* segment = last(); segment; segment = segment->prev()) {
-            if (segment->segmentType() & (SegmentType::EndBarLine | SegmentType::TimeSigAnnounce))
+            if (segment->isType(SegmentType::EndBarLine | SegmentType::TimeSigAnnounce))
                   segment->setRtick(ticks());
             else if (segment->isChordRestType()) {
                   // Tuplet ticks are stored as absolute ticks, so they must be adjusted.
@@ -1177,7 +1177,7 @@ void Measure::cmdRemoveStaves(int sStaff, int eStaff)
                         score()->undo(new RemoveElement(el));
                         }
                   }
-            foreach (Element* e, s->annotations()) {
+            for (Element* e : s->annotations()) {
                   int staffIdx = e->staffIdx();
                   if ((staffIdx >= sStaff) && (staffIdx < eStaff) && !e->systemFlag()) {
                         e->undoUnlink();
@@ -1767,7 +1767,7 @@ RepeatMeasure* Measure::cmdInsertRepeatMeasure(int staffIdx)
       //
       score()->select(0, SelectType::SINGLE, 0);
       for (Segment* s = first(); s; s = s->next()) {
-            if (s->segmentType() & SegmentType::ChordRest) {
+            if (s->isType(SegmentType::ChordRest)) {
                   int strack = staffIdx * VOICES;
                   int etrack = strack + VOICES;
                   for (int track = strack; track < etrack; ++track) {
@@ -1819,7 +1819,7 @@ void Measure::adjustToLen(Fraction nf, bool appendRestsIfNecessary)
             if (nl > ol) {
                   // move EndBarLine, TimeSigAnnounce, KeySigAnnounce
                   for (Segment* seg = m->first(); seg; seg = seg->next()) {
-                        if (seg->segmentType() & (SegmentType::EndBarLine|SegmentType::TimeSigAnnounce|SegmentType::KeySigAnnounce)) {
+                        if (seg->isType(SegmentType::EndBarLine|SegmentType::TimeSigAnnounce|SegmentType::KeySigAnnounce)) {
                               seg->setRtick(nl);
                               }
                         }
@@ -1892,7 +1892,7 @@ void Measure::adjustToLen(Fraction nf, bool appendRestsIfNecessary)
                   if (n < Fraction(0,1))  {
                         for (Segment* segment = m->last(); segment;) {
                               Segment* pseg = segment->prev();
-                              if (segment->segmentType() == SegmentType::ChordRest) {
+                              if (segment->isChordRestType()) {
                                     for (Element* a : segment->annotations())
                                           if (a->track() == trk)
                                                 s->undoRemoveElement(a);
@@ -1911,7 +1911,7 @@ void Measure::adjustToLen(Fraction nf, bool appendRestsIfNecessary)
                                                 break;
                                           }
                                     }
-                              else if (segment->segmentType() == SegmentType::Breath) {
+                              else if (segment->isBreathType()) {
                                     Element* e = segment->element(trk);
                                     if (e)
                                           s->undoRemoveElement(e);
@@ -2732,7 +2732,7 @@ void Measure::connectTremolo()
 void Measure::createVoice(int track)
       {
       for (Segment* s = first(); s; s = s->next()) {
-            if (s->segmentType() != SegmentType::ChordRest)
+            if (!s->isChordRestType())
                   continue;
             if (s->element(track) == 0)
                   score()->setRest(s->tick(), track, ticks(), true, 0);
@@ -2883,7 +2883,7 @@ bool Measure::hasVoice(int track) const
       if (track >= score()->ntracks())
             return false;
       for (Segment* s = first(); s; s = s->next()) {
-            if (s->segmentType() != SegmentType::ChordRest)
+            if (!s->isChordRestType())
                   continue;
             if (s->element(track))
                   return true;
@@ -2969,7 +2969,7 @@ bool Measure::isCutawayClef(int staffIdx) const
       // find segment before EndBarLine
       Segment* s = nullptr;
       for (Segment* ls = last(); ls; ls = ls->prev()) {
-            if (ls->segmentType() ==  SegmentType::EndBarLine) {
+            if (ls->isEndBarLineType()) {
                   s = ls->prev();
                   break;
                   }
@@ -3132,7 +3132,8 @@ Measure* Measure::cloneMeasure(Score* sc, const Fraction& tick, TieMap* tieMap)
       m->setPageBreak(pageBreak());
       m->setSectionBreak(sectionBreak() ? new LayoutBreak(*sectionBreakElement()) : 0);
 
-      m->setHeader(header()); m->setTrailer(trailer());
+      m->setHeader(header());
+      m->setTrailer(trailer());
 
       int tracks = sc->nstaves() * VOICES;
       TupletMap tupletMap;
@@ -3242,7 +3243,8 @@ Measure* Measure::cloneMeasureLimited(Score* scoreDest, const Fraction& tick, Ti
       m->setPageBreak(pageBreak());
       m->setSectionBreak(sectionBreak() ? new LayoutBreak(*sectionBreakElement()) : 0);
 
-      m->setHeader(header()); m->setTrailer(trailer());
+      m->setHeader(header());
+      m->setTrailer(trailer());
       TupletMap tupletMap;
 
       auto fcr = scoreDest->selection().firstChordRest();
@@ -3605,7 +3607,7 @@ Element* Measure::nextElementStaff(int staff)
             e = score()->selection().elements().first();
 
       // handle measure elements
-      if (e->parent() == this) {
+      if (e && e->parent() == this) {
             auto i = std::find(el().begin(), el().end(), e);
             if (i != el().end()) {
                   if (++i != el().end()) {
@@ -3616,7 +3618,7 @@ Element* Measure::nextElementStaff(int staff)
                   }
             }
 
-      for (; e && e->type() != ElementType::SEGMENT; e = e->parent()) {
+      for (; e && !e->isSegment(); e = e->parent()) {
             ;
       }
       Segment* seg = toSegment(e);
@@ -3639,7 +3641,7 @@ Element* Measure::prevElementStaff(int staff)
             e = score()->selection().elements().first();
 
       // handle measure elements
-      if (e->parent() == this) {
+      if (e && e->parent() == this) {
             auto i = std::find(el().rbegin(), el().rend(), e);
             if (i != el().rend()) {
                   if (++i != el().rend()) {
@@ -3815,7 +3817,7 @@ void Measure::stretchMeasure(qreal targetWidth)
                   else if (t == ElementType::BAR_LINE) {
                         e->rypos() = 0.0;
                         // for end barlines, x position was set in createEndBarLines
-                        if (s.segmentType() != SegmentType::EndBarLine)
+                        if (!s.isEndBarLineType())
                               e->rxpos() = 0.0;
                         }
                   }

--- a/libmscore/mscoreview.cpp
+++ b/libmscore/mscoreview.cpp
@@ -55,7 +55,7 @@ Page* MuseScoreView::point2page(const QPointF& p)
       {
       if (score()->layoutMode() == LayoutMode::LINE)
             return score()->pages().isEmpty() ? 0 : score()->pages().front();
-      foreach(Page* page, score()->pages()) {
+      for (Page* page : score()->pages()) {
             if (page->bbox().translated(page->pos()).contains(p))
                   return page;
             }

--- a/libmscore/navigate.cpp
+++ b/libmscore/navigate.cpp
@@ -164,7 +164,7 @@ ChordRest* prevChordRest(ChordRest* cr, bool skipGrace)
       for (Segment* seg = cr->segment()->prev1MM(st); seg; seg = seg->prev1MM(st)) {
             ChordRest* e = toChordRest(seg->element(track));
             if (e) {
-                  if (e->type() == ElementType::CHORD && !skipGrace) {
+                  if (e->isChord() && !skipGrace) {
                         QVector<Chord*> cl = toChord(e)->graceNotesAfter();
                         if (!cl.empty())
                               return cl.last();
@@ -640,7 +640,7 @@ Element* Score::nextElement()
                   case ElementType::KEYSIG:
                   case ElementType::TIMESIG:
                   case ElementType::BAR_LINE: {
-                       for (; e && e->type() != ElementType::SEGMENT; e = e->parent()) {
+                       for (; e && !e->isSegment(); e = e->parent()) {
                              ;
                              }
                        Segment* s = toSegment(e);
@@ -765,7 +765,7 @@ Element* Score::prevElement()
                   case ElementType::KEYSIG:
                   case ElementType::TIMESIG:
                   case ElementType::BAR_LINE: {
-                        for (; e && e->type() != ElementType::SEGMENT; e = e->parent()) {
+                        for (; e && !e->isSegment(); e = e->parent()) {
                               ;
                               }
                         Segment* s = toSegment(e);
@@ -803,8 +803,7 @@ Element* Score::prevElement()
                                           return last;
                                     }
                               Element* el = startSeg->lastElementOfSegment(startSeg, staffId);
-                              if (stEl->type() == ElementType::CHORD || stEl->type() == ElementType::REST
-                                       || stEl->type() == ElementType::REPEAT_MEASURE || stEl->type() == ElementType::NOTE) {
+                              if (stEl->isChordRest() || stEl->isNote()) {
                                     ChordRest* cr = startSeg->cr(stEl->track());
                                     if (cr) {
                                           Element* elCr = cr->lastElementBeforeSegment();
@@ -829,7 +828,7 @@ Element* Score::prevElement()
                         SpannerSegment* s = toSpannerSegment(e);
                         Spanner* sp = s->spanner();
                         Element* elSt = sp->startElement();
-                        Q_ASSERT(elSt->type() == ElementType::NOTE);
+                        Q_ASSERT(elSt->isNote());
                         Note* n = toNote(elSt);
                         Element* prev =  n->prevElement();
                         if(prev)

--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -1936,7 +1936,7 @@ Element* Note::drop(EditData& data)
             case ElementType::GLISSANDO:
                   {
                   for (auto ee : qAsConst(_spannerFor)) {
-                        if (ee->type() == ElementType::GLISSANDO) {
+                        if (ee->isGlissando()) {
                               qDebug("there is already a glissando");
                               delete e;
                               return 0;
@@ -3362,7 +3362,7 @@ Element* Note::nextElement()
                         return _tieFor->frontSegment();
                   else if (!_spannerFor.empty()) {
                         for (auto i : qAsConst(_spannerFor)) {
-                              if (i->type() == ElementType::GLISSANDO)
+                              if (i->isGlissando())
                                     return i->spannerSegments().front();
                               }
                         }
@@ -3372,7 +3372,7 @@ Element* Note::nextElement()
             case ElementType::TIE_SEGMENT:
                   if (!_spannerFor.empty()) {
                       for (auto i : qAsConst(_spannerFor)) {
-                            if (i->type() == ElementType::GLISSANDO)
+                            if (i->isGlissando())
                                   return i->spannerSegments().front();
                                   }
                             }
@@ -3459,7 +3459,7 @@ Element* Note::lastElementBeforeSegment()
       {
       if (!_spannerFor.empty()) {
             for (auto i : qAsConst(_spannerFor)) {
-                  if (i->type() == ElementType::GLISSANDO)
+                  if (i->isGlissando())
                         return i->spannerSegments().front();
                   }
             }

--- a/libmscore/noteentry.cpp
+++ b/libmscore/noteentry.cpp
@@ -380,7 +380,7 @@ void Score::putNote(const Position& p, bool replace)
                   {
                   if (st->isTabStaff(cr->tick())) {      // TAB
                         // if a note on same string already exists, update to new pitch/fret
-                        foreach (Note* note, toChord(cr)->notes())
+                        for (Note* note : toChord(cr)->notes())
                               if (note->string() == nval.string) {       // if string is the same
                                     // if adding a new digit will keep fret number within fret limit,
                                     // add a digit to existing fret number

--- a/libmscore/page.cpp
+++ b/libmscore/page.cpp
@@ -538,7 +538,7 @@ bool Page::isOdd() const
 void Page::write(XmlWriter& xml) const
       {
       xml.stag(this);
-      foreach(System* system, _systems) {
+      for (System* system : _systems) {
             system->write(xml);
             }
       xml.etag();

--- a/libmscore/palmmute.cpp
+++ b/libmscore/palmmute.cpp
@@ -244,7 +244,7 @@ QPointF PalmMute::linePos(Grip grip, System** sys) const
                                     if (crFound)
                                           break;
                                     }
-                              else if (seg->segmentType() == SegmentType::EndBarLine) {
+                              else if (seg->isEndBarLineType()) {
                                     break;
                                     }
                               }
@@ -257,7 +257,7 @@ QPointF PalmMute::linePos(Grip grip, System** sys) const
             else if (c) {
                   s = c->segment()->system();
                   x = c->pos().x() + c->segment()->pos().x() + c->segment()->measure()->pos().x();
-                  if (c->type() == ElementType::REST && c->durationType() == TDuration::DurationType::V_MEASURE)
+                  if (c->isRest() && c->durationType() == TDuration::DurationType::V_MEASURE)
                         x -= c->x();
                   }
             if (!s) {

--- a/libmscore/paste.cpp
+++ b/libmscore/paste.cpp
@@ -909,7 +909,7 @@ void Score::pasteSymbols(XmlReader& e, ChordRest* dst)
                                                 // in any case, look for a f.b. in annotations:
                                                 // if there is a f.b. element in the right track,
                                                 // this is an (actual) f.b. location
-                                                foreach (Element* a, prevSegm->annotations()) {
+                                                for (Element* a : prevSegm->annotations()) {
                                                       if (a->isFiguredBass() && a->track() == destTrack) {
                                                             onNoteFB = toFiguredBass(a);
                                                             done1 = true;
@@ -947,7 +947,7 @@ void Score::pasteSymbols(XmlReader& e, ChordRest* dst)
                                           ticks = toChordRest(currSegm->element(destTrack))->ticks();
                                     // in both cases, look for an existing f.b. element in segment and remove it, if found
                                     FiguredBass* oldFB = nullptr;
-                                    foreach (Element* a, currSegm->annotations()) {
+                                    for (Element* a : currSegm->annotations()) {
                                           if (a->isFiguredBass() && a->track() == destTrack) {
                                                 oldFB = toFiguredBass(a);
                                                 break;

--- a/libmscore/pedal.cpp
+++ b/libmscore/pedal.cpp
@@ -10,13 +10,12 @@
 //  the file LICENCE.GPL
 //=============================================================================
 
-#include "pedal.h"
-#include "sym.h"
-#include "xml.h"
-#include "system.h"
-#include "measure.h"
 #include "chordrest.h"
+#include "measure.h"
+#include "pedal.h"
 #include "staff.h"
+#include "system.h"
+#include "xml.h"
 
 #include "score.h"
 
@@ -214,7 +213,7 @@ QPointF Pedal::linePos(Grip grip, System** sys) const
             if (c) {
                   s = c->segment()->system();
                   x = c->pos().x() + c->segment()->pos().x() + c->segment()->measure()->pos().x();
-                  if (c->type() == ElementType::REST && c->durationType() == TDuration::DurationType::V_MEASURE)
+                  if (c->isRest() && c->durationType() == TDuration::DurationType::V_MEASURE)
                         x -= c->x();
                   if (beginHookType() == HookType::HOOK_45)
                         x += nhw * .5;
@@ -234,7 +233,7 @@ QPointF Pedal::linePos(Grip grip, System** sys) const
                   if (seg) {
                         seg = seg->next();
                         for ( ; seg; seg = seg->next()) {
-                              if (seg->segmentType() == SegmentType::ChordRest) {
+                              if (seg->isChordRestType()) {
                                     // look for a chord/rest in any voice on this staff
                                     bool crFound = false;
                                     int track = staffIdx() * VOICES;
@@ -247,7 +246,7 @@ QPointF Pedal::linePos(Grip grip, System** sys) const
                                     if (crFound)
                                           break;
                                     }
-                              else if (seg->segmentType() == SegmentType::EndBarLine) {
+                              else if (seg->isEndBarLineType()) {
                                     if (!seg->enabled()) {
                                           // disabled barline layout is not reliable
                                           // use width of measure instead
@@ -268,7 +267,7 @@ QPointF Pedal::linePos(Grip grip, System** sys) const
             else if (c) {
                   s = c->segment()->system();
                   x = c->pos().x() + c->segment()->pos().x() + c->segment()->measure()->pos().x();
-                  if (c->type() == ElementType::REST && c->durationType() == TDuration::DurationType::V_MEASURE)
+                  if (c->isRest() && c->durationType() == TDuration::DurationType::V_MEASURE)
                         x -= c->x();
                   }
             if (!s) {

--- a/libmscore/read114.cpp
+++ b/libmscore/read114.cpp
@@ -1563,7 +1563,7 @@ static void readMeasure(Measure* m, int staffIdx, XmlReader& e)
                         }
                   else {
                         segment->add(chord);
-                        Q_ASSERT(segment->segmentType() == SegmentType::ChordRest);
+                        Q_ASSERT(segment->isChordRestType());
 
                         for (int i = 0; i < graceNotes.size(); ++i) {
                               Chord* gc = graceNotes[i];
@@ -1587,7 +1587,7 @@ static void readMeasure(Measure* m, int staffIdx, XmlReader& e)
                                     Chord* pch = 0;       // previous chord
                                     if (ss) {
                                           ChordRest* cr = toChordRest(ss->element(track));
-                                          if (cr && cr->type() == ElementType::CHORD)
+                                          if (cr && cr->isChord())
                                                 pch = toChord(cr);
                                           }
                                     if (pch) {
@@ -1921,7 +1921,7 @@ static void readMeasure(Measure* m, int staffIdx, XmlReader& e)
                   Element* el = Element::name2Element(tag, m->score());
                   // hack - needed because tick tags are unreliable in 1.3 scores
                   // for symbols attached to anything but a measure
-                  if (el->type() == ElementType::SYMBOL)
+                  if (el->isSymbol())
                         el->setParent(m);    // this will get reset when adding to segment
                   el->setTrack(e.track());
                   el->read(e);
@@ -3126,7 +3126,7 @@ Score::FileError MasterScore::read114(XmlReader& e)
             bool first = true;
             for (int track = 0; track < tracks; ++track) {
                   for (Segment* s = m->first(); s; s = s->next()) {
-                        if (s->segmentType() != SegmentType::ChordRest)
+                        if (!s->isChordRestType())
                               continue;
                         ChordRest* cr = toChordRest(s->element(track));
                         if (cr) {

--- a/libmscore/read206.cpp
+++ b/libmscore/read206.cpp
@@ -1710,7 +1710,7 @@ bool readChordRestProperties206(XmlReader& e, ChordRest* ch)
       if (tag == "durationType") {
             ch->setDurationType(e.readElementText());
             if (ch->actualDurationType().type() != TDuration::DurationType::V_MEASURE) {
-                  if (ch->score()->mscVersion() < 112 && (ch->type() == ElementType::REST) &&
+                  if (ch->score()->mscVersion() < 112 && (ch->isRest()) &&
                               // for backward compatibility, convert V_WHOLE rests to V_MEASURE
                               // if long enough to fill a measure.
                               // OTOH, freshly created (un-initialized) rests have numerator == 0 (< 4/4)
@@ -1777,7 +1777,7 @@ bool readChordRestProperties206(XmlReader& e, ChordRest* ch)
             int i = e.readInt();
             if (i == 0)
                   i = mticks;
-            if ((ch->type() == ElementType::REST) && (mticks == i)) {
+            if (ch->isRest() && (mticks == i)) {
                   ch->setDurationType(TDuration::DurationType::V_MEASURE);
                   ch->setTicks(Fraction::fromTicks(i));
                   }
@@ -1815,7 +1815,7 @@ bool readChordRestProperties206(XmlReader& e, ChordRest* ch)
                               spanner->setTicks(spanner->ticks() - e.tick() - Fraction::fromTicks(1));
                         spanner->setTick(e.tick());
                         spanner->setTrack(ch->track());
-                        if (spanner->type() == ElementType::SLUR)
+                        if (spanner->isSlur())
                               spanner->setStartElement(ch);
                         if (e.pasteMode()) {
                               for (ScoreElement*& el : spanner->linkList()) {
@@ -1827,7 +1827,7 @@ bool readChordRestProperties206(XmlReader& e, ChordRest* ch)
                                           ChordRest* cr = toChordRest(ee);
                                           if (cr->score() == ee->score() && cr->staffIdx() == ls->staffIdx()) {
                                                 ls->setTrack(cr->track());
-                                                if (ls->type() == ElementType::SLUR)
+                                                if (ls->isSlur())
                                                       ls->setStartElement(cr);
                                                 break;
                                                 }
@@ -1853,7 +1853,7 @@ bool readChordRestProperties206(XmlReader& e, ChordRest* ch)
                                           ChordRest* cr = toChordRest(ee);
                                           if (cr->score() == ee->score() && cr->staffIdx() == ls->staffIdx()) {
                                                 ls->setTrack2(cr->track());
-                                                if (ls->type() == ElementType::SLUR)
+                                                if (ls->isSlur())
                                                       ls->setEndElement(cr);
                                                 break;
                                                 }
@@ -2872,10 +2872,10 @@ static void readMeasure(Measure* m, int staffIdx, XmlReader& e)
                         bool firstSegment = false;
                         // the first clef may be missing and is added later in layout
                         for (Segment* s = m->segments().first(); s && s->tick() == e.tick(); s = s->next()) {
-                              if (s->segmentType() == SegmentType::Clef
+                              if (s->isClefType()
                                     // hack: there may be other segment types which should
                                     // generate a clef at current position
-                                 || s->segmentType() == SegmentType::StartRepeatBarLine
+                                 || s->isStartRepeatBarLineType()
                                  ) {
                                     firstSegment = true;
                                     break;
@@ -2890,7 +2890,7 @@ static void readMeasure(Measure* m, int staffIdx, XmlReader& e)
                                     }
                               segment = 0;
                               for (Segment* s = ns; s && s->tick() == e.tick(); s = s->next()) {
-                                    if (s->segmentType() == SegmentType::Clef) {
+                                    if (s->isClefType()) {
                                           segment = s;
                                           break;
                                           }

--- a/libmscore/rendermidi.cpp
+++ b/libmscore/rendermidi.cpp
@@ -206,7 +206,7 @@ void Score::updateChannel()
                         if (!s->element(track))
                               continue;
                         Element* e = s->element(track);
-                        if (e->type() != ElementType::CHORD)
+                        if (!e->isChord())
                               continue;
                         Chord* c = toChord(e);
                         int channel = st->channel(c->tick(), c->voice());
@@ -241,7 +241,7 @@ int toMilliseconds(float tempo, float midiTime) {
 //---------------------------------------------------------
 bool isGlissandoFor(const Note* note) {
       for (Spanner* spanner : note->spannerFor())
-            if (spanner->type() == ElementType::GLISSANDO)
+            if (spanner->isGlissando())
                   return true;
       return false;
       }
@@ -264,7 +264,7 @@ static void playNote(EventMap* events, const Note* note, int channel, int pitch,
       events->insert(std::pair<int, NPlayEvent>(onTime, ev));
       // adds portamento for continuous glissando
       for (Spanner* spanner : note->spannerFor()) {
-            if (spanner->type() == ElementType::GLISSANDO) {
+            if (spanner->isGlissando()) {
                   Glissando *glissando = toGlissando(spanner);
                   if (glissando->glissandoStyle() == GlissandoStyle::PORTAMENTO) {
                         Note* nextNote = toNote(spanner->endElement());
@@ -465,7 +465,7 @@ static void collectNote(EventMap* events, int channel, const Note* note, qreal v
 
       // Bends
       for (Element* e : note->el()) {
-            if (e == 0 || e->type() != ElementType::BEND)
+            if (e == 0 || !e->isBend())
                   continue;
             Bend* bend = toBend(e);
             if (!bend->playBend())
@@ -726,7 +726,7 @@ void MidiRenderer::collectMeasureEventsSimple(EventMap* events, Measure const * 
                         continue;
                         }
                   Element* cr = seg->element(track);
-                  if (cr == 0 || cr->type() != ElementType::CHORD)
+                  if (cr == 0 || !cr->isChord())
                         continue;
 
                   Chord* chord = toChord(cr);
@@ -948,7 +948,7 @@ void Score::updateVelo()
                   for (const Element* e : s->annotations()) {
                         if (e->staffIdx() != staffIdx)
                               continue;
-                        if (e->type() != ElementType::DYNAMIC)
+                        if (!e->isDynamic())
                               continue;
                         const Dynamic* d = toDynamic(e);
                         int v            = d->velocity();
@@ -1035,7 +1035,7 @@ void Score::updateVelo()
                   }
             for (const auto& sp : _spanner.map()) {
                   Spanner* s = sp.second;
-                  if (s->type() != ElementType::HAIRPIN || sp.second->staffIdx() != staffIdx)
+                  if (!s->isHairpin() || sp.second->staffIdx() != staffIdx)
                         continue;
                   Hairpin* h = toHairpin(s);
                   updateHairpin(h);
@@ -1296,7 +1296,7 @@ void renderTremolo(Chord* chord, QList<NoteEventList>& ell)
                   return;
 
             Chord* c2 = toChord(s2El);
-            if (c2->type() == ElementType::CHORD) {
+            if (c2->isChord()) {
                   int notes2 = int(c2->notes().size());
                   int tnotes = qMax(notes, notes2);
                   int tticks = chord->ticks().ticks() * 2; // use twice the size
@@ -1485,7 +1485,7 @@ int articulationExcursion(Note *noteL, Note *noteR, int deltastep)
       bool done = false;
       for (int track = startTrack; track < endTrack; ++track) {
             Element *e = segment->element(track);
-            if (!e || e->type() != ElementType::CHORD)
+            if (!e || !e->isChord())
                   continue;
             Chord* chord = toChord(e);
             if (chord->vStaffIdx() != chordL->vStaffIdx())
@@ -1686,7 +1686,7 @@ bool renderNoteArticulation(NoteEventList* events, Note* note, bool chromatic, i
             bool isGlissando = false;
             QList<int> onTimes;
             for (Spanner* spanner : note->spannerFor()) {
-                  if (spanner->type() == ElementType::GLISSANDO) {
+                  if (spanner->isGlissando()) {
                         Glissando* glissando = toGlissando(spanner);
                         EaseInOut easeInOut(static_cast<qreal>(glissando->easeIn())/100.0,
                               static_cast<qreal>(glissando->easeOut())/100.0);
@@ -1855,7 +1855,7 @@ bool renderNoteArticulation(NoteEventList* events, Note * note, bool chromatic, 
 bool noteHasGlissando(Note *note)
       {
       for (Spanner* spanner : note->spannerFor()) {
-            if ((spanner->type() == ElementType::GLISSANDO)
+            if ((spanner->isGlissando())
                && spanner->endElement()
                && (ElementType::NOTE == spanner->endElement()->type()))
                   return true;
@@ -1922,7 +1922,7 @@ void renderGlissando(NoteEventList* events, Note *notestart)
       std::vector<int> empty = {};
       std::vector<int> body;
       for (Spanner* spanner : notestart->spannerFor()) {
-            if (spanner->type() == ElementType::GLISSANDO
+            if (spanner->isGlissando()
             && toGlissando(spanner)->playGlissando()
             && glissandoPitchOffsets(spanner, body))
                   renderNoteArticulation(events, notestart, true, MScore::division, empty, body, false, true, empty, 16, 0);
@@ -1942,11 +1942,11 @@ Trill* findFirstTrill(Chord *chord)
       auto spanners = chord->score()->spannerMap().findOverlapping(1+chord->tick().ticks(),
          chord->tick().ticks() + chord->actualTicks().ticks() - 1);
       for (auto i : spanners) {
-            if (i.value->type() != ElementType::TRILL)
+            if (!i.value->isTrill())
                   continue;
             if (i.value->track() != chord->track())
                   continue;
-            Trill *trill = toTrill (i.value);
+            Trill *trill = toTrill(i.value);
             if (trill->playArticulation() == false)
                   continue;
             return trill;

--- a/libmscore/rest.cpp
+++ b/libmscore/rest.cpp
@@ -554,7 +554,7 @@ int Rest::computeLineOffset(int lines)
                   Element* e = s->element(baseTrack + v);
                   // try to find match in any other voice
                   if (e) {
-                        if (e->type() == ElementType::REST) {
+                        if (e->isRest()) {
                               Rest* r = toRest(e);
                               if (r->globalTicks() == globalTicks()) {
                                     matchFound = true;

--- a/libmscore/revisions.cpp
+++ b/libmscore/revisions.cpp
@@ -80,7 +80,7 @@ void Revisions::write(XmlWriter& xml) const
 void Revisions::write(XmlWriter& xml, const Revision* r) const
       {
       r->write(xml);
-      foreach(const Revision* rr, r->branches())
+      for (const Revision* rr : r->branches())
             write(xml, rr);
       }
 

--- a/libmscore/scoreElement.cpp
+++ b/libmscore/scoreElement.cpp
@@ -848,23 +848,23 @@ bool ScoreElement::isSLineSegment() const
 
 bool ScoreElement::isTextBase() const
       {
-      return type()  == ElementType::TEXT
-         || type() == ElementType::LYRICS
-         || type() == ElementType::DYNAMIC
-         || type() == ElementType::FINGERING
-         || type() == ElementType::HARMONY
-         || type() == ElementType::MARKER
-         || type() == ElementType::JUMP
-         || type() == ElementType::STAFF_TEXT
-         || type() == ElementType::SYSTEM_TEXT
-         || type() == ElementType::REHEARSAL_MARK
-         || type() == ElementType::INSTRUMENT_CHANGE
-         || type() == ElementType::FIGURED_BASS
-         || type() == ElementType::TEMPO_TEXT
-         || type() == ElementType::INSTRUMENT_NAME
-         || type() == ElementType::MEASURE_NUMBER
-         || type() == ElementType::MMREST_RANGE
-         || type() == ElementType::STICKING
+      return isText()
+         || isLyrics()
+         || isDynamic()
+         || isFingering()
+         || isHarmony()
+         || isMarker()
+         || isJump()
+         || isStaffText()
+         || isSystemText()
+         || isRehearsalMark()
+         || isInstrumentChange()
+         || isFiguredBass()
+         || isTempoText()
+         || isInstrumentName()
+         || isMeasureNumber()
+         || isMMRestRange()
+         || isSticking()
          ;
       }
 

--- a/libmscore/scoreElement.h
+++ b/libmscore/scoreElement.h
@@ -423,23 +423,19 @@ class ScoreElement {
 //---------------------------------------------------
 
 static inline ChordRest* toChordRest(ScoreElement* e) {
-      Q_ASSERT(e == 0 || e->type() == ElementType::CHORD || e->type() == ElementType::REST
-         || e->type() == ElementType::REPEAT_MEASURE);
+      Q_ASSERT(e == 0 || e->isChordRest());
       return (ChordRest*)e;
       }
 static inline const ChordRest* toChordRest(const ScoreElement* e) {
-      Q_ASSERT(e == 0 || e->type() == ElementType::CHORD || e->type() == ElementType::REST
-         || e->type() == ElementType::REPEAT_MEASURE);
+      Q_ASSERT(e == 0 || e->isChordRest());
       return (const ChordRest*)e;
       }
 static inline DurationElement* toDurationElement(ScoreElement* e) {
-      Q_ASSERT(e == 0 || e->type() == ElementType::CHORD || e->type() == ElementType::REST
-         || e->type() == ElementType::REPEAT_MEASURE || e->type() == ElementType::TUPLET);
+      Q_ASSERT(e == 0 || e->isChordRest() || e->isTuplet());
       return (DurationElement*)e;
       }
 static inline const DurationElement* toDurationElement(const ScoreElement* e) {
-      Q_ASSERT(e == 0 || e->type() == ElementType::CHORD || e->type() == ElementType::REST
-         || e->type() == ElementType::REPEAT_MEASURE || e->type() == ElementType::TUPLET);
+      Q_ASSERT(e == 0 || e->isChordRest() || e->isTuplet());
       return (const DurationElement*)e;
       }
 static inline Rest* toRest(ScoreElement* e) {
@@ -451,15 +447,15 @@ static inline const Rest* toRest(const ScoreElement* e) {
       return (const Rest*)e;
       }
 static inline SlurTieSegment* toSlurTieSegment(ScoreElement* e) {
-      Q_ASSERT(e == 0 || e->type() == ElementType::SLUR_SEGMENT || e->type() == ElementType::TIE_SEGMENT);
+      Q_ASSERT(e == 0 || e->isSlurTieSegment());
       return (SlurTieSegment*)e;
       }
 static inline const SlurTieSegment* toSlurTieSegment(const ScoreElement* e) {
-      Q_ASSERT(e == 0 || e->type() == ElementType::SLUR_SEGMENT || e->type() == ElementType::TIE_SEGMENT);
+      Q_ASSERT(e == 0 || e->isSlurTieSegment());
       return (const SlurTieSegment*)e;
       }
 static inline const MeasureBase* toMeasureBase(const ScoreElement* e) {
-     Q_ASSERT(e == 0 || e->isMeasure() || e->isVBox() || e->isHBox() || e->isTBox() || e->isFBox());
+     Q_ASSERT(e == 0 || e->isMeasure() || e->isBox());
       return (const MeasureBase*)e;
       }
 static inline MeasureBase* toMeasureBase(ScoreElement* e) {

--- a/libmscore/scorefile.cpp
+++ b/libmscore/scorefile.cpp
@@ -1132,7 +1132,7 @@ QByteArray MasterScore::readCompressedToBuffer()
       //
       // load images
       //
-      foreach(const QString& s, images) {
+      for (const QString& s : images) {
             QByteArray dbuf = uz.fileData(s);
             imageStore.add(s, dbuf);
             }
@@ -1368,7 +1368,7 @@ void Score::writeSegments(XmlWriter& xml, int strack, int etrack,
                         continue;
                   if (e->generated())
                         continue;
-                  if (forceTimeSig && track2voice(track) == 0 && segment->segmentType() == SegmentType::ChordRest && !timeSigWritten && !crWritten) {
+                  if (forceTimeSig && track2voice(track) == 0 && segment->isChordRestType() && !timeSigWritten && !crWritten) {
                         // Ensure that <voice> tag is open
                         voiceTagWritten |= writeVoiceMove(xml, segment, startTick, track, &lastTrackWritten);
                         // we will miss a key sig!
@@ -1411,11 +1411,11 @@ void Score::writeSegments(XmlWriter& xml, int strack, int etrack,
                   if (!(e->isRest() && toRest(e)->isGap()))
                         segment->write(xml);    // write only once
                   if (forceTimeSig) {
-                        if (segment->segmentType() == SegmentType::KeySig)
+                        if (segment->isKeySigType())
                               keySigWritten = true;
-                        if (segment->segmentType() == SegmentType::TimeSig)
+                        if (segment->isTimeSigType())
                               timeSigWritten = true;
-                        if (segment->segmentType() == SegmentType::ChordRest)
+                        if (segment->isChordRestType())
                               crWritten = true;
                         }
                   }

--- a/libmscore/segmentlist.cpp
+++ b/libmscore/segmentlist.cpp
@@ -204,7 +204,7 @@ Segment* SegmentList::firstCRSegment() const
 Segment* SegmentList::first(SegmentType types) const
       {
       for (Segment* s = _first; s; s = s->next()) {
-            if (s->segmentType() & types)
+            if (s->isType(types))
                   return s;
             }
       return 0;

--- a/libmscore/select.cpp
+++ b/libmscore/select.cpp
@@ -390,27 +390,27 @@ bool SelectionFilter::canSelect(const Element* e) const
             return isFiltered(SelectionFilterType::ARTICULATION);
       if ((e->isArticulation() && toArticulation(e)->isOrnament()) || e->isTrill())
             return isFiltered(SelectionFilterType::ORNAMENT);
-      if (e->type() == ElementType::LYRICS)
+      if (e->isLyrics())
             return isFiltered(SelectionFilterType::LYRICS);
-      if (e->type() == ElementType::FINGERING)
+      if (e->isFingering())
             return isFiltered(SelectionFilterType::FINGERING);
-      if (e->type() == ElementType::HARMONY)
+      if (e->isHarmony())
             return isFiltered(SelectionFilterType::CHORD_SYMBOL);
-      if (e->type() == ElementType::SLUR)
+      if (e->isSlur())
             return isFiltered(SelectionFilterType::SLUR);
-      if (e->type() == ElementType::FIGURED_BASS)
+      if (e->isFiguredBass())
             return isFiltered(SelectionFilterType::FIGURED_BASS);
-      if (e->type() == ElementType::OTTAVA)
+      if (e->isOttava())
             return isFiltered(SelectionFilterType::OTTAVA);
-      if (e->type() == ElementType::PEDAL)
+      if (e->isPedal())
             return isFiltered(SelectionFilterType::PEDAL_LINE);
-      if (e->type() == ElementType::ARPEGGIO)
+      if (e->isArpeggio())
             return isFiltered(SelectionFilterType::ARPEGGIO);
-      if (e->type() == ElementType::GLISSANDO)
+      if (e->isGlissando())
             return isFiltered(SelectionFilterType::GLISSANDO);
-      if (e->type() == ElementType::FRET_DIAGRAM)
+      if (e->isFretDiagram())
             return isFiltered(SelectionFilterType::FRET_DIAGRAM);
-      if (e->type() == ElementType::BREATH)
+      if (e->isBreath())
             return isFiltered(SelectionFilterType::BREATH);
       if (e->isTextBase()) // only TEXT, INSTRCHANGE and STAFFTEXT are caught here, rest are system thus not in selection
             return isFiltered(SelectionFilterType::OTHER_TEXT);
@@ -1074,7 +1074,7 @@ Enabling copying of more element types requires enabling pasting in Score::paste
             numSegs = 0;
             // with figured bass, we need to look for the proper segment
             // not only according to ChordRest elements, but also annotations
-            if (iter->second.e->type() == ElementType::FIGURED_BASS) {
+            if (iter->second.e->isFiguredBass()) {
                   bool done = false;
                   for ( ; seg; seg = seg->next1()) {
                         if (seg->isChordRestType()) {
@@ -1087,7 +1087,7 @@ Enabling copying of more element types requires enabling pasting in Score::paste
                                                 break;
                                                 }
                                           // do annotations include any f.b.?
-                                          if (el->type() == ElementType::FIGURED_BASS && el->track() == track) {
+                                          if (el->isFiguredBass() && el->track() == track) {
                                                 numSegs++;  //yes: it counts as a step
                                                 break;
                                                 }
@@ -1138,13 +1138,13 @@ std::vector<Note*> Selection::noteList(int selTrack) const
                   int startTrack = staffIdx * VOICES;
                   int endTrack   = startTrack + VOICES;
                   for (Segment* seg = _startSegment; seg && seg != _endSegment; seg = seg->next1()) {
-                        if (!(seg->segmentType() & (SegmentType::ChordRest)))
+                        if (!seg->isType(SegmentType::ChordRest))
                               continue;
                         for (int track = startTrack; track < endTrack; ++track) {
                               if (!canSelectVoice(track))
                                   continue;
                               Element* e = seg->element(track);
-                              if (e == 0 || e->type() != ElementType::CHORD
+                              if (e == 0 || !e->isChord()
                                  || (selTrack != -1 && selTrack != track))
                                     continue;
                               Chord* c = toChord(e);
@@ -1181,7 +1181,7 @@ static bool checkStart(Element* e)
                   tuplet = tuplet->tuplet();
                   }
             }
-      else if (cr->type() == ElementType::CHORD) {
+      else if (cr->isChord()) {
             rv = false;
             Chord* chord = toChord(cr);
             if (chord->tremolo() && chord->tremolo()->twoNotes())
@@ -1216,7 +1216,7 @@ static bool checkEnd(Element* e, const Fraction& endTick)
             if (tuplet->elements().front()->tick() + tuplet->actualTicks() > endTick)
                   return true;
             }
-      else if (cr->type() == ElementType::CHORD) {
+      else if (cr->isChord()) {
             rv = false;
             Chord* chord = toChord(cr);
             if (chord->tremolo() && chord->tremolo()->twoNotes())

--- a/libmscore/slur.cpp
+++ b/libmscore/slur.cpp
@@ -412,7 +412,7 @@ void SlurSegment::layoutSegment(const QPointF& p1, const QPointF& p2)
                         if (s == ss || s == es)
                               continue;
                         // allow slurs to cross barlines
-                        if (s->segmentType() & SegmentType::BarLineType)
+                        if (s->isType(SegmentType::BarLineType))
                               continue;
                         qreal x1 = s->x() + s->measure()->x();
                         qreal x2 = x1 + s->width();

--- a/libmscore/spanner.cpp
+++ b/libmscore/spanner.cpp
@@ -496,7 +496,7 @@ void Spanner::scanElements(void* data, void (*func)(void*, Element*), bool all)
 void Spanner::setScore(Score* s)
       {
       Element::setScore(s);
-      foreach(SpannerSegment* seg, segments)
+      for (SpannerSegment* seg : segments)
             seg->setScore(s);
       }
 
@@ -810,7 +810,7 @@ Chord* Spanner::endChord()
       {
       Q_ASSERT(_anchor == Anchor::CHORD);
 
-      if (!_endElement && type() == ElementType::SLUR) {
+      if (!_endElement && isSlur()) {
             Segment* s = score()->tick2segmentMM(tick2(), false, SegmentType::ChordRest);
             _endElement = s ? toChordRest(s->element(track2())) : nullptr;
             if (_endElement && !_endElement->isChord())
@@ -952,7 +952,7 @@ void Spanner::setStartElement(Element* e)
       {
 #ifndef NDEBUG
       if (_anchor == Anchor::NOTE)
-            Q_ASSERT(!e || e->type() == ElementType::NOTE);
+            Q_ASSERT(!e || e->isNote());
 #endif
       _startElement = e;
       }
@@ -965,7 +965,7 @@ void Spanner::setEndElement(Element* e)
       {
 #ifndef NDEBUG
       if (_anchor == Anchor::NOTE)
-            Q_ASSERT(!e || e->type() == ElementType::NOTE);
+            Q_ASSERT(!e || e->isNote());
 #endif
       _endElement = e;
       if (e && ticks() == Fraction() && _tick >= Fraction())

--- a/libmscore/staff.cpp
+++ b/libmscore/staff.cpp
@@ -416,7 +416,7 @@ void Staff::setClef(Clef* clef)
             return;
       Fraction tick = clef->segment()->tick();
       for (Segment* s = clef->segment()->next1(); s && s->tick() == tick; s = s->next1()) {
-            if ((s->segmentType() == SegmentType::Clef || s->segmentType() == SegmentType::HeaderClef)
+            if ((s->isClefType() || s->isHeaderClefType())
                 && s->element(clef->track())
                 && !s->element(clef->track())->generated()) {
                   // adding this clef has no effect on the clefs list
@@ -437,7 +437,7 @@ void Staff::removeClef(const Clef* clef)
             return;
       Fraction tick = clef->segment()->tick();
       for (Segment* s = clef->segment()->next1(); s && s->tick() == tick; s = s->next1()) {
-            if ((s->segmentType() == SegmentType::Clef || s->segmentType() == SegmentType::HeaderClef)
+            if ((s->isClefType() || s->isHeaderClefType())
                 && s->element(clef->track())
                 && !s->element(clef->track())->generated()) {
                   // removal of this clef has no effect on the clefs list
@@ -446,7 +446,7 @@ void Staff::removeClef(const Clef* clef)
             }
       clefs.erase(clef->segment()->tick().ticks());
       for (Segment* s = clef->segment()->prev1(); s && s->tick() == tick; s = s->prev1()) {
-            if ((s->segmentType() == SegmentType::Clef || s->segmentType() == SegmentType::HeaderClef)
+            if ((s->isClefType() || s->isHeaderClefType())
                && s->element(clef->track())
                && !s->element(clef->track())->generated()) {
                   // a previous clef at the same tick position gets valid
@@ -536,7 +536,7 @@ const Groups& Staff::group(const Fraction& tick) const
 
 void Staff::addTimeSig(TimeSig* timesig)
       {
-      if (timesig->segment()->segmentType() == SegmentType::TimeSig)
+      if (timesig->segment()->isTimeSigType())
             timesigs[timesig->segment()->tick().ticks()] = timesig;
 //      dumpTimeSigs("after addTimeSig");
       }
@@ -547,7 +547,7 @@ void Staff::addTimeSig(TimeSig* timesig)
 
 void Staff::removeTimeSig(TimeSig* timesig)
       {
-      if (timesig->segment()->segmentType() == SegmentType::TimeSig)
+      if (timesig->segment()->isTimeSigType())
             timesigs.erase(timesig->segment()->tick().ticks());
 //      dumpTimeSigs("after removeTimeSig");
       }
@@ -1218,8 +1218,8 @@ void Staff::updateOttava()
       _pitchOffsets.clear();
       for (auto i : score()->spanner()) {
             const Spanner* s = i.second;
-            if (s->type() == ElementType::OTTAVA && s->staffIdx() == staffIdx) {
-                  const Ottava* o = static_cast<const Ottava*>(s);
+            if (s->isOttava() && s->staffIdx() == staffIdx) {
+                  const Ottava* o = toOttava(s);
                   _pitchOffsets.setPitchOffset(o->tick().ticks(), o->pitchShift());
                   _pitchOffsets.setPitchOffset(o->tick2().ticks(), 0);
                   }

--- a/libmscore/stafflines.cpp
+++ b/libmscore/stafflines.cpp
@@ -62,7 +62,7 @@ QPointF StaffLines::canvasPos() const
       QPointF p(pagePos());
       Element* e = parent();
       while (e) {
-            if (e->type() == ElementType::PAGE) {
+            if (e->isPage()) {
                   p += e->pos();
                   break;
                   }

--- a/libmscore/stafftype.cpp
+++ b/libmscore/stafftype.cpp
@@ -1244,10 +1244,10 @@ QList<QString> StaffType::fontNames(bool bDuration)
       {
       QList<QString> names;
       if(bDuration)
-            foreach(const TablatureDurationFont& f, _durationFonts)
+            for (const TablatureDurationFont& f : _durationFonts)
                   names.append(f.displayName);
       else
-            foreach(const TablatureFretFont& f, _fretFonts)
+            for (const TablatureFretFont& f : _fretFonts)
                   names.append(f.displayName);
       return names;
       }

--- a/libmscore/stem.cpp
+++ b/libmscore/stem.cpp
@@ -307,7 +307,7 @@ void Stem::reset()
 bool Stem::acceptDrop(EditData& data) const
       {
       Element* e = data.dropElement;
-      if ((e->type() == ElementType::TREMOLO) && (toTremolo(e)->tremoloType() <= TremoloType::R64)) {
+      if ((e->isTremolo()) && (toTremolo(e)->tremoloType() <= TremoloType::R64)) {
             return true;
             }
       return false;

--- a/libmscore/stringdata.cpp
+++ b/libmscore/stringdata.cpp
@@ -43,7 +43,7 @@ StringData::StringData(int numFrets, QList<instrString>& strings)
       _frets = numFrets;
 
       stringTable.clear();
-      foreach(instrString i, strings)
+      for (instrString i : strings)
             stringTable.append(i);
       }
 
@@ -87,7 +87,7 @@ void StringData::write(XmlWriter& xml) const
       {
       xml.stag("StringData");
       xml.tag("frets", _frets);
-      foreach(instrString strg, stringTable) {
+      for (instrString strg : stringTable) {
             if (strg.open)
                   xml.tag("string open=\"1\"", strg.pitch);
             else
@@ -171,7 +171,7 @@ void StringData::fretChords(Chord * chord) const
       int pitchOffset = -transp + chord->staff()->pitchOffset(chord->segment()->tick());
       // if chord parent is not a segment, the chord is special (usually a grace chord):
       // fret it by itself, ignoring the segment
-      if (chord->parent()->type() != ElementType::SEGMENT)
+      if (!chord->parent()->isSegment())
             sortChordNotes(sortedNotes, chord, pitchOffset, &count);
       else {
             // scan each chord of seg from same staff as 'chord', inserting each of its notes in sortedNotes
@@ -181,14 +181,14 @@ void StringData::fretChords(Chord * chord) const
             int trkTo   = trkFrom + VOICES;
             for(trk = trkFrom; trk < trkTo; ++trk) {
                   Element* ch = seg->elist().at(trk);
-                  if (ch && ch->type() == ElementType::CHORD)
+                  if (ch && ch->isChord())
                         sortChordNotes(sortedNotes, toChord(ch), pitchOffset, &count);
                   }
             }
       // determine used range of frets
       minFret = INT32_MAX;
       maxFret = INT32_MIN;
-      foreach(Note* note, sortedNotes) {
+      for (Note*& note : sortedNotes) {
             if (note->string() != INVALID_STRING_INDEX)
                   bUsed[note->string()]++;
             if (note->fret() != INVALID_FRET_INDEX && note->fret() < minFret)
@@ -198,7 +198,7 @@ void StringData::fretChords(Chord * chord) const
       }
 
       // scan chord notes from highest, matching with strings from the highest
-      foreach(Note * note, sortedNotes) {
+      for (Note*& note : sortedNotes) {
             nString     = nNewString    = note->string();
             nFret       = nNewFret      = note->fret();
             note->setFretConflict(false);       // assume no conflicts on this note

--- a/libmscore/symbol.cpp
+++ b/libmscore/symbol.cpp
@@ -66,7 +66,7 @@ QString Symbol::accessibleInfo() const
 
 void Symbol::layout()
       {
-      // foreach(Element* e, leafs())     done in BSymbol::layout() ?
+      // for (Element* e : leafs())     done in BSymbol::layout() ?
       //      e->layout();
       setbbox(_scoreFont ? _scoreFont->bbox(_sym, magS()) : symBbox(_sym));
       qreal w = width();

--- a/libmscore/system.cpp
+++ b/libmscore/system.cpp
@@ -906,7 +906,7 @@ void System::setInstrumentNames(bool longName, Fraction tick)
       if (!score()->showInstrumentNames()
               || (score()->styleB(Sid::hideInstrumentNameIfOneInstrument) && score()->parts().size() == 1)) {
             for (SysStaff* staff : qAsConst(_staves)) {
-                  foreach (InstrumentName* t, staff->instrumentNames)
+                  for (InstrumentName* t : staff->instrumentNames)
                         score()->removeElement(t);
                   }
             return;
@@ -966,7 +966,7 @@ int System::y2staff(qreal y) const
       y -= pos().y();
       int idx = 0;
       qreal margin = spatium() * 2;
-      foreach (SysStaff* s, _staves) {
+      for (SysStaff* s : _staves) {
             qreal y1 = s->bbox().top()    - margin;
             qreal y2 = s->bbox().bottom() + margin;
             if (y >= y1 && y < y2)
@@ -1383,7 +1383,7 @@ Element* System::prevSegmentElement()
                   if (!seg)
                         return score()->firstElement();
 
-                  if (seg->segmentType() == SegmentType::EndBarLine)
+                  if (seg->isEndBarLineType())
                         score()->inputState().setTrack((score()->staves().size() - 1) * VOICES); //correction
 
                   re = seg->lastElementForNavigation(score()->staves().size() - 1);

--- a/libmscore/textbase.cpp
+++ b/libmscore/textbase.cpp
@@ -2343,7 +2343,7 @@ bool TextBase::mousePress(EditData& ed)
 void TextBase::layoutEdit()
       {
       layout();
-      if (parent() && parent()->type() == ElementType::TBOX) {
+      if (parent() && parent()->isTBox()) {
             TBox* tbox = toTBox(parent());
             tbox->layout();
             System* system = tbox->system();

--- a/libmscore/textedit.cpp
+++ b/libmscore/textedit.cpp
@@ -335,13 +335,13 @@ bool TextBase::edit(EditData& ed)
                         return true;
 
                   case Qt::Key_Left:
-                        if (!_cursor->movePosition(ctrlPressed ? QTextCursor::WordLeft : QTextCursor::Left, mm) && type() == ElementType::LYRICS)
+                        if (!_cursor->movePosition(ctrlPressed ? QTextCursor::WordLeft : QTextCursor::Left, mm) && isLyrics())
                               return false;
                         s.clear();
                         break;
 
                   case Qt::Key_Right:
-                        if (!_cursor->movePosition(ctrlPressed ? QTextCursor::NextWord : QTextCursor::Right, mm) && type() == ElementType::LYRICS)
+                        if (!_cursor->movePosition(ctrlPressed ? QTextCursor::NextWord : QTextCursor::Right, mm) && isLyrics())
                               return false;
                         s.clear();
                         break;

--- a/libmscore/tie.cpp
+++ b/libmscore/tie.cpp
@@ -1070,7 +1070,7 @@ void Tie::setStartNote(Note* note)
 
 Note* Tie::startNote() const
       {
-      Q_ASSERT(!startElement() || startElement()->type() == ElementType::NOTE);
+      Q_ASSERT(!startElement() || startElement()->isNote());
       return toNote(startElement());
       }
 

--- a/libmscore/transpose.cpp
+++ b/libmscore/transpose.cpp
@@ -305,7 +305,7 @@ bool Score::transpose(TransposeMode mode, TransposeDirection direction, Key trKe
             }
 
       if (_selection.isList()) {
-            foreach (Element* e, _selection.uniqueElements()) {
+            for (Element* e : _selection.uniqueElements()) {
                   if (!e->staff() || e->staff()->staffType(e->tick())->group() == StaffGroup::PERCUSSION)
                         continue;
                   if (e->isNote()) {
@@ -459,8 +459,8 @@ bool Score::transpose(TransposeMode mode, TransposeDirection direction, Key trKe
                         }
                   }
             if (transposeChordNames) {
-                  foreach (Element* e, segment->annotations()) {
-                        if ((e->type() != ElementType::HARMONY) || (!tracks.contains(e->track())))
+                  for (Element* e : segment->annotations()) {
+                        if (!e->isHarmony() || (!tracks.contains(e->track())))
                               continue;
                         Harmony* hh  = toHarmony(e);
                         int rootTpc, baseTpc;
@@ -771,7 +771,7 @@ void Score::transpositionChanged(Part* part, Interval oldV, Fraction tickStart, 
                               }
                         // find chord symbols
                         for (Element* element : s->annotations()) {
-                              if (element->track() != track || element->type() != ElementType::HARMONY)
+                              if (element->track() != track || !element->isHarmony())
                                     continue;
                               Harmony* h  = toHarmony(element);
                               int rootTpc = transposeTpc(h->rootTpc(), diffV, false);

--- a/libmscore/trill.cpp
+++ b/libmscore/trill.cpp
@@ -67,7 +67,7 @@ void TrillSegment::draw(QPainter* painter) const
 void TrillSegment::add(Element* e)
       {
       e->setParent(this);
-      if (e->type() == ElementType::ACCIDENTAL) {
+      if (e->isAccidental()) {
             // accidental is part of trill
             trill()->setAccidental(toAccidental(e));
             }
@@ -301,7 +301,7 @@ Trill::~Trill()
 
 void Trill::add(Element* e)
       {
-      if (e->type() == ElementType::ACCIDENTAL) {
+      if (e->isAccidental()) {
             e->setParent(this);
             _accidental = toAccidental(e);
             }

--- a/libmscore/tuplet.cpp
+++ b/libmscore/tuplet.cpp
@@ -1386,7 +1386,7 @@ void Tuplet::addMissingElements()
 Element* Tuplet::nextElement()
       {
       ChordRest* firstElement = toChordRest(elements().front());
-      if (firstElement->type() == ElementType::CHORD) {
+      if (firstElement->isChord()) {
             Chord* chord = toChord(firstElement);
             return chord->firstGraceOrNote();
             }

--- a/libmscore/undo.cpp
+++ b/libmscore/undo.cpp
@@ -87,7 +87,7 @@ void updateNoteLines(Segment* segment, int track)
       if (staff->isDrumStaff(segment->tick()) || staff->isTabStaff(segment->tick()))
             return;
       for (Segment* s = segment->next1(); s; s = s->next1()) {
-            if ((s->segmentType() & (SegmentType::Clef | SegmentType::HeaderClef)) && s->element(track) && !s->element(track)->generated())
+            if (s->isType(SegmentType::Clef | SegmentType::HeaderClef) && s->element(track) && !s->element(track)->generated())
                   break;
             if (!s->isChordRestType())
                   continue;
@@ -1851,7 +1851,7 @@ void InsertRemoveMeasures::insertMeasures()
             fs = toMeasure(fm)->first();
             ls = toMeasure(lm)->last();
             for (Segment* s = fs; s && s != ls; s = s->next1()) {
-                  if (!s->enabled() || !(s->segmentType() & (SegmentType::Clef | SegmentType::HeaderClef | SegmentType::KeySig)))
+                  if (!s->enabled() || !s->isType(SegmentType::Clef | SegmentType::HeaderClef | SegmentType::KeySig))
                         continue;
                   for (int track = 0; track < score->ntracks(); track += VOICES) {
                         Element* e = s->element(track);
@@ -1902,7 +1902,7 @@ void InsertRemoveMeasures::insertMeasures()
                   if (e == 0 || !e->isChord())
                         continue;
                   Chord* chord = toChord(e);
-                  foreach (Note* n, chord->notes()) {
+                  for (Note* n : chord->notes()) {
                         Tie* tie = n->tieFor();
                         if (!tie)
                               continue;

--- a/libmscore/unrollrepeats.cpp
+++ b/libmscore/unrollrepeats.cpp
@@ -74,7 +74,7 @@ static void removeRepeatMarkings(Score* score)
       // set the last bar line to end symbol
       score->lastMeasure()->setEndBarLineType(BarLineType::END, false);
       Segment* last = score->lastMeasure()->segments().last();
-      if (last->segmentType() == SegmentType::EndBarLine) {
+      if (last->isEndBarLineType()) {
             auto els = last->elist();
             for (uint i = 0; i < els.size(); i++) {
                   if (!els[i]) continue;

--- a/libmscore/utils.cpp
+++ b/libmscore/utils.cpp
@@ -350,7 +350,7 @@ Note* prevChordNote(Note* note)
       // TODO : limit to same instrument, not simply to same staff!
       Segment*    seg   = note->chord()->segment()->prev1();
       while (seg) {
-            if (seg->segmentType() == SegmentType::ChordRest) {
+            if (seg->isChordRestType()) {
                   Element*    targetElement = seg->elementAt(track);
                   // if a chord exists in the same track, return its top note
                   if (targetElement && targetElement->isChord())

--- a/miditools/midifile.cpp
+++ b/miditools/midifile.cpp
@@ -358,7 +358,7 @@ bool MidiFile::write(QIODevice* f)
       writeShort(_format);          // format
       writeShort(_tracks.size());
       writeShort(_division);
-      foreach (const MidiTrack* t, _tracks) {
+      for (const MidiTrack* t : _tracks) {
             if (writeTrack(t))
                   return true;
             }

--- a/mscore/chordview.cpp
+++ b/mscore/chordview.cpp
@@ -195,7 +195,7 @@ void ChordView::drawBackground(QPainter* p, const QRectF& r)
       p->fillRect(r.intersected(r1), bg1);
       p->fillRect(r.intersected(r2), bg1);
 
-      foreach (const Note* n, chord->notes()) {
+      for (const Note* n : chord->notes()) {
             p->fillRect(QRect(CHORD_MAP_OFFSET, (127 - n->pitch()) * keyHeight,
                1000, keyHeight), bg2);
             }
@@ -276,7 +276,7 @@ void ChordView::setChord(Chord* c)
 
       curEvent = 0;
       _curNote  = 0;
-      foreach(Note* note, c->notes()) {
+      for (Note* note : c->notes()) {
             if (note->selected() && _curNote == 0)
                   _curNote = note;
             int n = note->playEvents().size();
@@ -310,7 +310,7 @@ void ChordView::setChord(Chord* c)
       //
       QList<QGraphicsItem*> items = scene()->selectedItems();
       QRectF boundingRect;
-      foreach(QGraphicsItem* item, items) {
+      for (QGraphicsItem* item : items) {
             Note* note = static_cast<Note*>(item->data(0).value<void*>());
             if (note)
                   boundingRect |= item->mapToScene(item->boundingRect()).boundingRect();
@@ -459,7 +459,7 @@ void ChordView::mousePressEvent(QMouseEvent* event)
             int pitch = y2pitch(int(p.y()));
             int tick  = int(p.x()) - CHORD_MAP_OFFSET;
             int tcks = 1000 - tick;
-            foreach(const NoteEvent& e, _curNote->playEvents()) {
+            for (const NoteEvent& e : _curNote->playEvents()) {
                   if (e.pitch() != pitch)
                         continue;
                   if (tick >= e.ontime() && tick < e.offtime()) {
@@ -568,7 +568,7 @@ void ChordView::selectionChanged()
 void ChordView::deleteItem()
       {
       QList<QGraphicsItem*> items = scene()->selectedItems();
-      foreach(QGraphicsItem* item, items) {
+      for (QGraphicsItem* item : items) {
             if (item->type() == ChordTypeItem) {
                   ChordItem* ci = static_cast<ChordItem*>(item);
                   if (curEvent == ci)

--- a/mscore/dragdrop.cpp
+++ b/mscore/dragdrop.cpp
@@ -465,7 +465,7 @@ void ScoreView::dropEvent(QDropEvent* event)
                   case ElementType::HARMONY:
                         {
                         Element* el = elementAt(pos);
-                        if (el == 0 || el->type() == ElementType::STAFF_LINES) {
+                        if (el == 0 || el->isStaffLines()) {
                               int staffIdx;
                               Segment* seg;
                               QPointF offset;
@@ -612,11 +612,11 @@ void ScoreView::dropEvent(QDropEvent* event)
 qDebug("drop <%s>", dta.data());
 
       Element* el = elementAt(pos);
-      if (el == 0 || el->type() != ElementType::MEASURE) {
+      if (el == 0 || !el->isMeasure()) {
             setDropTarget(0);
             return;
             }
-      Measure* measure = (Measure*) el;
+      Measure* measure = toMeasure(el);
 
       if (etype == ElementType::ELEMENT_LIST) {
             qDebug("drop element list");

--- a/mscore/drumroll.cpp
+++ b/mscore/drumroll.cpp
@@ -265,7 +265,7 @@ void DrumrollEditor::selectionChanged()
             }
       else {
             _score->select(0, SelectType::SINGLE, 0);
-            foreach(QGraphicsItem* item, items) {
+            for (QGraphicsItem* item : items) {
                   Note* note = static_cast<Note*>(item->data(0).value<void*>());
                   if (note)
                         _score->select(note, SelectType::ADD, 0);
@@ -285,7 +285,7 @@ void DrumrollEditor::changeSelection(SelState)
       gv->scene()->blockSignals(true);
       gv->scene()->clearSelection();
       QList<QGraphicsItem*> il = gv->scene()->items();
-      foreach(QGraphicsItem* item, il) {
+      for (QGraphicsItem* item : il) {
             Note* note = static_cast<Note*>(item->data(0).value<void*>());
             if (note)
                   item->setSelected(note->selected());
@@ -416,7 +416,7 @@ void DrumrollEditor::cmd(QAction* a)
       score()->startCmd();
       if (a->data() == "delete") {
             QList<QGraphicsItem*> items = gv->items();
-            foreach(QGraphicsItem* item, items) {
+            for (QGraphicsItem* item : items) {
                   Note* note = static_cast<Note*>(item->data(0).value<void*>());
                   if (note) {
                         score()->deleteItem(note);

--- a/mscore/drumtools.cpp
+++ b/mscore/drumtools.cpp
@@ -202,8 +202,8 @@ void DrumTools::editDrumset()
 void DrumTools::drumNoteSelected(int val)
       {
       Element* element = drumPalette->element(val);
-      if (element && element->type() == ElementType::CHORD) {
-            Chord* ch        = static_cast<Chord*>(element);
+      if (element && element->isChord()) {
+            Chord* ch        = toChord(element);
             Note* note       = ch->downNote();
             int ticks        = MScore::defaultPlayDuration;
             int pitch        = note->pitch();
@@ -229,8 +229,8 @@ int DrumTools::selectedDrumNote()
       if (idx < 0)
             return -1;
       Element* element = drumPalette->element(idx);
-      if (element && element->type() == ElementType::CHORD) {
-            Chord* ch  = static_cast<Chord*>(element);
+      if (element && element->isChord()) {
+            Chord* ch  = toChord(element);
             Note* note = ch->downNote();
             auto pitchCell = drumPalette->cellAt(idx);
             pitchName->setText(pitchCell->name);

--- a/mscore/drumview.cpp
+++ b/mscore/drumview.cpp
@@ -284,10 +284,10 @@ void DrumView::setStaff(Staff* s, Pos* l)
       for (Segment* seg = staff->score()->firstSegment(SegmentType::All); seg; seg = seg->next1()) {
             for (int track = startTrack; track < endTrack; ++track) {
                   Element* e = seg->element(track);
-                  if (e == 0 || e->type() != ElementType::CHORD)
+                  if (e == 0 || !e->isChord())
                         continue;
-                  Chord* chord = static_cast<Chord*>(e);
-                  foreach(Note* n, chord->notes()) {
+                  Chord* chord = toChord(e);
+                  for (Note* n : chord->notes()) {
                         if (n->tieBack())
                               continue;
                         scene()->addItem(new DrumItem(n));
@@ -307,7 +307,7 @@ void DrumView::setStaff(Staff* s, Pos* l)
       //
       QList<QGraphicsItem*> items = scene()->selectedItems();
       QRectF boundingRect;
-      foreach(QGraphicsItem* item, items) {
+      for (QGraphicsItem* item : items) {
             Note* note = static_cast<Note*>(item->data(0).value<void*>());
             if (note)
                   boundingRect |= item->mapToScene(item->boundingRect()).boundingRect();

--- a/mscore/editstafftype.cpp
+++ b/mscore/editstafftype.cpp
@@ -80,11 +80,11 @@ EditStaffType::EditStaffType(QWidget* parent, Staff* st)
 
       // tab page configuration
       QList<QString> fontNames = StaffType::fontNames(false);
-      foreach (const QString& fn, fontNames)   // fill fret font name combo
+      for (QString& fn : fontNames)   // fill fret font name combo
             fretFontName->addItem(fn);
       fretFontName->setCurrentIndex(0);
       fontNames = StaffType::fontNames(true);
-      foreach(const QString& fn, fontNames)   // fill duration font name combo
+      for (QString& fn : fontNames)   // fill duration font name combo
             durFontName->addItem(fn);
       durFontName->setCurrentIndex(0);
 

--- a/mscore/exampleview.cpp
+++ b/mscore/exampleview.cpp
@@ -266,15 +266,15 @@ void ExampleView::dragMoveEvent(QDragMoveEvent* event)
       {
       event->acceptProposedAction();
 
-      if (!dragElement || dragElement->type() != ElementType::ICON)
+      if (!dragElement || !dragElement->isIcon())
             return;
 
       QPointF pos(imatrix.map(QPointF(event->pos())));
       QList<Element*> el = elementsAt(pos);
       bool found = false;
-      foreach(const Element* e, el) {
-            if (e->type() == ElementType::NOTE) {
-                  setDropTarget(const_cast<Element*>(e));
+      for (const Element* e : el) {
+            if (e->isNote()) {
+                  setDropTarget(toElement(e));
                   found = true;
                   break;
                   }
@@ -324,15 +324,15 @@ void ExampleView::dropEvent(QDropEvent* event)
 
       if (!dragElement)
            return;
-      if (dragElement->type() != ElementType::ICON) {
+      if (!dragElement->isIcon()) {
             delete dragElement;
             dragElement = 0;
             return;
             }
-      foreach (Element* e, elementsAt(pos)) {
-            if (e->type() == ElementType::NOTE) {
-                  Icon* icon = static_cast<Icon*>(dragElement);
-                  Chord* chord = static_cast<Note*>(e)->chord();
+      for (Element* e : elementsAt(pos)) {
+            if (e->isNote()) {
+                  Icon* icon = toIcon(dragElement);
+                  Chord* chord = toNote(e)->chord();
                   emit beamPropertyDropped(chord, icon);
                   switch (icon->iconType()) {
                         case IconType::SBEAM:
@@ -369,9 +369,9 @@ void ExampleView::mousePressEvent(QMouseEvent* event)
       startMove  = imatrix.map(QPointF(event->pos()));
       QPointF pos(imatrix.map(QPointF(event->pos())));
 
-      foreach (Element* e, elementsAt(pos)) {
-            if (e->type() == ElementType::NOTE) {
-                  emit noteClicked(static_cast<Note*>(e));
+      for (Element* e : elementsAt(pos)) {
+            if (e->isNote()) {
+                  emit noteClicked(toNote(e));
                   break;
                   }
             }

--- a/mscore/excerptsdialog.cpp
+++ b/mscore/excerptsdialog.cpp
@@ -714,7 +714,7 @@ void ExcerptsDialog::accept()
       score->startCmd();
 
       // first pass : see if actual parts needs to be deleted or renamed
-      foreach (Excerpt* e, score->excerpts()) {
+      for (Excerpt* e : score->excerpts()) {
             Score* partScore  = e->partScore();
             ExcerptItem* ei = getExcerptItem(e);
             if (!getExcerptItem(e) && partScore)      // Delete it because not in the list anymore
@@ -756,7 +756,7 @@ void ExcerptsDialog::accept()
             bool found = false;
 
             // Looks for the excerpt and its position.
-            foreach(Excerpt* e, score->excerpts()) {
+            for (Excerpt* e : score->excerpts()) {
                   if (ei->excerpt() == e) {
                         found = true;
                         break;

--- a/mscore/file.cpp
+++ b/mscore/file.cpp
@@ -801,7 +801,7 @@ MasterScore* MuseScore::getNewFile()
                               if (!dList.empty()) {
                                     Fraction ltick = tick;
                                     int k = 0;
-                                    foreach (TDuration d, dList) {
+                                    for (TDuration d : dList) {
                                           if (k < puRests.count())
                                                 rest = static_cast<Rest*>(puRests[k]->linkedClone());
                                           else {
@@ -839,7 +839,7 @@ MasterScore* MuseScore::getNewFile()
       //
       Measure* m = score->firstMeasure();
       for (Segment* s = m->first(); s; s = s->next()) {
-            if (s->segmentType() == SegmentType::ChordRest) {
+            if (s->isChordRestType()) {
                   if (s->element(0)) {
                         score->select(s->element(0), SelectType::SINGLE, 0);
                         break;
@@ -855,7 +855,7 @@ MasterScore* MuseScore::getNewFile()
 
       if (!title.isEmpty() || !subtitle.isEmpty() || !composer.isEmpty() || !poet.isEmpty()) {
             MeasureBase* measure = score->measures()->first();
-            if (measure->type() != ElementType::VBOX) {
+            if (!measure->isVBox()) {
                   MeasureBase* nm = nvb ? nvb : new VBox(score);
                   nm->setTick(Fraction(0,1));
                   nm->setNext(measure);
@@ -3061,7 +3061,7 @@ bool MuseScore::saveSvg(Score* score, QIODevice* device, int pageNumber, bool dr
       int lastNoteIndex = -1;
       for (int i = 0; i < pageNumber; ++i) {
             for (const Element* element : score->pages()[i]->elements()) {
-                  if (element->type() == ElementType::NOTE) {
+                  if (element->isNote()) {
                         lastNoteIndex++;
                         }
                   }
@@ -3075,7 +3075,7 @@ bool MuseScore::saveSvg(Score* score, QIODevice* device, int pageNumber, bool dr
             // Always exclude invisible elements
             if (!e->visible())
                   continue;
-            if (e->type() == ElementType::STAFF_LINES) {
+            if (e->isStaffLines()) {
                   currentMeasure = e->findMeasure();
                   currentSystem = currentMeasure->system();
 
@@ -3144,7 +3144,7 @@ bool MuseScore::saveSvg(Score* score, QIODevice* device, int pageNumber, bool dr
             printer.setElement(e);
 
             // Paint it
-            if (e->type() == ElementType::NOTE && !notesColors.isEmpty()) {
+            if (e->isNote() && !notesColors.isEmpty()) {
                   QColor color = e->color();
                   int currentNoteIndex = (++lastNoteIndex);
 
@@ -3152,7 +3152,7 @@ bool MuseScore::saveSvg(Score* score, QIODevice* device, int pageNumber, bool dr
                         color = notesColors[currentNoteIndex];
                         }
 
-                  Element *note = dynamic_cast<const Note*>(e)->clone();
+                  Element *note = toNote(e)->clone();
                   note->setColor(color);
                   paintElement(p, note);
                   delete note;

--- a/mscore/fotomode.cpp
+++ b/mscore/fotomode.cpp
@@ -594,7 +594,7 @@ void ScoreView::paintRect(bool printMode, QPainter& p, const QRectF& r, double m
 
       score()->setPrinting(printMode);
 
-      foreach (Page* page, _score->pages()) {
+      for (Page* page : _score->pages()) {
             // QRectF pr(page->abbox());
             QRectF pr(page->canvasBoundingRect());
             if (pr.right() < r.left())

--- a/mscore/harmonyedit.cpp
+++ b/mscore/harmonyedit.cpp
@@ -134,7 +134,7 @@ void ChordStyleEditor::loadChordDescriptionFile(const QString& s)
 void ChordStyleEditor::setChordList(ChordList* cl)
       {
       harmonyList->clear();
-      foreach (const ChordDescription& d, *cl) {
+      for (const ChordDescription& d : *cl) {
             QTreeWidgetItem* item = new QTreeWidgetItem;
             item->setData(0, Qt::UserRole, QVariant::fromValue<void*>((void*)&d));
             item->setText(0, QString("%1").arg(d.id));
@@ -147,7 +147,7 @@ void ChordStyleEditor::setChordList(ChordList* cl)
       canvas->setChordDescription(0, 0);
 
       paletteTab->clear();
-      foreach(const ChordFont& f, chordList->fonts) {
+      for (const ChordFont& f : chordList->fonts) {
             // create symbol palette
             Palette* p = new Palette();
             PaletteScrollArea* accPalette = new PaletteScrollArea(p);
@@ -270,15 +270,15 @@ void HarmonyCanvas::paintEvent(QPaintEvent* event)
       p.drawLine(f.x(), 0.0, f.width(), 0.0);
       p.drawLine(0.0, f.y(), 0.0, f.height());
 
-      foreach(const TextSegment* ts, textList) {
+      for (const TextSegment* ts: textList) {
             p.setFont(ts->font);
             QPen pen(ts->select ? Qt::blue : palette().color(QPalette::Text));
             p.setPen(pen);
             p.drawText(ts->x, ts->y, ts->text);
             }
 
-      if (dragElement && dragElement->type() == ElementType::FSYMBOL) {
-            FSymbol* sb = static_cast<FSymbol*>(dragElement);
+      if (dragElement && dragElement->isFSymbol()) {
+            FSymbol* sb = toFSymbol(dragElement);
 
 //TODO:ws             double _spatium = 2.0 * PALETTE_SPATIUM / extraMag;
 //            const TextStyle* st = &gscore->textStyle(TextStyleType::HARMONY);
@@ -315,7 +315,7 @@ void HarmonyCanvas::render(const QList<RenderAction>& /*renderList*/, double& /*
       QList<QFont> fontList;              // temp values used in render()
       const TextStyle* st = &gscore->textStyle(TextStyleType::HARMONY);
 
-      foreach(ChordFont cf, chordList->fonts) {
+      for (ChordFont cf : chordList->fonts) {
             if (cf.family.isEmpty() || cf.family == "default")
                   fontList.append(st->font(_spatium * cf.mag * MScore::pixelRatio));
             else {
@@ -327,7 +327,7 @@ void HarmonyCanvas::render(const QList<RenderAction>& /*renderList*/, double& /*
       if (fontList.isEmpty())
             fontList.append(st->font(_spatium * MScore::pixelRatio));
 
-      foreach(const RenderAction& a, renderList) {
+      for(const RenderAction& a : renderList) {
             if (a.type == RenderAction::RenderActionType::SET) {
                   TextSegment* ts = new TextSegment(fontList[fontIdx], x, y);
                   ChordSymbol cs = chordList->symbol(a.text);
@@ -402,7 +402,7 @@ void HarmonyCanvas::mousePressEvent(QMouseEvent* event)
       {
       startMove = imatrix.map(QPointF(event->pos()));
       moveElement = 0;
-      foreach(TextSegment* ts, textList) {
+      for (TextSegment* ts : textList) {
             QRectF r = ts->boundingRect().translated(ts->x, ts->y);
             ts->select = r.contains(startMove);
             if (ts->select)
@@ -444,7 +444,7 @@ void HarmonyCanvas::setChordDescription(ChordDescription* sd, ChordList* sl)
       chordDescription = sd;
       chordList = sl;
 
-      foreach(TextSegment* s, textList)
+      for (TextSegment* s : textList)
             delete s;
       textList.clear();
 
@@ -471,7 +471,7 @@ void HarmonyCanvas::setChordDescription(ChordDescription* sd, ChordList* sl)
 void HarmonyCanvas::dropEvent(QDropEvent* /*event*/)
       {
 #if 0       // TODO:ws
-      if (dragElement && dragElement->type() == ElementType::FSYMBOL) {
+      if (dragElement && dragElement->isFSymbol()) {
             FSymbol* sb = static_cast<FSymbol*>(dragElement);
 
             double _spatium = 2.0 * PALETTE_SPATIUM / extraMag;
@@ -543,7 +543,7 @@ void HarmonyCanvas::dragLeaveEvent(QDragLeaveEvent*)
 void HarmonyCanvas::dragMoveEvent(QDragMoveEvent* event)
       {
       event->acceptProposedAction();
-      if (dragElement && dragElement->type() == ElementType::FSYMBOL) {
+      if (dragElement && dragElement->isFSymbol()) {
             dragElement->setPos(imatrix.map(event->pos()));
             update();
             }
@@ -567,8 +567,8 @@ void HarmonyCanvas::deleteAction()
 
 static void updateHarmony(void*, Element* e)
       {
-      if (e->type() == ElementType::HARMONY)
-            static_cast<Harmony*>(e)->render();
+      if (e->isHarmony())
+            toHarmony(e)->render();
       }
 
 //---------------------------------------------------------
@@ -598,7 +598,7 @@ void HarmonyCanvas::updateChordDescription()
 
       int idx = 0;
       double x  = 0, y = 0;
-      foreach(const TextSegment* ts, textList) {
+      for (const TextSegment* ts : textList) {
             ++idx;
             if (idx == 1) {     // don’t save base
                   x = ts->x + ts->width();

--- a/mscore/keyedit.cpp
+++ b/mscore/keyedit.cpp
@@ -64,7 +64,7 @@ KeyCanvas::KeyCanvas(QWidget* parent)
 
 void KeyCanvas::deleteElement()
       {
-      foreach(Accidental* a, accidentals) {
+      for (Accidental* a : accidentals) {
             if (a->selected()) {
                   accidentals.removeOne(a);
                   delete a;
@@ -80,7 +80,7 @@ void KeyCanvas::deleteElement()
 
 void KeyCanvas::clear()
       {
-      foreach(Accidental* a, accidentals)
+      for (Accidental* a : accidentals)
             delete a;
       accidentals.clear();
       update();
@@ -126,7 +126,7 @@ void KeyCanvas::paintEvent(QPaintEvent*)
             dragElement->draw(&painter);
             painter.restore();
             }
-      foreach(Accidental* a, accidentals) {
+      for (Accidental* a : accidentals) {
             painter.save();
             painter.translate(a->pagePos());
             a->draw(&painter);
@@ -146,7 +146,7 @@ void KeyCanvas::mousePressEvent(QMouseEvent* event)
       {
       startMove = imatrix.map(QPointF(event->pos() - base));
       moveElement = 0;
-      foreach(Accidental* a, accidentals) {
+      for (Accidental* a : accidentals) {
             QRectF r = a->abbox();
             if (r.contains(startMove)) {
                   a->setSelected(true);
@@ -212,7 +212,7 @@ void KeyCanvas::dragEnterEvent(QDragEnterEvent* event)
       else {
             if (MScore::debugMode) {
                   qDebug("KeyCanvas::dragEnterEvent: formats:");
-                  foreach(const QString& s, event->mimeData()->formats())
+                  for (const QString& s : event->mimeData()->formats())
                         qDebug("   %s", qPrintable(s));
                   }
             }

--- a/mscore/layer.cpp
+++ b/mscore/layer.cpp
@@ -45,7 +45,7 @@ LayerManager::LayerManager(Score* s, QWidget* parent)
 
       layers->setRowCount(score->layer().size());
       int row = 0;
-      foreach(const Layer& l, score->layer()) {
+      for (const Layer& l : score->layer()) {
             QTableWidgetItem* item = new QTableWidgetItem(l.name);
             layers->setItem(row, 0, item);
             QString tagString;
@@ -199,7 +199,7 @@ void LayerManager:: accept()
             l.tags           = 1;
             QString ts       = layers->item(i, 1)->text();
             QStringList tgs  = ts.split(",");
-            foreach (QString tag, tgs) {
+            for (QString tag : tgs) {
                   for (int idx = 0; idx < 32; ++idx) {
                         if (tag == score->layerTags()[idx]) {
                               l.tags |= 1 << idx;

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -6154,7 +6154,7 @@ void MuseScore::endCmd(bool undoRedo)
             if (e && (cs->playNote() || cs->playChord())
                         && entryMethod != NoteEntryMethod::REALTIME_AUTO
                         && entryMethod != NoteEntryMethod::REALTIME_MANUAL) {
-                  if (cs->playChord() && preferences.getBool(PREF_SCORE_CHORD_PLAYONADDNOTE) &&  e->type() == ElementType::NOTE)
+                  if (cs->playChord() && preferences.getBool(PREF_SCORE_CHORD_PLAYONADDNOTE) &&  e->isNote())
                         play(static_cast<Note*>(e)->chord());
                   else
                         play(e);

--- a/mscore/osc.cpp
+++ b/mscore/osc.cpp
@@ -268,8 +268,8 @@ void MuseScore::oscColorNote(QVariantList list)
             Element* e = s->element(i);
             if (e && e->isChordRest()) {
                   ChordRest* cr = static_cast<ChordRest*>(e);
-                  if (cr->type() == ElementType::CHORD) {
-                        Chord* chord = static_cast<Chord*>(cr);
+                  if (cr->isChord()) {
+                        Chord* chord = toChord(cr);
                         for (Note* note : chord->notes()) {
                               if (note->pitch() == pitch) {
                                     cs->startCmd();

--- a/mscore/palette.cpp
+++ b/mscore/palette.cpp
@@ -595,7 +595,7 @@ bool Palette::applyPaletteElement(Element* element, Qt::KeyboardModifiers modifi
             else if (element->isSLine() && !element->isGlissando() && addSingle) {
                   Segment* startSegment = cr1->segment();
                   Segment* endSegment = cr2->segment();
-                  if (element->type() == ElementType::PEDAL && cr2 != cr1)
+                  if (element->isPedal() && cr2 != cr1)
                         endSegment = endSegment->nextCR(cr2->track());
 
                   QByteArray a = element->mimeData(QPointF());
@@ -616,17 +616,17 @@ bool Palette::applyPaletteElement(Element* element, Qt::KeyboardModifiers modifi
                   }
             }
       else if (sel.isRange()) {
-            if (element->type() == ElementType::BAR_LINE
-                || element->type() == ElementType::MARKER
-                || element->type() == ElementType::JUMP
-                || element->type() == ElementType::SPACER
-                || element->type() == ElementType::VBOX
-                || element->type() == ElementType::HBOX
-                || element->type() == ElementType::TBOX
-                || element->type() == ElementType::MEASURE
-                || element->type() == ElementType::BRACKET
-                || element->type() == ElementType::STAFFTYPE_CHANGE
-                || (element->type() == ElementType::ICON
+            if (element->isBarLine()
+                || element->isMarker()
+                || element->isJump()
+                || element->isSpacer()
+                || element->isVBox()
+                || element->isHBox()
+                || element->isTBox()
+                || element->isMeasure()
+                || element->isBracket()
+                || element->isStaffTypeChange()
+                || (element->isIcon()
                     && (toIcon(element)->iconType() == IconType::VFRAME
                         || toIcon(element)->iconType() == IconType::HFRAME
                         || toIcon(element)->iconType() == IconType::TFRAME
@@ -642,8 +642,8 @@ bool Palette::applyPaletteElement(Element* element, Qt::KeyboardModifiers modifi
                               break;
                         }
                   }
-            else if (element->type() == ElementType::LAYOUT_BREAK) {
-                  LayoutBreak* breakElement = static_cast<LayoutBreak*>(element);
+            else if (element->isLayoutBreak()) {
+                  LayoutBreak* breakElement = toLayoutBreak(element);
                   score->cmdToggleLayoutBreak(breakElement->layoutBreakType());
                   }
             else if (element->isClef() || element->isKeySig() || element->isTimeSig()) {
@@ -656,24 +656,24 @@ bool Palette::applyPaletteElement(Element* element, Qt::KeyboardModifiers modifi
                   // for clefs, apply to each staff separately
                   // otherwise just apply to top staff
                   int staffIdx1 = sel.staffStart();
-                  int staffIdx2 = element->type() == ElementType::CLEF ? sel.staffEnd() : staffIdx1 + 1;
+                  int staffIdx2 = element->isClef() ? sel.staffEnd() : staffIdx1 + 1;
                   for (int i = staffIdx1; i < staffIdx2; ++i) {
                         // for clefs, use mid-measure changes if appropriate
                         Element* e1 = nullptr;
                         Element* e2 = nullptr;
                         // use mid-measure clef changes as appropriate
-                        if (element->type() == ElementType::CLEF) {
+                        if (element->isClef()) {
                               if (sel.startSegment()->isChordRestType() && sel.startSegment()->rtick().isNotZero()) {
-                                    ChordRest* cr = static_cast<ChordRest*>(sel.startSegment()->nextChordRest(i * VOICES));
+                                    ChordRest* cr = toChordRest(sel.startSegment()->nextChordRest(i * VOICES));
                                     if (cr && cr->isChord())
-                                          e1 = static_cast<Chord*>(cr)->upNote();
+                                          e1 = toChord(cr)->upNote();
                                     else
                                           e1 = cr;
                                     }
-                              if (sel.endSegment() && sel.endSegment()->segmentType() == SegmentType::ChordRest) {
-                                    ChordRest* cr = static_cast<ChordRest*>(sel.endSegment()->nextChordRest(i * VOICES));
+                              if (sel.endSegment() && sel.endSegment()->isChordRestType()) {
+                                    ChordRest* cr = toChordRest(sel.endSegment()->nextChordRest(i * VOICES));
                                     if (cr && cr->isChord())
-                                          e2 = static_cast<Chord*>(cr)->upNote();
+                                          e2 = toChord(cr)->upNote();
                                     else
                                           e2 = cr;
                                     }
@@ -743,7 +743,7 @@ bool Palette::applyPaletteElement(Element* element, Qt::KeyboardModifiers modifi
             else if (element->isSlur()) {
                   viewer->cmdAddSlur(toSlur(element));
                   }
-            else if (element->isSLine() && element->type() != ElementType::GLISSANDO) {
+            else if (element->isSLine() && !element->isGlissando()) {
                   Segment* startSegment = sel.startSegment();
                   Segment* endSegment = sel.endSegment();
                   bool firstStaffOnly = (element->isVolta() || (element->isTextLine() && toTextLine(element)->systemFlag())) && !(modifiers & Qt::ControlModifier);
@@ -1492,7 +1492,7 @@ bool Palette::read(const QString& p)
       //
       // load images
       //
-      foreach(const QString& s, images)
+      for (const QString& s : images)
             imageStore.add(s, f.fileData(s));
 
       if (rootfile.isEmpty()) {
@@ -1547,7 +1547,7 @@ void Palette::write(const QString& p)
       QSet<ImageStoreItem*> images;
       int n = cells.size();
       for (int i = 0; i < n; ++i) {
-            if (cells[i] == 0 || cells[i]->element == 0 || cells[i]->element->type() != ElementType::IMAGE)
+            if (cells[i] == 0 || cells[i]->element == 0 || !cells[i]->element->isImage())
                   continue;
             images.insert(static_cast<Image*>(cells[i]->element.get())->storeItem());
             }
@@ -1576,7 +1576,7 @@ void Palette::write(const QString& p)
       xml.stag("rootfiles");
       xml.stag(QString("rootfile full-path=\"%1\"").arg(XmlWriter::xmlString("palette.xml")));
       xml.etag();
-      foreach (ImageStoreItem* ip, images) {
+      for (ImageStoreItem* ip : images) {
             QString ipath = QString("Pictures/") + ip->hashName();
             xml.tag("file", ipath);
             }
@@ -1588,7 +1588,7 @@ void Palette::write(const QString& p)
       f.addFile("META-INF/container.xml", cbuf.data());
 
       // save images
-      foreach(ImageStoreItem* ip, images) {
+      for (ImageStoreItem* ip : images) {
             QString ipath = QString("Pictures/") + ip->hashName();
             f.addFile(ipath, ip->buffer());
             }
@@ -1656,8 +1656,8 @@ void Palette::read(XmlReader& e)
                               else {
                                     cell->element->read(e);
                                     cell->element->styleChanged();
-                                    if (cell->element->type() == ElementType::ICON) {
-                                          Icon* icon = static_cast<Icon*>(cell->element.get());
+                                    if (cell->element->isIcon()) {
+                                          Icon* icon = toIcon(cell->element.get());
                                           QAction* ac = getAction(icon->action());
                                           if (ac) {
                                                 QIcon qicon(ac->icon());
@@ -1759,8 +1759,8 @@ void Palette::actionToggled(bool /*val*/)
       int nn = ccp()->size();
       for (int n = 0; n < nn; ++n) {
             const Element* e = cellAt(n)->element.get();
-            if (e && e->type() == ElementType::ICON) {
-                  QAction* a = getAction(static_cast<const Icon*>(e)->action());
+            if (e && e->isIcon()) {
+                  QAction* a = getAction(toIcon(e)->action());
                   if (a->isChecked()) {
                         selectedIdx = n;
                         break;

--- a/mscore/palette/palettetree.cpp
+++ b/mscore/palette/palettetree.cpp
@@ -22,7 +22,6 @@
 #include "globals.h"
 #include "musescore.h"
 #include "palette.h"
-#include "preferences.h"
 #include "shortcut.h"
 
 #include "libmscore/articulation.h"
@@ -285,8 +284,8 @@ bool PaletteCell::read(XmlReader& e)
                   else {
                         element->read(e);
                         element->styleChanged();
-                        if (element->type() == ElementType::ICON) {
-                              Icon* icon = static_cast<Icon*>(element.get());
+                        if (element->isIcon()) {
+                              Icon* icon = toIcon(element.get());
                               QAction* ac = getAction(icon->action());
                               if (ac) {
                                     QIcon qicon(ac->icon());
@@ -495,7 +494,7 @@ bool PalettePanel::writeToFile(const QString& p) const
       QSet<ImageStoreItem*> images;
       size_t n = cells.size();
       for (size_t i = 0; i < n; ++i) {
-            if (cells[i] == 0 || cells[i]->element == 0 || cells[i]->element->type() != ElementType::IMAGE)
+            if (cells[i] == 0 || cells[i]->element == 0 || !cells[i]->element->isImage())
                   continue;
             images.insert(toImage(cells[i]->element.get())->storeItem());
             }
@@ -524,7 +523,7 @@ bool PalettePanel::writeToFile(const QString& p) const
       xml.stag("rootfiles");
       xml.stag(QString("rootfile full-path=\"%1\"").arg(XmlWriter::xmlString("palette.xml")));
       xml.etag();
-      foreach (ImageStoreItem* ip, images) {
+      for (ImageStoreItem* ip : images) {
             QString ipath = QString("Pictures/") + ip->hashName();
             xml.tag("file", ipath);
             }
@@ -536,7 +535,7 @@ bool PalettePanel::writeToFile(const QString& p) const
       f.addFile("META-INF/container.xml", cbuf.data());
 
       // save images
-      foreach(ImageStoreItem* ip, images) {
+      for (ImageStoreItem* ip : images) {
             QString ipath = QString("Pictures/") + ip->hashName();
             f.addFile(ipath, ip->buffer());
             }
@@ -610,7 +609,7 @@ bool PalettePanel::readFromFile(const QString& p)
       //
       // load images
       //
-      foreach(const QString& s, images)
+      for (const QString& s : images)
             imageStore.add(s, f.fileData(s));
 
       if (rootfile.isEmpty()) {

--- a/mscore/parteditbase.cpp
+++ b/mscore/parteditbase.cpp
@@ -312,7 +312,7 @@ void PartEdit::soloToggled(bool val, bool syncControls)
                         }
                   }
             if (!found){
-                  foreach(Part* p, part->score()->parts()) {
+                  for (Part* p : part->score()->parts()) {
                         const InstrumentList* il = p->instruments();
                         for (auto i = il->begin(); i != il->end(); ++i) {
                               const Instrument* instr = i->second;
@@ -537,7 +537,7 @@ void PartEdit::midiChannelChanged(int)
             }
       else {
             // Initializing an instrument with new channel
-            foreach(const MidiCoreEvent& e, channel->initList()) {
+            for (const MidiCoreEvent& e : channel->initList()) {
                   if (e.type() == ME_INVALID)
                         continue;
                   NPlayEvent event(e.type(), channel->channel(), e.dataA(), e.dataB());

--- a/mscore/pianoroll/pianoview.cpp
+++ b/mscore/pianoroll/pianoview.cpp
@@ -1944,7 +1944,7 @@ void PianoView::setStaff(Staff* s, Pos* l)
       QRectF boundingRectSel;
       bool brsInit = false;
 
-      foreach (PianoItem* item, _noteList) {
+      for (PianoItem*& item : _noteList) {
             if (!brInit) {
                   boundingRect = item->boundingRect();
                   brInit = true;

--- a/mscore/plugin/api/cursor.cpp
+++ b/mscore/plugin/api/cursor.cpp
@@ -164,7 +164,7 @@ void Cursor::rewindToTick(int tick)
       // better to search not precisely if possible
       Ms::Fraction fTick = Ms::Fraction::fromTicks(tick + 1);
       Ms::Segment* seg = _score->tick2leftSegment(fTick);
-      if (!(seg->segmentType() & _filter)) {
+      if (!seg->isType(_filter)) {
             // we need another segment type, search by known tick
             seg = _score->tick2segment(seg->tick(), /* first */ true, _filter);
             }
@@ -255,12 +255,12 @@ void Cursor::add(Element* wrapped)
 
       if (s->isChordRest())
             s->score()->undoAddCR(toChordRest(s), _segment->measure(), _segment->tick());
-      else if (s->type() == ElementType::KEYSIG) {
+      else if (s->isKeySig()) {
             Ms::Segment* ns = _segment->measure()->undoGetSegment(SegmentType::KeySig, _segment->tick());
             s->setParent(ns);
             _score->undoAddElement(s);
             }
-      else if (s->type() == ElementType::TIMESIG) {
+      else if (s->isTimeSig()) {
             Ms::Measure* m = _segment->measure();
             Fraction tick = m->tick();
             _score->cmdAddTimeSig(m, _track, toTimeSig(s), false);

--- a/mscore/plugin/api/elements.cpp
+++ b/mscore/plugin/api/elements.cpp
@@ -268,7 +268,7 @@ void Chord::remove(Ms::PluginAPI::Element* wrapped)
             qWarning("PluginAPI::Chord::remove: Unable to retrieve element. %s", qPrintable(wrapped->name()));
       else if (s->parent() != chord())
             qWarning("PluginAPI::Chord::remove: The element is not a child of this chord. Use removeElement() instead.");
-      else if (chord()->notes().size() <= 1 && s->type() == ElementType::NOTE)
+      else if (chord()->notes().size() <= 1 && s->isNote())
             qWarning("PluginAPI::Chord::remove: Removal of final note is not allowed.");
       else
             chord()->score()->deleteItem(s); // Create undo op and remove the element.

--- a/mscore/plugin/api/util.cpp
+++ b/mscore/plugin/api/util.cpp
@@ -183,7 +183,7 @@ void ScoreView::paint(QPainter* p)
             }
       page->scanElements(&el, collectElements, false);
 
-      foreach(const Element* e, el) {
+      for (const Element* e : el) {
             QPointF pos(e->pagePos());
             p->translate(pos);
             e->draw(p);

--- a/mscore/plugin/mscorePlugins.cpp
+++ b/mscore/plugin/mscorePlugins.cpp
@@ -38,7 +38,7 @@ void MuseScore::registerPlugin(PluginDescription* plugin)
             return;
       QString baseName = np.completeBaseName();
 
-      foreach(QString s, plugins) {
+      for (QString s : plugins) {
             QFileInfo fi(s);
             if (fi.completeBaseName() == baseName) {
                   if (MScore::debugMode)
@@ -61,7 +61,7 @@ void MuseScore::registerPlugin(PluginDescription* plugin)
       obj = component.create();
       if (obj == 0) {
             qDebug("creating component <%s> failed", qPrintable(_pluginPath));
-            foreach(QQmlError e, component.errors()) {
+            for (QQmlError e : component.errors()) {
                   qDebug("   line %d: %s", e.line(), qPrintable(e.description()));
                   }
             return;
@@ -103,7 +103,7 @@ void MuseScore::unregisterPlugin(PluginDescription* plugin)
       QString baseName = np.completeBaseName();
 
       bool found = false;
-      foreach(QString s, plugins) {
+      for (QString s : plugins) {
             QFileInfo fi(s);
             if (fi.completeBaseName() == baseName) {
                   found = true;
@@ -136,7 +136,7 @@ void MuseScore::createMenuEntry(PluginDescription* plugin)
       QStringList ml;
       QString s;
       bool escape = false;
-      foreach (QChar c, menu) {
+      for (QChar c : menu) {
             if (escape) {
                   escape = false;
                   s += c;
@@ -165,7 +165,7 @@ void MuseScore::createMenuEntry(PluginDescription* plugin)
             QString m  = ml[i];
             bool found = false;
             QList<QObject*> ol = curMenu->children();
-            foreach(QObject* o, ol) {
+            for (QObject* o : ol) {
                   QMenu* cmenu = qobject_cast<QMenu*>(o);
                   if (!cmenu)
                         continue;
@@ -190,7 +190,7 @@ void MuseScore::createMenuEntry(PluginDescription* plugin)
                         if (sl.size() == 2) {
                               QList<QAction*> al = cm->actions();
                               QAction* ba = 0;
-                              foreach(QAction* ia, al) {
+                              for (QAction* ia : al) {
                                     if (ia->text() == sl[0]) {
                                           ba = ia;
                                           break;
@@ -235,7 +235,7 @@ void MuseScore::removeMenuEntry(PluginDescription* plugin)
       QStringList ml;
       QString s;
       bool escape = false;
-      foreach (QChar c, menu) {
+      for (QChar c : menu) {
             if (escape) {
                   escape = false;
                   s += c;
@@ -266,7 +266,7 @@ void MuseScore::removeMenuEntry(PluginDescription* plugin)
       for(int i = 0; i < n-1; ++i) {
             QString m  = ml[i];
             QList<QObject*> ol = curMenu->children();
-            foreach(QObject* o, ol) {
+            for (QObject* o : ol) {
                   QMenu* cmenu = qobject_cast<QMenu*>(o);
                   if (!cmenu)
                         continue;
@@ -299,7 +299,7 @@ int MuseScore::pluginIdxFromPath(QString _pluginPath) {
       QFileInfo np(_pluginPath);
       QString baseName = np.completeBaseName();
       int idx = 0;
-      foreach(QString s, plugins) {
+      for (QString s : plugins) {
             QFileInfo fi(s);
             if (fi.completeBaseName() == baseName)
                   return idx;
@@ -382,7 +382,7 @@ QmlPlugin* pluginFromPath(QmlPluginEngine* engine, QString pluginPath)
       component.loadUrl(QUrl::fromLocalFile(pluginPath));
       QObject* obj = component.create();
       if (!obj ) {
-            foreach(QQmlError e, component.errors())
+            for (QQmlError e : component.errors())
                   qDebug("   line %d: %s", e.line(), qPrintable(e.description()));
             return nullptr;
             }
@@ -517,7 +517,7 @@ bool collectPluginMetaInformation(PluginDescription* d)
       QObject* obj = component.create();
       if (obj == 0) {
             qDebug("creating component <%s> failed", qPrintable(d->path));
-            foreach(QQmlError e, component.errors()) {
+            for (QQmlError e : component.errors()) {
                   qDebug("   line %d: %s", e.line(), qPrintable(e.description()));
                   }
             return false;

--- a/mscore/plugin/pluginManager.cpp
+++ b/mscore/plugin/pluginManager.cpp
@@ -51,7 +51,7 @@ void PluginManager::init()
       //
       qDeleteAll(localShortcuts);
       localShortcuts.clear();
-      foreach(const Shortcut* s, Shortcut::shortcuts())
+      for (const Shortcut* s : Shortcut::shortcuts())
             localShortcuts[s->key()] = new Shortcut(*s);
       shortcutsChanged = false;
       loadList(false);
@@ -124,7 +124,7 @@ void PluginManager::writePluginList()
       XmlWriter xml(0, &f);
       xml.header();
       xml.stag("museScore version=\"" MSC_VERSION "\"");
-      foreach(const PluginDescription& d, _pluginList) {
+      for (const PluginDescription& d : _pluginList) {
             xml.stag("Plugin");
             xml.tag("path", d.path);
             xml.tag("load", d.load);
@@ -157,7 +157,7 @@ static void updatePluginList(QList<QString>& pluginPathList, const QString& plug
             if (fi.isFile()) {
                   if (path.endsWith(".qml")) {
                         bool alreadyInList = false;
-                        foreach (const PluginDescription& p, pluginList) {
+                        for (const PluginDescription& p : pluginList) {
                               if (p.path == path) {
                                     alreadyInList = true;
                                     break;
@@ -258,7 +258,7 @@ void PluginManager::accept()
       {
       if (shortcutsChanged) {
             shortcutsChanged = false;
-            foreach(const Shortcut* s, localShortcuts) {
+            for (const Shortcut* s : localShortcuts) {
                   Shortcut* os = Shortcut::getShortcut(s->key());
                   if (os) {
                         if (!os->compareKeys(*s))

--- a/mscore/propertymenu.cpp
+++ b/mscore/propertymenu.cpp
@@ -61,7 +61,7 @@ namespace Ms {
 
 void ScoreView::genPropertyMenu1(Element* e, QMenu* popup)
       {
-      if ((!e->generated() || e->type() == ElementType::BAR_LINE) && enableExperimental){
+      if ((!e->generated() || e->isBarLine()) && enableExperimental){
             if (e->flag(ElementFlag::HAS_TAG)) {
                   popup->addSeparator();
 
@@ -286,9 +286,9 @@ void ScoreView::elementPropertyAction(const QString& cmd, Element* e)
             }
       else if (cmd == "measure-props") {
             Measure* m = 0;
-            if (e->type() == ElementType::NOTE)
+            if (e->isNote())
                   m = toNote(e)->chord()->segment()->measure();
-            else if (e->type() == ElementType::REST)
+            else if (e->isRest())
                   m = toRest(e)->segment()->measure();
             if (m) {
                   MeasureProperties vp(m);

--- a/mscore/resourceManager.cpp
+++ b/mscore/resourceManager.cpp
@@ -332,7 +332,7 @@ void ResourceManager::downloadLanguage()
             QString destinationDir(zfi.absolutePath());
             QVector<MQZipReader::FileInfo> allFiles = zipFile.fileInfoList();
             bool success = true;
-            foreach (MQZipReader::FileInfo fi, allFiles) {
+            for (MQZipReader::FileInfo fi : allFiles) {
                   const QString absPath = destinationDir + "/" + fi.filePath;
                   if (fi.isFile) {
                         QFile f(absPath);

--- a/mscore/scoreaccessibility.cpp
+++ b/mscore/scoreaccessibility.cpp
@@ -243,11 +243,11 @@ void ScoreAccessibility::currentInfoChanged()
             if (!e) {
                   return;
                   }
-            Element* el = e->isSpannerSegment() ? static_cast<SpannerSegment*>(e)->spanner() : e;
+            Element* el = e->isSpannerSegment() ? toSpannerSegment(e)->spanner() : e;
             QString barsAndBeats = "";
             QString optimizedBarsAndBeats = "";
             if (el->isSpanner()) {
-                  Spanner* s = static_cast<Spanner*>(el);
+                  Spanner* s = toSpanner(el);
                   std::pair<int, float> bar_beat = s->startSegment()->barbeat();
                   barsAndBeats += " " + tr("Start Measure: %1; Start Beat: %2").arg(QString::number(bar_beat.first), QString::number(bar_beat.second));
                   Segment* seg = s->endSegment();
@@ -255,8 +255,7 @@ void ScoreAccessibility::currentInfoChanged()
                         seg = score->lastSegment()->prev1MM(SegmentType::ChordRest);
 
                   if (seg->tick() != score->lastSegment()->prev1MM(SegmentType::ChordRest)->tick() &&
-                      s->type() != ElementType::SLUR                                               &&
-                      s->type() != ElementType::TIE                                                )
+                      !s->isSlur() && !s->isTie())
                         seg = seg->prev1MM(SegmentType::ChordRest);
 
                   bar_beat = seg->barbeat();

--- a/mscore/scoretab.cpp
+++ b/mscore/scoretab.cpp
@@ -528,7 +528,7 @@ void ScoreTab::removeTab(int idx, bool noCurrentChangedSignal)
                   break;
                   }
             }
-      foreach (Excerpt* excerpt, score->excerpts()) {
+      for (Excerpt* excerpt : score->excerpts()) {
             Score* sc = excerpt->partScore();
             for (int i = 0; i < stack->count(); ++i) {
                   QSplitter* vs = static_cast<QSplitter*>(stack->widget(i));

--- a/mscore/selectdialog.cpp
+++ b/mscore/selectdialog.cpp
@@ -130,8 +130,8 @@ void SelectDialog::setPattern(ElementPattern* p)
       p->subtypeValid = sameSubtype->isChecked();
       if (sameSystem->isChecked()) {
             do {
-                  if (e->type() == ElementType::SYSTEM) {
-                        p->system = static_cast<const System*>(e);
+                  if (e->isSystem()) {
+                        p->system = toSystem(e);
                         break;
                         }
                   e = e->parent();

--- a/mscore/seq.cpp
+++ b/mscore/seq.cpp
@@ -458,7 +458,7 @@ void MuseScore::seqStopped()
 
 void Seq::unmarkNotes()
       {
-      foreach(const Note* n, markedNotes) {
+      for (const Note* n : markedNotes) {
             n->setMark(false);
             cs->addRefresh(n->canvasBoundingRect());
             }

--- a/mscore/stafftextproperties.cpp
+++ b/mscore/stafftextproperties.cpp
@@ -36,7 +36,7 @@ namespace Ms {
 static void initChannelCombo(QComboBox* cb, StaffTextBase* st)
       {
       Part* part = st->staff()->part();
-      Fraction tick = static_cast<Segment*>(st->parent())->tick();
+      Fraction tick = toSegment(st->parent())->tick();
       for (const Channel* a : part->instrument(tick)->channel()) {
             QString name = a->name();
             if (a->name().isEmpty())
@@ -70,7 +70,7 @@ StaffTextProperties::StaffTextProperties(const StaffTextBase* st, QWidget* paren
             //if (!enableExperimental) tabWidget->removeTab(tabWidget->indexOf(tabMIDIAction));
             }
       setWindowFlags(this->windowFlags() & ~Qt::WindowContextHelpButtonHint);
-      _staffText = static_cast<StaffTextBase*>(st->clone());
+      _staffText = toStaffTextBase(st->clone());
 
       vb[0][0] = voice1_1;
       vb[0][1] = voice1_2;
@@ -105,7 +105,7 @@ StaffTextProperties::StaffTextProperties(const StaffTextBase* st, QWidget* paren
             initChannelCombo(channelCombo[i], _staffText);
 
       Part* part = _staffText->staff()->part();
-      Fraction tick = static_cast<Segment*>(st->parent())->tick();
+      Fraction tick = toSegment(st->parent())->tick();
       int n = part->instrument(tick)->channel().size();
       int rows = 0;
       for (int voice = 0; voice < VOICES; ++voice) {
@@ -382,7 +382,7 @@ void StaffTextProperties::channelItemChanged(QTreeWidgetItem* item, QTreeWidgetI
       Part* part = _staffText->staff()->part();
 
       int channelIdx      = item->data(0, Qt::UserRole).toInt();
-      Fraction tick = static_cast<Segment*>(_staffText->parent())->tick();
+      Fraction tick       = toSegment(_staffText->parent())->tick();
       Channel* channel    = part->instrument(tick)->channel(channelIdx);
       QString channelName = channel->name();
 
@@ -433,8 +433,8 @@ void StaffTextProperties::saveValues()
             _staffText->setChannelName(voice, QString());
             for (int row = 0; row < VOICES; ++row) {
                   if (vb[voice][row]->isChecked()) {
-                        int idx     = channelCombo[row]->currentIndex();
-                        Fraction instrId = static_cast<Segment*>(_staffText->parent())->tick();
+                        int idx = channelCombo[row]->currentIndex();
+                        Fraction instrId = toSegment(_staffText->parent())->tick();
                         _staffText->setChannelName(voice, part->instrument(instrId)->channel(idx)->name());
                         break;
                         }

--- a/mscore/svggenerator.cpp
+++ b/mscore/svggenerator.cpp
@@ -135,7 +135,7 @@ static void translate_dashPattern(QVector<qreal> pattern, const qreal& width, QS
     Q_ASSERT(pattern_string);
 
     // Note that SVG operates in absolute lengths, whereas Qt uses a length/width ratio.
-    foreach (qreal entry, pattern)
+    for (qreal entry : pattern)
         *pattern_string += QString::fromLatin1("%1,").arg(entry * width);
 
     pattern_string->chop(1);
@@ -449,7 +449,7 @@ public:
 //            }
 //        }
 //
-//        foreach(QGradientStop stop, stops) {
+//        for (QGradientStop stop : stops) {
 //            QString color =
 //                QString::fromLatin1("#%1%2%3")
 //                .arg(stop.second.red(), 2, 16, QLatin1Char('0'))

--- a/mscore/symboldialog.cpp
+++ b/mscore/symboldialog.cpp
@@ -108,8 +108,8 @@ void SymbolDialog::systemFlagChanged(int state)
       bool sysFlag = state == Qt::Checked;
       for (int i = 0; i < sp->size(); ++i) {
             Element* e = sp->element(i);
-            if (e && e->type() == ElementType::SYMBOL)
-                  static_cast<Symbol*>(e)->setSystemFlag(sysFlag);
+            if (e && e->isSymbol())
+                  toSymbol(e)->setSystemFlag(sysFlag);
             }
       }
 

--- a/mscore/timedialog.cpp
+++ b/mscore/timedialog.cpp
@@ -191,8 +191,8 @@ int TimeDialog::denominator() const
 
 void TimeDialog::paletteChanged(int idx)
       {
-      TimeSig* e = static_cast<TimeSig*>(sp->element(idx));
-      if (!e || e->type() != ElementType::TIMESIG) {
+      TimeSig* e = toTimeSig(sp->element(idx));
+      if (!e || !e->isTimeSig()) {
             zNominal->setEnabled(false);
             nNominal->setEnabled(false);
             zText->setEnabled(false);

--- a/mtest/libmscore/barline/tst_barline.cpp
+++ b/mtest/libmscore/barline/tst_barline.cpp
@@ -159,7 +159,7 @@ void TestBarline::barline02()
             snprintf(msg, sizeof msg, "No SegEndBarLine in measure %d.", msrNo);
             QVERIFY2(seg != nullptr, msg);
 
-            BarLine* bar = static_cast<BarLine*>(seg->element(0));
+            BarLine* bar = toBarLine(seg->element(0));
             snprintf(msg, sizeof msg, "No barline in measure %d.", msrNo);
             QVERIFY2(bar != nullptr, msg);
 
@@ -237,7 +237,7 @@ void TestBarline::barline04()
       Segment* seg = msr->findSegment(SegmentType::StartRepeatBarLine, msr->tick());
       QVERIFY2(seg != nullptr, "No SegStartRepeatBarLine segment in measure 5.");
 
-      BarLine* bar = static_cast<BarLine*>(seg->element(0));
+      BarLine* bar = toBarLine(seg->element(0));
       QVERIFY2(bar != nullptr, "No start-repeat barline in measure 5.");
 
       bar->undoChangeProperty(Pid::BARLINE_SPAN, 2);
@@ -284,7 +284,7 @@ void TestBarline::barline05()
       // check an end-repeat bar line has been created at the end of this measure and it is generated
       Segment* seg = msr->findSegment(SegmentType::EndBarLine, msr->tick()+msr->ticks());
       QVERIFY2(seg != nullptr, "No SegEndBarLine segment in measure 4.");
-      BarLine* bar = static_cast<BarLine*>(seg->element(0));
+      BarLine* bar = toBarLine(seg->element(0));
       QVERIFY2(bar != nullptr, "No end-repeat barline in measure 4.");
       QVERIFY2(bar->barLineType() == BarLineType::END_REPEAT, "Barline at measure 4 is not END-REPEAT");
       QVERIFY2(bar->generated(), "End-repeat barline in measure 4 is non-generated.");
@@ -294,7 +294,7 @@ void TestBarline::barline05()
       msr = msr->nextMeasure();
       seg = msr->findSegment(SegmentType::StartRepeatBarLine, msr->tick());
       QVERIFY2(seg != nullptr, "No SegStartRepeatBarLine segment in measure 5.");
-      bar = static_cast<BarLine*>(seg->element(0));
+      bar = toBarLine(seg->element(0));
       QVERIFY2(bar != nullptr, "No start-repeat barline in measure 5.");
       QVERIFY2(bar->generated(), "Start-reapeat barline in measure 5 is not generated.");
 
@@ -332,7 +332,7 @@ void TestBarline::barline06()
 
             // check only i-th staff has custom bar line type
             for (int j=0; j < 3; j++) {
-                  BarLine* bar = static_cast<BarLine*>(seg->element(j*VOICES));
+                  BarLine* bar = toBarLine(seg->element(j*VOICES));
                   // if not the i-th staff, bar should be normal and not custom
                   if (j != i) {
                         snprintf(msg, sizeof msg, "barline type NOT NORMAL or CUSTOM TYPE in staff %d of measure %d.", j+1, msrNo);

--- a/mtest/libmscore/copypaste/tst_copypaste.cpp
+++ b/mtest/libmscore/copypaste/tst_copypaste.cpp
@@ -453,6 +453,7 @@ void TestCopyPaste::copypasteSplitNoteOverBarDrumStave()
 
       QVERIFY(saveCompareScore(score, QString("copypasteSplit04.mscx"),
          DIR + "copypasteSplit04-ref.mscx"));
+      delete score;
 }
 
 //---------------------------------------------------------
@@ -537,6 +538,7 @@ void TestCopyPaste::copypastenote(const QString& idx, Fraction scale)
       score->cmdPaste(&mimeData, 0, scale);
       score->endCmd();
       QVERIFY(saveCompareScore(score, "copypasteNote" + idx + ".mscx", DIR + "copypasteNote" + idx + "-ref.mscx"));
+      delete score;
       }
 
 QTEST_MAIN(TestCopyPaste)

--- a/mtest/libmscore/exchangevoices/tst_exchangevoices.cpp
+++ b/mtest/libmscore/exchangevoices/tst_exchangevoices.cpp
@@ -118,8 +118,8 @@ void TestExchangevoices::undoChangeVoice()
       // select bottom note of all voice 1 chords
       for (Segment* s = score->firstSegment(SegmentType::ChordRest); s; s = s->next1()) {
             ChordRest* cr = static_cast<ChordRest*>(s->element(0));
-            if (cr && cr->type() == ElementType::CHORD) {
-                  Ms::Chord* c = static_cast<Ms::Chord*>(cr);
+            if (cr && cr->isChord()) {
+                  Ms::Chord* c = toChord(cr);
                   score->select(c->downNote(), SelectType::ADD);
                   }
             }

--- a/mtest/libmscore/midi/tst_midi.cpp
+++ b/mtest/libmscore/midi/tst_midi.cpp
@@ -174,23 +174,23 @@ bool compareElements(Element* e1, Element* e2)
       {
       if (e1->type() != e2->type())
             return false;
-      if (e1->type() == ElementType::TIMESIG) {
+      if (e1->isTimeSig()) {
             }
-      else if (e1->type() == ElementType::KEYSIG) {
-            KeySig* ks1 = static_cast<KeySig*>(e1);
-            KeySig* ks2 = static_cast<KeySig*>(e2);
+      else if (e1->isKeySig()) {
+            KeySig* ks1 = toKeySig(e1);
+            KeySig* ks2 = toKeySig(e2);
             if (ks1->key() != ks2->key()) {
                   qDebug("      key signature %d  !=  %d", int(ks1->key()), int(ks2->key()));
                   return false;
                   }
             }
-      else if (e1->type() == ElementType::CLEF) {
+      else if (e1->isClef()) {
             }
-      else if (e1->type() == ElementType::REST) {
+      else if (e1->isRest()) {
             }
-      else if (e1->type() == ElementType::CHORD) {
-            Ms::Chord* c1 = static_cast<Ms::Chord*>(e1);
-            Ms::Chord* c2 = static_cast<Ms::Chord*>(e2);
+      else if (e1->isChord()) {
+            Ms::Chord* c1 = toChord(e1);
+            Ms::Chord* c2 = toChord(e2);
             if (c1->ticks() != c2->ticks()) {
                   Fraction f1 = c1->ticks();
                   Fraction f2 = c2->ticks();

--- a/mtest/libmscore/parts/tst_parts.cpp
+++ b/mtest/libmscore/parts/tst_parts.cpp
@@ -614,11 +614,11 @@ MasterScore* TestParts::doRemoveFingering()
 
       Measure* m   = score->firstMeasure();
       Segment* s   = m->first()->next(SegmentType::ChordRest);
-      Ms::Chord* chord = static_cast<Ms::Chord*>(s->element(0));
+      Ms::Chord* chord = toChord(s->element(0));
       Note* note   = chord->upNote();
       Element* fingering = 0;
-      foreach(Element* e, note->el()) {
-            if (e->type() == ElementType::FINGERING) {
+      for (Element* e : note->el()) {
+            if (e->isFingering()) {
                   fingering = e;
                   break;
                   }
@@ -740,8 +740,8 @@ MasterScore* TestParts::doRemoveSymbol()
       Ms::Chord* chord = static_cast<Ms::Chord*>(s->element(0));
       Note* note   = chord->upNote();
       Element* se = 0;
-      foreach(Element* e, note->el()) {
-            if (e->type() == ElementType::SYMBOL) {
+      for (Element* e : note->el()) {
+            if (e->isSymbol()) {
                   se = e;
                   break;
                   }
@@ -863,8 +863,8 @@ MasterScore* TestParts::doRemoveChordline()
       Ms::Chord* chord = static_cast<Ms::Chord*>(s->element(0));
 
       Element* se = 0;
-      foreach(Element* e, chord->el()) {
-            if (e->type() == ElementType::CHORDLINE) {
+      for (Element* e : chord->el()) {
+            if (e->isChordLine()) {
                   se = e;
                   break;
                   }
@@ -983,11 +983,11 @@ MasterScore* TestParts::doRemoveImage()
 
       Measure* m   = score->firstMeasure();
       Segment* s   = m->first()->next(SegChordRest);
-      Ms::Chord* chord = static_cast<Ms::Chord*>(s->element(0));
+      Ms::Chord* chord = toChord(s->element(0));
       Note* note   = chord->upNote();
       Element* fingering = 0;
-      foreach(Element* e, note->el()) {
-            if (e->type() == IMAGE) {
+      for (Element* e : note->el()) {
+            if (e->isImage()) {
                   fingering = e;
                   break;
                   }

--- a/mtest/mtest.cpp
+++ b/mtest/mtest.cpp
@@ -105,7 +105,7 @@ static void process(const QString& cmd)
 static void scanDir(QDir d)
       {
       QFileInfoList l = d.entryInfoList(QDir::NoDotAndDotDot | QDir::Files | QDir::Dirs);
-      foreach(const QFileInfo& fi, l) {
+      for (const QFileInfo& fi : l) {
             if (fi.isDir()) {
                   scanDir(QDir(fi.filePath()));
                   }

--- a/mtest/scripting/tst_scripting.cpp
+++ b/mtest/scripting/tst_scripting.cpp
@@ -72,7 +72,7 @@ QmlPlugin* TestScripting::loadPlugin(QString path)
       component.loadUrl(QUrl::fromLocalFile(path));
       QObject* obj = component.create();
       if (obj == 0) {
-            foreach(QQmlError e, component.errors())
+            for (QQmlError e : component.errors())
                   qDebug("   line %d: %s", e.line(), qPrintable(e.description()));
             return nullptr;
             }
@@ -103,7 +103,7 @@ void TestScripting::plugins01()
       QObject* object = component.create();
       if (object == 0) {
             qDebug("creating component <%s> failed", qPrintable(path));
-            foreach(QQmlError e, component.errors())
+            for (QQmlError e : component.errors())
                   qDebug("   line %d: %s", e.line(), qPrintable(e.description()));
             }
       else {
@@ -128,7 +128,7 @@ void TestScripting::plugins02()
       QObject* object = component.create();
       if (object == 0) {
             qDebug("creating component <%s> failed", qPrintable(path));
-            foreach(QQmlError e, component.errors())
+            for (QQmlError e : component.errors())
                   qDebug("   line %d: %s", e.line(), qPrintable(e.description()));
             }
       else {

--- a/thirdparty/ofqf/qoscserver.cpp
+++ b/thirdparty/ofqf/qoscserver.cpp
@@ -89,7 +89,7 @@ void QOscServer::readyRead()
                   i++; //move one byte more!
         			    if ( ! args.isEmpty() ) {
         				        QList<QVariant> list1;
-        				        foreach( QChar type, args ) {
+                          for ( QChar type : args ) {
         					            while ( i%4 != 0 ) ++i;
         					            //qDebug() << i << "\ttrying to convert to" << type;
         
@@ -131,13 +131,13 @@ void QOscServer::readyRead()
               		replacements[ "*" ] = ".*";
               		replacements[ "?" ] = ".";
               
-              		foreach( QString rep, replacements.keys() )
+                  for ( QString rep : replacements.keys() )
               			path.replace( rep, replacements[ rep ] );
               
               		//qDebug() << " after transformation to OSC-RegExp path is" << path;
               
               		QRegExp exp( path );
-              		foreach( PathObject* obj, paths ) {
+                  for ( PathObject* obj : paths ) {
               		      if ( exp.exactMatch( obj->_path ) )
               				        obj->signalData( arguments );
               		      else if ( QRegExp( obj->_path ).exactMatch( path ) )

--- a/thirdparty/ofqf/qosctypes.cpp
+++ b/thirdparty/ofqf/qosctypes.cpp
@@ -100,7 +100,7 @@ void QOscBase::oscMessageParseArgs( const QVariant& data, QString& argtypes, QBy
 	}
 	if ( data.type() == QVariant::List ) {
 		QList<QVariant> list = data.toList();
-		foreach( QVariant v, list )
+		for ( QVariant& v : list )
 			oscMessageParseArgs( v, argtypes, arguments );
 	}
 }

--- a/thirdparty/qt-google-analytics/ganalytics.cpp
+++ b/thirdparty/qt-google-analytics/ganalytics.cpp
@@ -411,7 +411,7 @@ QString GAnalytics::Private::getSystemInfo()
 QList<QString> GAnalytics::Private::persistMessageQueue()
 {
     QList<QString> dataList;
-    foreach (QueryBuffer buffer, messageQueue)
+    for (QueryBuffer buffer : messageQueue)
     {
         dataList << buffer.postQuery.toString();
         dataList << buffer.time.toString(dateTimeFormat);


### PR DESCRIPTION
Inspired by #31434

* use `isType()` for engraving objects where suited, rather than `type() ==`
* use safe casting methods (`toType`)
* use `isType()` for engraving objects where suited, rather than `segmentType() ==`
* change all `foreach(..., ...)` to `for (... : ...)`