### PR TITLE
Fix #1127: Blank notes in score and keys on Piano keyboard

### DIFF
--- a/mscore/pianotools.cpp
+++ b/mscore/pianotools.cpp
@@ -514,6 +514,7 @@ void HPiano::wheelEvent(QWheelEvent* event)
                   }
             setScale(mag);
             }
+      updateAllKeys();
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
Attempted resolve: #1127 

Not sure since have yet to replicate the behavior, but this may be a start