### PR TITLE
Fix Shift+click selection between chord symbols and Roman numerals

### DIFF
--- a/libmscore/harmony.h
+++ b/libmscore/harmony.h
@@ -175,6 +175,8 @@ class Harmony final : public TextBase {
       HarmonyType harmonyType() const          { return _harmonyType;  }
       void setHarmonyType(HarmonyType val);
 
+      int subtype() const override { return static_cast<int>(harmonyType()); }
+
       void write(XmlWriter& xml) const override;
       void read(XmlReader&) override;
       QString harmonyName() const;

--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -3793,6 +3793,10 @@ void Score::selectSimilarInRange(Element* e)
                   pattern.subtype = e->subtype();
             pattern.subtypeValid = true;
             }
+      else if (type == ElementType::HARMONY) {
+            pattern.subtype = e->subtype();
+            pattern.subtypeValid = true;
+            }
       pattern.staffStart = selection().staffStart();
       pattern.staffEnd = selection().staffEnd();
       pattern.voice = -1;


### PR DESCRIPTION
Backport of #31547

Resolves: [musescore#31410](https://www.github.com/musescore/MuseScore/issues/31410)