### PR TITLE
Fix GH#31735: Separate select similar for chord symbols and roman numerals / Fix GH#13485: cresc. and dim. properties popups affect each other

### DIFF
--- a/libmscore/hairpin.h
+++ b/libmscore/hairpin.h
@@ -57,8 +57,9 @@ class HairpinSegment final : public TextLineBaseSegment {
 
       HairpinSegment* clone() const override { return new HairpinSegment(*this);    }
       ElementType type() const override      { return ElementType::HAIRPIN_SEGMENT; }
+      int subtype() const override           { return static_cast<int>(HairpinType()); }
 
-      Hairpin* hairpin() const                       { return (Hairpin*)spanner();          }
+      Hairpin* hairpin() const               { return (Hairpin*)spanner();          }
 
       Element* propertyDelegate(Pid) override;
 

--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -3762,6 +3762,10 @@ void Score::selectSimilar(Element* e, bool sameStaff)
             else
                   pattern.subtype = e->subtype();
             }
+      else if (type == ElementType::HARMONY) {
+            pattern.subtype = e->subtype();
+            pattern.subtypeValid = true;
+            }
       pattern.staffStart = sameStaff ? e->staffIdx() : -1;
       pattern.staffEnd = sameStaff ? e->staffIdx() + 1 : -1;
       pattern.voice = -1;

--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -3766,6 +3766,10 @@ void Score::selectSimilar(Element* e, bool sameStaff)
             else
                   pattern.subtype = e->subtype();
             }
+      else if (type == ElementType::HARMONY) {
+            pattern.subtype = e->subtype();
+            pattern.subtypeValid = true;
+            }
       pattern.staffStart = sameStaff ? e->staffIdx() : -1;
       pattern.staffEnd = sameStaff ? e->staffIdx() + 1 : -1;
       pattern.voice = -1;

--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -3766,7 +3766,7 @@ void Score::selectSimilar(Element* e, bool sameStaff)
             else
                   pattern.subtype = e->subtype();
             }
-      else if (type == ElementType::HARMONY) {
+      else if (e->isHairpinSegment() || type == ElementType::HARMONY) {
             pattern.subtype = e->subtype();
             pattern.subtypeValid = true;
             }
@@ -3801,7 +3801,7 @@ void Score::selectSimilarInRange(Element* e)
                   pattern.subtype = e->subtype();
             pattern.subtypeValid = true;
             }
-      else if (type == ElementType::HARMONY) {
+      else if (e->isHairpinSegment() || type == ElementType::HARMONY) {
             pattern.subtype = e->subtype();
             pattern.subtypeValid = true;
             }


### PR DESCRIPTION
Backports of #31736 and #13578

Resolves: [musescore#31735](https://www.github.com/musescore/MuseScore/issues/31735)
Resolves: [musescore#13485](https://www.github.com/musescore/MuseScore/issues/13485)