### PR TITLE
New build number format with month and day

### DIFF
--- a/build/ci/tools/make_build_number.sh
+++ b/build/ci/tools/make_build_number.sh
@@ -22,7 +22,8 @@ ARTIFACTS_DIR="build.artifacts"
 
 NUMBER=$1
 if [ -z "$NUMBER" ]; then
-    NUMBER=$(date -u +%y%j%H%M) # less than 2147483647 to fit in Int32 for WiX packaging tool
+    NUMBER="$(date -u +%y%m%d%H%M)"
+    NUMBER="${NUMBER:0:9}" # less than 2147483647 to fit in Int32 for WiX packaging tool
 fi
 
 if [ -z "$NUMBER" ]; then echo "error: not set BUILD_NUMBER"; exit 1; fi


### PR DESCRIPTION
Use month (01..12) and day (01..31) instead of day-of-year (001..366), so we can more easily tell what date a given build was created on.

WiX requires a 32-bit integer, hence the new format requires us to lose the final digit of the minute number (00..59), yielding a format like:

* `YYMMDDhhx` where `x` increments every 10 minutes (range 0..5)

This means we only know the build time to the nearest 10 minutes, but that's OK since CI builds take longer than 10 minutes anyway.

Backport of #31564