### PR TITLE
Comparison Tool: provide custom color for selection

### DIFF
--- a/global/settings/types/preferencekeys.h
+++ b/global/settings/types/preferencekeys.h
@@ -127,6 +127,8 @@
 #define PREF_SCORE_NOTE_INPUT_DISABLE_MOUSE_INPUT           "ui/score/noteEntry/disableMouseEntry"
 #define PREF_SCORE_STYLE_DEFAULTSTYLEFILE                   "score/style/defaultStyleFile"
 #define PREF_SCORE_STYLE_PARTSTYLEFILE                      "score/style/partStyleFile"
+#define PREF_SCORE_COMPARISON_SELECTION_COLOR               "ui/score/selection/comparison/color"
+#define PREF_SCORE_COMPARISON_SELECTION_COLOR_ENABLED       "ui/score/selection/comparison/color/enabled"
 #define PREF_UI_CANVAS_BG_USECOLOR                          "ui/canvas/background/useColor"
 #define PREF_UI_CANVAS_FG_USECOLOR                          "ui/canvas/foreground/useColor"
 #define PREF_UI_CANVAS_FG_USECOLOR_IN_PALETTES              "ui/canvas/foreground/useColorInPalettes"

--- a/libmscore/element.cpp
+++ b/libmscore/element.cpp
@@ -98,6 +98,8 @@
 #include "volta.h"
 #include "xml.h"
 
+#include "mscore/preferences.h"
+
 namespace Ms {
 
 // extern bool showInvisible;
@@ -415,7 +417,9 @@ QColor Element::curColor(bool isVisible, QColor normalColor) const
             }
       if (selected() || marked ) {
             QColor originalColor;
-            if (track() == -1)
+            if (score()->selection().isComparison() && preferences.getBool(PREF_SCORE_COMPARISON_SELECTION_COLOR_ENABLED))
+                  originalColor = preferences.getColor(PREF_SCORE_COMPARISON_SELECTION_COLOR);
+            else if (track() == -1)
                   originalColor = MScore::selectColor[0];
             else
                   originalColor = MScore::selectColor[voice()];

--- a/libmscore/mscore.h
+++ b/libmscore/mscore.h
@@ -141,7 +141,7 @@ enum class TransposeMode : char {
 //---------------------------------------------------------
 
 enum class SelectType : char {
-      SINGLE, RANGE, ADD
+      SINGLE, RANGE, ADD, COMPARISON
       };
 
 //---------------------------------------------------------

--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -3387,6 +3387,10 @@ void Score::select(Element* e, SelectType type, int staffIdx)
             case SelectType::SINGLE:
                   selectSingle(e, staffIdx);
                   break;
+            case SelectType::COMPARISON:
+                  selectSingle(e, staffIdx);
+                  _selection.setState(SelState::COMPARISON);
+                  break;
             case SelectType::ADD:
                   selectAdd(e);
                   break;

--- a/libmscore/select.h
+++ b/libmscore/select.h
@@ -71,6 +71,7 @@ enum class SelState : char {
       LIST,   // disjoint selection
       RANGE,  // adjacent selection, a range in one or more staves
                   // is selected
+      COMPARISON,
       };
 
 //---------------------------------------------------------
@@ -175,6 +176,7 @@ class Selection {
       bool isNone() const              { return _state == SelState::NONE; }
       bool isRange() const             { return _state == SelState::RANGE; }
       bool isList() const              { return _state == SelState::LIST; }
+      bool isComparison() const        { return _state == SelState::COMPARISON; }
       void setState(SelState s);
 
       //! NOTE If locked, the selected items should not be changed.

--- a/mscore/preferences.cpp
+++ b/mscore/preferences.cpp
@@ -273,6 +273,8 @@ void Preferences::init(bool storeInMemoryOnly)
             {PREF_UI_SCORE_VOICE3_COLOR,                           new ColorPreference(QColor(0xC53F00))},
             {PREF_UI_SCORE_VOICE4_COLOR,                           new ColorPreference(QColor(0xC31989))},
             {PREF_UI_SCORE_CURSOR_COLOR,                           new ColorPreference(QColor(0x0065BF))},
+            {PREF_SCORE_COMPARISON_SELECTION_COLOR,                new ColorPreference(QColor(Qt::green))},
+            {PREF_SCORE_COMPARISON_SELECTION_COLOR_ENABLED,        new BoolPreference(false)},
             {PREF_UI_THEME_ICONWIDTH,                              new IntPreference(28, false)},
             {PREF_UI_THEME_ICONHEIGHT,                             new IntPreference(24, false)},
             {PREF_UI_THEME_FONTFAMILY,                             new StringPreference(QApplication::font().family(), false) },

--- a/mscore/scorecmp/scorecmp.cpp
+++ b/mscore/scorecmp/scorecmp.cpp
@@ -22,6 +22,8 @@
 
 #include "libmscore/scorediff.h"
 
+#include "preferences.h"
+
 namespace Ms {
 
 //---------------------------------------------------------
@@ -35,6 +37,11 @@ ScoreComparisonTool::ScoreComparisonTool(QWidget* parent)
       _mode = Mode::INTELLIGENT;
       _ui->intelligentModeRadioButton->setChecked(true);
       _ui->diffWidget->setCurrentWidget(_ui->pageIntelligentDiff);
+
+      const QColor selectionColor = _ui->colorEnable->isChecked() ? preferences.getColor(PREF_SCORE_COMPARISON_SELECTION_COLOR) : MScore::selectColor[0];
+      _ui->colorButton->setStyleSheet("background-color:" + selectionColor.name());
+      _ui->colorEnable->setChecked(preferences.getBool(PREF_SCORE_COMPARISON_SELECTION_COLOR_ENABLED));
+
       connect(
          _ui->score1ComboBox, QOverload<int>::of(&QComboBox::currentIndexChanged),
          this, &ScoreComparisonTool::selectedVersionsChanged);
@@ -464,7 +471,7 @@ void ScoreComparisonTool::showElement(const ScoreElement* se, bool select)
             if (el->isChordRest())
                   score->select(el, SelectType::RANGE);
             else
-                  score->select(el);
+                  score->select(el, SelectType::COMPARISON);
             }
 
       if (score1 == score) {
@@ -516,4 +523,33 @@ void ScoreComparisonTool::slotWindowSplit(bool split)
                );
             }
       }
+
+//---------------------------------------------------------
+//   on_colorEnable_stateChanged
+//    update color selector when enabled/disabled
+//---------------------------------------------------------
+
+void ScoreComparisonTool::on_colorEnable_stateChanged(int state)
+      {
+      const bool checked = (state == Qt::Checked);
+      preferences.setPreference(PREF_SCORE_COMPARISON_SELECTION_COLOR_ENABLED, checked);
+      const QColor color = checked ? preferences.getColor(PREF_SCORE_COMPARISON_SELECTION_COLOR) : MScore::selectColor[0];
+      _ui->colorButton->setStyleSheet("background-color:" + color.name());
+      }
+
+//---------------------------------------------------------
+//   on_colorButton_clicked
+//    Select special color for comparison selection
+//---------------------------------------------------------
+
+void ScoreComparisonTool::on_colorButton_clicked()
+      {
+      const QColor curColor = preferences.getColor(PREF_SCORE_COMPARISON_SELECTION_COLOR);
+      const QColor newColor = QColorDialog::getColor(curColor, this);
+      if (newColor.isValid()) {
+            preferences.setPreference(PREF_SCORE_COMPARISON_SELECTION_COLOR, newColor);
+            _ui->colorButton->setStyleSheet("background-color:" + newColor.name());
+            }
+      }
+
 }

--- a/mscore/scorecmp/scorecmp.h
+++ b/mscore/scorecmp/scorecmp.h
@@ -66,6 +66,8 @@ class ScoreComparisonTool : public QDockWidget {
       void on_intelligentModeRadioButton_toggled(bool);
       void on_intelligentDiffView_activated(const QModelIndex&);
       void selectedVersionsChanged();
+      void on_colorEnable_stateChanged(int);
+      void on_colorButton_clicked();
 
    protected:
       void changeEvent(QEvent* e) override;

--- a/mscore/scorecmp/scorecmp_tool.ui
+++ b/mscore/scorecmp/scorecmp_tool.ui
@@ -142,6 +142,30 @@
          </property>
         </widget>
        </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QCheckBox" name="colorEnable">
+           <property name="text">
+            <string>Specify:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="colorButton">
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
       </layout>
      </widget>
     </item>


### PR DESCRIPTION
Resolves: #1147

Testing appreciated

<img width="869" height="534" alt="image" src="https://github.com/user-attachments/assets/79e63080-278d-45e0-9212-f7052a96f35f" />

If specify is unchecked, then default behavior occurs and the color button will show voice-1 color. 
Enabled, it will show the user-specified color, and that color + enabled state will be saved between MS3.7 sessions.

Doesn't apply to range-selections: I couldn't actuate a range selection from the comparison tool, so it's apparently not relevant here.