### PR TITLE
Misc. XML fixes

### DIFF
--- a/importexport/musicxml/importmxmlpass1.cpp
+++ b/importexport/musicxml/importmxmlpass1.cpp
@@ -1784,7 +1784,7 @@ void MusicXMLParserPass1::defaults()
             else if (/*isImportLayout && */_e.name() == "staff-layout") {
                   while (_e.readNextStartElement()) {
                         if (_e.name() == "staff-distance") {
-                              Spatium val(_e.readElementText().toDouble() / 10.0);
+                              const Spatium val(_e.readElementText().toDouble() / 10.0);
                               if (isImportLayout)
                                     _score->style().set(Sid::staffDistance, val);
                               }

--- a/importexport/musicxml/importmxmlpass1.cpp
+++ b/importexport/musicxml/importmxmlpass1.cpp
@@ -1782,7 +1782,7 @@ void MusicXMLParserPass1::defaults()
             else if (/*isImportLayout && */_e.name() == "staff-layout") {
                   while (_e.readNextStartElement()) {
                         if (_e.name() == "staff-distance") {
-                              Spatium val(_e.readElementText().toDouble() / 10.0);
+                              const Spatium val(_e.readElementText().toDouble() / 10.0);
                               if (isImportLayout)
                                     _score->style().set(Sid::staffDistance, val);
                               }

--- a/importexport/musicxml/importmxmlpass2.cpp
+++ b/importexport/musicxml/importmxmlpass2.cpp
@@ -3051,7 +3051,7 @@ void MusicXMLParserPass2::measureLayout(Measure* measure)
       while (_e.readNextStartElement()) {
             if (_e.name() == "measure-distance") {
                   const Spatium val(_e.readElementText().toDouble() / 10.0);
-                  if (!measure->prev()->isHBox()) {
+                  if (!measure->prev() || !measure->prev()->isHBox()) {
                         _score->insertMeasure(ElementType::HBOX, measure);
                         toHBox(measure)->setBoxWidth(val);
                         }

--- a/importexport/musicxml/importmxmlpass2.cpp
+++ b/importexport/musicxml/importmxmlpass2.cpp
@@ -4606,6 +4606,11 @@ void MusicXMLParserDirection::handleRepeats(Measure* measure, const int track, c
                         measure = measure->prevMeasure();
                   else if (tb->tid() == Tid::REPEAT_LEFT && !closerToLeft && measure->nextMeasure())
                         measure = measure->nextMeasure();
+                  // Temporary solution to indent codas - add a horizontal frame at start of system or midway through
+                  if (tb->isMarker() && toMarker(tb)->markerType() == Marker::Type::CODA) {
+                        _score->insertMeasure(ElementType::HBOX, measure);
+                        toHBox(measure->prev())->setBoxWidth(Spatium(10));
+                        }
                   tb->setVisible(_visible);
                   measure->add(tb);
                   }

--- a/importexport/musicxml/importmxmlpass2.cpp
+++ b/importexport/musicxml/importmxmlpass2.cpp
@@ -4607,7 +4607,9 @@ void MusicXMLParserDirection::handleRepeats(Measure* measure, const int track, c
                   else if (tb->tid() == Tid::REPEAT_LEFT && !closerToLeft && measure->nextMeasure())
                         measure = measure->nextMeasure();
                   // Temporary solution to indent codas - add a horizontal frame at start of system or midway through
-                  if (tb->isMarker() && toMarker(tb)->markerType() == Marker::Type::CODA) {
+                  const MeasureBase* prevMeasureBase = measure->prev();
+                  const bool hbox = prevMeasureBase && prevMeasureBase->isHBox();
+                  if (tb->isMarker() && toMarker(tb)->markerType() == Marker::Type::CODA && !hbox) {
                         _score->insertMeasure(ElementType::HBOX, measure);
                         toHBox(measure->prev())->setBoxWidth(Spatium(10));
                         }

--- a/importexport/musicxml/importmxmlpass2.cpp
+++ b/importexport/musicxml/importmxmlpass2.cpp
@@ -2929,8 +2929,25 @@ void MusicXMLParserPass2::measure(const QString& partId,
                   }
             else if (_e.name() == "barline")
                   barline(partId, measure, time + mTime);
-            else if (_e.name() == "print")
-                  _e.skipCurrentElement();
+            else if (_e.name() == "print") {
+                  if (_score->parts()[0] == _pass1.getPart(partId)) {
+                        // only process for first part
+                        while (_e.readNextStartElement()) {
+                              if (_e.name() == "page-layout")
+                                    _e.skipCurrentElement();            // skip but don't log
+                              else if (_e.name() == "system-layout")
+                                    _e.skipCurrentElement();            // skip but don't log
+                              else if (_e.name() == "staff-layout")
+                                    _e.skipCurrentElement();            // skip but don't log
+                              else if (_e.name() == "measure-layout")
+                                    measureLayout(measure);
+                              else
+                                    skipLogCurrElem();
+                              }
+                        }
+                  else
+                        _e.skipCurrentElement();
+                  }
             else
                   skipLogCurrElem();
 
@@ -3023,6 +3040,25 @@ void MusicXMLParserPass2::measure(const QString& partId,
             }
 
       addError(checkAtEndElement(_e, "measure"));
+      }
+
+//---------------------------------------------------------
+//   measureLayout
+//---------------------------------------------------------
+
+void MusicXMLParserPass2::measureLayout(Measure* measure)
+      {
+      while (_e.readNextStartElement()) {
+            if (_e.name() == "measure-distance") {
+                  const Spatium val(_e.readElementText().toDouble() / 10.0);
+                  if (!measure->prev()->isHBox()) {
+                        _score->insertMeasure(ElementType::HBOX, measure);
+                        toHBox(measure)->setBoxWidth(val);
+                        }
+                  else
+                        skipLogCurrElem();
+                  }
+            }
       }
 
 //---------------------------------------------------------

--- a/importexport/musicxml/importmxmlpass2.cpp
+++ b/importexport/musicxml/importmxmlpass2.cpp
@@ -2932,8 +2932,25 @@ void MusicXMLParserPass2::measure(const QString& partId,
                   }
             else if (_e.name() == "barline")
                   barline(partId, measure, time + mTime);
-            else if (_e.name() == "print")
-                  _e.skipCurrentElement();
+            else if (_e.name() == "print") {
+                  if (_score->parts()[0] == _pass1.getPart(partId)) {
+                        // only process for first part
+                        while (_e.readNextStartElement()) {
+                              if (_e.name() == "page-layout")
+                                    _e.skipCurrentElement();            // skip but don't log
+                              else if (_e.name() == "system-layout")
+                                    _e.skipCurrentElement();            // skip but don't log
+                              else if (_e.name() == "staff-layout")
+                                    _e.skipCurrentElement();            // skip but don't log
+                              else if (_e.name() == "measure-layout")
+                                    measureLayout(measure);
+                              else
+                                    skipLogCurrElem();
+                              }
+                        }
+                  else
+                        _e.skipCurrentElement();
+                  }
             else
                   skipLogCurrElem();
 
@@ -3026,6 +3043,25 @@ void MusicXMLParserPass2::measure(const QString& partId,
             }
 
       addError(checkAtEndElement(_e, "measure"));
+      }
+
+//---------------------------------------------------------
+//   measureLayout
+//---------------------------------------------------------
+
+void MusicXMLParserPass2::measureLayout(Measure* measure)
+      {
+      while (_e.readNextStartElement()) {
+            if (_e.name() == "measure-distance") {
+                  const Spatium val(_e.readElementText().toDouble() / 10.0);
+                  if (!measure->prev()->isHBox()) {
+                        _score->insertMeasure(ElementType::HBOX, measure);
+                        toHBox(measure)->setBoxWidth(val);
+                        }
+                  else
+                        skipLogCurrElem();
+                  }
+            }
       }
 
 //---------------------------------------------------------

--- a/importexport/musicxml/importmxmlpass2.cpp
+++ b/importexport/musicxml/importmxmlpass2.cpp
@@ -4610,7 +4610,9 @@ void MusicXMLParserDirection::handleRepeats(Measure* measure, const int track, c
                   else if (tb->tid() == Tid::REPEAT_LEFT && !closerToLeft && measure->nextMeasure())
                         measure = measure->nextMeasure();
                   // Temporary solution to indent codas - add a horizontal frame at start of system or midway through
-                  if (tb->isMarker() && toMarker(tb)->markerType() == Marker::Type::CODA) {
+                  const MeasureBase* prevMeasureBase = measure->prev();
+                  const bool hbox = prevMeasureBase && prevMeasureBase->isHBox();
+                  if (tb->isMarker() && toMarker(tb)->markerType() == Marker::Type::CODA && !hbox) {
                         _score->insertMeasure(ElementType::HBOX, measure);
                         toHBox(measure->prev())->setBoxWidth(Spatium(10));
                         }

--- a/importexport/musicxml/importmxmlpass2.cpp
+++ b/importexport/musicxml/importmxmlpass2.cpp
@@ -3054,7 +3054,7 @@ void MusicXMLParserPass2::measureLayout(Measure* measure)
       while (_e.readNextStartElement()) {
             if (_e.name() == "measure-distance") {
                   const Spatium val(_e.readElementText().toDouble() / 10.0);
-                  if (!measure->prev()->isHBox()) {
+                  if (!measure->prev() || !measure->prev()->isHBox()) {
                         _score->insertMeasure(ElementType::HBOX, measure);
                         toHBox(measure)->setBoxWidth(val);
                         }

--- a/importexport/musicxml/importmxmlpass2.cpp
+++ b/importexport/musicxml/importmxmlpass2.cpp
@@ -4609,6 +4609,11 @@ void MusicXMLParserDirection::handleRepeats(Measure* measure, const int track, c
                         measure = measure->prevMeasure();
                   else if (tb->tid() == Tid::REPEAT_LEFT && !closerToLeft && measure->nextMeasure())
                         measure = measure->nextMeasure();
+                  // Temporary solution to indent codas - add a horizontal frame at start of system or midway through
+                  if (tb->isMarker() && toMarker(tb)->markerType() == Marker::Type::CODA) {
+                        _score->insertMeasure(ElementType::HBOX, measure);
+                        toHBox(measure->prev())->setBoxWidth(Spatium(10));
+                        }
                   tb->setVisible(_visible);
                   measure->add(tb);
                   }

--- a/importexport/musicxml/importmxmlpass2.h
+++ b/importexport/musicxml/importmxmlpass2.h
@@ -321,6 +321,7 @@ private:
       void measChordNote( /*, const MxmlPhase2Note note, ChordRest& currChord */);
       void measChordFlush( /*, ChordRest& currChord */);
       void measure(const QString& partId, const Fraction time);
+      void measureLayout(Measure* measure);
       void attributes(const QString& partId, Measure* measure, const Fraction& tick);
       void measureStyle(Measure* measure);
       void barline(const QString& partId, Measure* measure, const Fraction& tick);

--- a/mtest/musicxml/io/testBackupRoundingError_ref.mscx
+++ b/mtest/musicxml/io/testBackupRoundingError_ref.mscx
@@ -112,6 +112,9 @@
           <text>MuseScore testfile</text>
           </Text>
         </VBox>
+      <HBox>
+        <width>7</width>
+        </HBox>
       <Measure>
         <voice>
           <Clef>
@@ -207,7 +210,7 @@
             </Chord>
           <Beam>
             <StemDirection>up</StemDirection>
-            <l1>-12</l1>
+            <l1>-14</l1>
             <l2>-19</l2>
             </Beam>
           <Chord>

--- a/mtest/musicxml/io/testBreaksSystem_no_ref.xml
+++ b/mtest/musicxml/io/testBreaksSystem_no_ref.xml
@@ -71,6 +71,16 @@
         </note>
       </measure>
     <measure number="2">
+      <print>
+        <measure-layout>
+          <measure-distance>50</measure-distance>
+          </measure-layout>
+        </print>
+      <print>
+        <measure-layout>
+          <measure-distance>50</measure-distance>
+          </measure-layout>
+        </print>
       <direction placement="above" system="only-top">
         <direction-type>
           <words>After system break in horizontal frame</words>
@@ -98,6 +108,11 @@
         </note>
       </measure>
     <measure number="2">
+      <print>
+        <measure-layout>
+          <measure-distance>50</measure-distance>
+          </measure-layout>
+        </print>
       <direction placement="above" system="only-top">
         <direction-type>
           <words>After page break in horizontal frame</words>
@@ -139,6 +154,11 @@
         </note>
       </measure>
     <measure number="5">
+      <print>
+        <measure-layout>
+          <measure-distance>50</measure-distance>
+          </measure-layout>
+        </print>
       <direction placement="above" system="only-top">
         <direction-type>
           <words>After system break in hframe</words>

--- a/mtest/musicxml/io/testBuzzRoll_ref.mscx
+++ b/mtest/musicxml/io/testBuzzRoll_ref.mscx
@@ -121,6 +121,9 @@
           <text>James M</text>
           </Text>
         </VBox>
+      <HBox>
+        <width>5</width>
+        </HBox>
       <Measure>
         <voice>
           <Clef>

--- a/mtest/musicxml/io/testChordSymbols2_ref.mscx
+++ b/mtest/musicxml/io/testChordSymbols2_ref.mscx
@@ -120,6 +120,9 @@
           <text>James M</text>
           </Text>
         </VBox>
+      <HBox>
+        <width>5</width>
+        </HBox>
       <Measure>
         <voice>
           <Clef>

--- a/mtest/musicxml/io/testCodaHBox.xml
+++ b/mtest/musicxml/io/testCodaHBox.xml
@@ -1,0 +1,361 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 4.0 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="4.0">
+  <work>
+    <work-title>Untitled score</work-title>
+    </work>
+  <identification>
+    <creator type="composer">Composer / arranger</creator>
+    <encoding>
+      <software>MuseScore 4.4.0</software>
+      <encoding-date>2024-02-20</encoding-date>
+      <supports element="accidental" type="yes"/>
+      <supports element="beam" type="yes"/>
+      <supports element="print" attribute="new-page" type="yes" value="yes"/>
+      <supports element="print" attribute="new-system" type="yes" value="yes"/>
+      <supports element="stem" type="yes"/>
+      </encoding>
+    </identification>
+  <defaults>
+    <scaling>
+      <millimeters>7</millimeters>
+      <tenths>40</tenths>
+      </scaling>
+    <page-layout>
+      <page-height>1696.94</page-height>
+      <page-width>1200.48</page-width>
+      <page-margins type="even">
+        <left-margin>85.7252</left-margin>
+        <right-margin>85.7252</right-margin>
+        <top-margin>85.7252</top-margin>
+        <bottom-margin>85.7252</bottom-margin>
+        </page-margins>
+      <page-margins type="odd">
+        <left-margin>85.7252</left-margin>
+        <right-margin>85.7252</right-margin>
+        <top-margin>85.7252</top-margin>
+        <bottom-margin>85.7252</bottom-margin>
+        </page-margins>
+      </page-layout>
+    <appearance>
+      <line-width type="light barline">1.8</line-width>
+      <line-width type="heavy barline">5.5</line-width>
+      <line-width type="beam">5</line-width>
+      <line-width type="bracket">4.5</line-width>
+      <line-width type="dashes">1</line-width>
+      <line-width type="enclosure">1</line-width>
+      <line-width type="ending">1.1</line-width>
+      <line-width type="extend">1</line-width>
+      <line-width type="leger">1.6</line-width>
+      <line-width type="pedal">1.1</line-width>
+      <line-width type="octave shift">1.1</line-width>
+      <line-width type="slur middle">2.1</line-width>
+      <line-width type="slur tip">0.5</line-width>
+      <line-width type="staff">1.1</line-width>
+      <line-width type="stem">1</line-width>
+      <line-width type="tie middle">2.1</line-width>
+      <line-width type="tie tip">0.5</line-width>
+      <line-width type="tuplet bracket">1</line-width>
+      <line-width type="wedge">1.2</line-width>
+      <note-size type="cue">70</note-size>
+      <note-size type="grace">70</note-size>
+      <note-size type="grace-cue">49</note-size>
+      </appearance>
+    <music-font font-family="Leland"/>
+    <word-font font-family="Edwin" font-size="10"/>
+    <lyric-font font-family="Edwin" font-size="10"/>
+    </defaults>
+  <part-list>
+    <score-part id="P1">
+      <part-name>Piano</part-name>
+      <part-abbreviation>Pno.</part-abbreviation>
+      <score-instrument id="P1-I1">
+        <instrument-name>Piano</instrument-name>
+        <instrument-sound>keyboard.piano</instrument-sound>
+        </score-instrument>
+      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-instrument id="P1-I1">
+        <midi-channel>1</midi-channel>
+        <midi-program>1</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    </part-list>
+  <part id="P1">
+    <measure number="1" width="297.24">
+      <print>
+        <system-layout>
+          <system-margins>
+            <left-margin>50</left-margin>
+            <right-margin>-0</right-margin>
+            </system-margins>
+          <top-system-distance>70</top-system-distance>
+          </system-layout>
+        <staff-layout number="2">
+          <staff-distance>65</staff-distance>
+          </staff-layout>
+        </print>
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>0</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <staves>2</staves>
+        <clef number="1">
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        <clef number="2">
+          <sign>F</sign>
+          <line>4</line>
+          </clef>
+        </attributes>
+      <note default-x="172.71" default-y="-10">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        <staff>1</staff>
+        </note>
+      <backup>
+        <duration>4</duration>
+        </backup>
+      <note default-x="172.71" default-y="-115">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>5</voice>
+        <staff>2</staff>
+        </note>
+      </measure>
+    <measure number="2" width="227.26">
+      <note default-x="106.23" default-y="-10">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        <staff>1</staff>
+        </note>
+      <backup>
+        <duration>4</duration>
+        </backup>
+      <note default-x="106.23" default-y="-115">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>5</voice>
+        <staff>2</staff>
+        </note>
+      </measure>
+    <measure number="3" width="227.26">
+      <note default-x="106.23" default-y="-10">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        <staff>1</staff>
+        </note>
+      <backup>
+        <duration>4</duration>
+        </backup>
+      <note default-x="106.23" default-y="-115">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>5</voice>
+        <staff>2</staff>
+        </note>
+      </measure>
+    <measure number="4" width="227.26">
+      <note default-x="106.23" default-y="-10">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        <staff>1</staff>
+        </note>
+      <backup>
+        <duration>4</duration>
+        </backup>
+      <note default-x="106.23" default-y="-115">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>5</voice>
+        <staff>2</staff>
+        </note>
+      </measure>
+    <measure number="5" width="293.15">
+      <print new-system="yes">
+        <system-layout>
+          <system-margins>
+            <left-margin>0</left-margin>
+            <right-margin>-0</right-margin>
+            </system-margins>
+          <system-distance>222.5</system-distance>
+          </system-layout>
+        <staff-layout number="2">
+          <staff-distance>65</staff-distance>
+          </staff-layout>
+        </print>
+      <note default-x="157.11" default-y="-10">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        <staff>1</staff>
+        </note>
+      <backup>
+        <duration>4</duration>
+        </backup>
+      <note default-x="157.11" default-y="-115">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>5</voice>
+        <staff>2</staff>
+        </note>
+      </measure>
+    <measure number="6" width="245.29">
+      <direction placement="above">
+        <direction-type>
+          <coda default-x="-13.76" relative-y="20"/>
+          </direction-type>
+        <sound coda="codab"/>
+        </direction>
+      <note default-x="115.25" default-y="-10">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        <staff>1</staff>
+        </note>
+      <backup>
+        <duration>4</duration>
+        </backup>
+      <note default-x="115.25" default-y="-115">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>5</voice>
+        <staff>2</staff>
+        </note>
+      </measure>
+    <measure number="7" width="245.29">
+      <note default-x="115.25" default-y="-10">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        <staff>1</staff>
+        </note>
+      <backup>
+        <duration>4</duration>
+        </backup>
+      <note default-x="115.25" default-y="-115">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>5</voice>
+        <staff>2</staff>
+        </note>
+      </measure>
+    <measure number="8" width="245.29">
+      <note default-x="115.25" default-y="-10">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        <staff>1</staff>
+        </note>
+      <backup>
+        <duration>4</duration>
+        </backup>
+      <note default-x="115.25" default-y="-115">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>5</voice>
+        <staff>2</staff>
+        </note>
+      </measure>
+    <measure number="9" width="290.85">
+      <print new-system="yes">
+        <system-layout>
+          <system-margins>
+            <left-margin>0</left-margin>
+            <right-margin>0</right-margin>
+            </system-margins>
+          <system-distance>222.5</system-distance>
+          </system-layout>
+        <staff-layout number="2">
+          <staff-distance>65</staff-distance>
+          </staff-layout>
+        </print>
+      <direction placement="above">
+        <direction-type>
+          <coda default-x="-13.76" default-y="20.87" relative-y="20"/>
+          </direction-type>
+        <sound coda="codab"/>
+        </direction>
+      <note default-x="155.96" default-y="-10">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        <staff>1</staff>
+        </note>
+      <backup>
+        <duration>4</duration>
+        </backup>
+      <note default-x="155.96" default-y="-115">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>5</voice>
+        <staff>2</staff>
+        </note>
+      </measure>
+    <measure number="10" width="242.99">
+      <note default-x="114.1" default-y="-10">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        <staff>1</staff>
+        </note>
+      <backup>
+        <duration>4</duration>
+        </backup>
+      <note default-x="114.1" default-y="-115">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>5</voice>
+        <staff>2</staff>
+        </note>
+      </measure>
+    <measure number="11" width="242.99">
+      <note default-x="114.1" default-y="-10">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        <staff>1</staff>
+        </note>
+      <backup>
+        <duration>4</duration>
+        </backup>
+      <note default-x="114.1" default-y="-115">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>5</voice>
+        <staff>2</staff>
+        </note>
+      </measure>
+    <measure number="12" width="252.19">
+      <note default-x="114.1" default-y="-10">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        <staff>1</staff>
+        </note>
+      <backup>
+        <duration>4</duration>
+        </backup>
+      <note default-x="114.1" default-y="-115">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>5</voice>
+        <staff>2</staff>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  </score-partwise>

--- a/mtest/musicxml/io/testCodaHBox_ref.mscx
+++ b/mtest/musicxml/io/testCodaHBox_ref.mscx
@@ -1,0 +1,370 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<museScore version="3.02">
+  <Score>
+    <LayerTag id="0" tag="default"></LayerTag>
+    <currentLayer>0</currentLayer>
+    <Division>480</Division>
+    <Style>
+      <pageWidth>8.27102</pageWidth>
+      <pageHeight>11.6915</pageHeight>
+      <pagePrintableWidth>7.08977</pagePrintableWidth>
+      <pageEvenLeftMargin>0.590626</pageEvenLeftMargin>
+      <pageOddLeftMargin>0.590626</pageOddLeftMargin>
+      <pageEvenTopMargin>0.590626</pageEvenTopMargin>
+      <pageEvenBottomMargin>0.590626</pageEvenBottomMargin>
+      <pageOddTopMargin>0.590626</pageOddTopMargin>
+      <pageOddBottomMargin>0.590626</pageOddBottomMargin>
+      <lyricsDashLineThickness>0.1</lyricsDashLineThickness>
+      <bracketWidth>0.45</bracketWidth>
+      <stemWidth>0.1</stemWidth>
+      <staffLineWidth>0.11</staffLineWidth>
+      <pedalLineWidth>0.11</pedalLineWidth>
+      <hideInstrumentNameIfOneInstrument>0</hideInstrumentNameIfOneInstrument>
+      <slurEndWidth>0.05</slurEndWidth>
+      <slurMidWidth>0.21</slurMidWidth>
+      <tieEndWidth>0.05</tieEndWidth>
+      <tieMidWidth>0.21</tieMidWidth>
+      <voltaLineWidth>0.11</voltaLineWidth>
+      <ottavaLineWidth>0.11</ottavaLineWidth>
+      <Spatium>1.75</Spatium>
+      </Style>
+    <showInvisible>1</showInvisible>
+    <showUnprintable>1</showUnprintable>
+    <showFrames>1</showFrames>
+    <showMargins>0</showMargins>
+    <metaTag name="arranger"></metaTag>
+    <metaTag name="composer">Composer / arranger</metaTag>
+    <metaTag name="copyright"></metaTag>
+    <metaTag name="lyricist"></metaTag>
+    <metaTag name="movementNumber"></metaTag>
+    <metaTag name="movementTitle"></metaTag>
+    <metaTag name="poet"></metaTag>
+    <metaTag name="source"></metaTag>
+    <metaTag name="translator"></metaTag>
+    <metaTag name="workNumber"></metaTag>
+    <metaTag name="workTitle">Untitled score</metaTag>
+    <Part>
+      <Staff id="1">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        <hideWhenEmpty>3</hideWhenEmpty>
+        <bracket type="1" span="2" col="1"/>
+        <barLineSpan>1</barLineSpan>
+        </Staff>
+      <Staff id="2">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        <hideWhenEmpty>3</hideWhenEmpty>
+        </Staff>
+      <trackName>Piano</trackName>
+      <Instrument id="piano">
+        <longName>Piano</longName>
+        <shortName>Pno.</shortName>
+        <trackName>Piano</trackName>
+        <minPitchP>21</minPitchP>
+        <maxPitchP>108</maxPitchP>
+        <minPitchA>21</minPitchA>
+        <maxPitchA>108</maxPitchA>
+        <instrumentId>keyboard.piano</instrumentId>
+        <clef staff="2">F</clef>
+        <Articulation>
+          <velocity>100</velocity>
+          <gateTime>95</gateTime>
+          </Articulation>
+        <Articulation name="staccatissimo">
+          <velocity>100</velocity>
+          <gateTime>33</gateTime>
+          </Articulation>
+        <Articulation name="staccato">
+          <velocity>100</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="portato">
+          <velocity>100</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="tenuto">
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="marcato">
+          <velocity>120</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="sforzato">
+          <velocity>150</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="sforzatoStaccato">
+          <velocity>150</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="marcatoStaccato">
+          <velocity>120</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="marcatoTenuto">
+          <velocity>120</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Channel>
+          <program value="0"/>
+          <controller ctrl="10" value="63"/>
+          </Channel>
+        </Instrument>
+      </Part>
+    <Staff id="1">
+      <VBox>
+        <height>10</height>
+        <Text>
+          <style>Title</style>
+          <text>Untitled score</text>
+          </Text>
+        <Text>
+          <style>Composer</style>
+          <text>Composer / arranger</text>
+          </Text>
+        </VBox>
+      <Measure>
+        <voice>
+          <Clef>
+            <concertClefType>G</concertClefType>
+            <transposingClefType>G</transposingClefType>
+            </Clef>
+          <TimeSig>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+            </TimeSig>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>1/1</duration>
+            </Rest>
+          </voice>
+        </Measure>
+      <Measure>
+        <voice>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>1/1</duration>
+            </Rest>
+          </voice>
+        </Measure>
+      <Measure>
+        <voice>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>1/1</duration>
+            </Rest>
+          </voice>
+        </Measure>
+      <Measure>
+        <LayoutBreak>
+          <subtype>line</subtype>
+          </LayoutBreak>
+        <voice>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>1/1</duration>
+            </Rest>
+          </voice>
+        </Measure>
+      <Measure>
+        <voice>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>1/1</duration>
+            </Rest>
+          </voice>
+        </Measure>
+      <HBox>
+        <width>10</width>
+        </HBox>
+      <Measure>
+        <Marker>
+          <style>Repeat Text Left</style>
+          <text><sym>coda</sym></text>
+          <label>codab</label>
+          </Marker>
+        <voice>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>1/1</duration>
+            </Rest>
+          </voice>
+        </Measure>
+      <Measure>
+        <voice>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>1/1</duration>
+            </Rest>
+          </voice>
+        </Measure>
+      <Measure>
+        <LayoutBreak>
+          <subtype>line</subtype>
+          </LayoutBreak>
+        <voice>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>1/1</duration>
+            </Rest>
+          </voice>
+        </Measure>
+      <HBox>
+        <width>10</width>
+        </HBox>
+      <Measure>
+        <Marker>
+          <style>Repeat Text Left</style>
+          <text><sym>coda</sym></text>
+          <label>codab</label>
+          </Marker>
+        <voice>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>1/1</duration>
+            </Rest>
+          </voice>
+        </Measure>
+      <Measure>
+        <voice>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>1/1</duration>
+            </Rest>
+          </voice>
+        </Measure>
+      <Measure>
+        <voice>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>1/1</duration>
+            </Rest>
+          </voice>
+        </Measure>
+      <Measure>
+        <voice>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>1/1</duration>
+            </Rest>
+          <BarLine>
+            <subtype>end</subtype>
+            </BarLine>
+          </voice>
+        </Measure>
+      </Staff>
+    <Staff id="2">
+      <Measure>
+        <voice>
+          <Clef>
+            <concertClefType>F</concertClefType>
+            <transposingClefType>F</transposingClefType>
+            </Clef>
+          <TimeSig>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+            </TimeSig>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>1/1</duration>
+            </Rest>
+          </voice>
+        </Measure>
+      <Measure>
+        <voice>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>1/1</duration>
+            </Rest>
+          </voice>
+        </Measure>
+      <Measure>
+        <voice>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>1/1</duration>
+            </Rest>
+          </voice>
+        </Measure>
+      <Measure>
+        <voice>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>1/1</duration>
+            </Rest>
+          </voice>
+        </Measure>
+      <Measure>
+        <voice>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>1/1</duration>
+            </Rest>
+          </voice>
+        </Measure>
+      <Measure>
+        <voice>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>1/1</duration>
+            </Rest>
+          </voice>
+        </Measure>
+      <Measure>
+        <voice>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>1/1</duration>
+            </Rest>
+          </voice>
+        </Measure>
+      <Measure>
+        <voice>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>1/1</duration>
+            </Rest>
+          </voice>
+        </Measure>
+      <Measure>
+        <voice>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>1/1</duration>
+            </Rest>
+          </voice>
+        </Measure>
+      <Measure>
+        <voice>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>1/1</duration>
+            </Rest>
+          </voice>
+        </Measure>
+      <Measure>
+        <voice>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>1/1</duration>
+            </Rest>
+          </voice>
+        </Measure>
+      <Measure>
+        <voice>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>1/1</duration>
+            </Rest>
+          <BarLine>
+            <subtype>end</subtype>
+            </BarLine>
+          </voice>
+        </Measure>
+      </Staff>
+    </Score>
+  </museScore>

--- a/mtest/musicxml/io/testDCalCoda.xml
+++ b/mtest/musicxml/io/testDCalCoda.xml
@@ -99,6 +99,11 @@
         </note>
       </measure>
     <measure number="5">
+      <print>
+        <measure-layout>
+          <measure-distance>100</measure-distance>
+          </measure-layout>
+        </print>
       <direction placement="above">
         <direction-type>
           <coda/>

--- a/mtest/musicxml/io/testDSalCodaMisplaced_ref.mscx
+++ b/mtest/musicxml/io/testDSalCodaMisplaced_ref.mscx
@@ -338,6 +338,9 @@
             </Rest>
           </voice>
         </Measure>
+      <HBox>
+        <width>10</width>
+        </HBox>
       <Measure>
         <Marker>
           <style>Repeat Text Left</style>

--- a/mtest/musicxml/io/testDSalCoda_ref.mscx
+++ b/mtest/musicxml/io/testDSalCoda_ref.mscx
@@ -341,6 +341,9 @@
             </Rest>
           </voice>
         </Measure>
+      <HBox>
+        <width>10</width>
+        </HBox>
       <Measure>
         <Marker>
           <style>Repeat Text Left</style>

--- a/mtest/musicxml/io/testInferredCrescLines2_ref.mscx
+++ b/mtest/musicxml/io/testInferredCrescLines2_ref.mscx
@@ -129,6 +129,9 @@
           <text>James M</text>
           </Text>
         </VBox>
+      <HBox>
+        <width>5</width>
+        </HBox>
       <Measure>
         <voice>
           <Clef>

--- a/mtest/musicxml/io/testInferredCrescLines_ref.mscx
+++ b/mtest/musicxml/io/testInferredCrescLines_ref.mscx
@@ -129,6 +129,9 @@
           <text>James M</text>
           </Text>
         </VBox>
+      <HBox>
+        <width>5</width>
+        </HBox>
       <Measure>
         <voice>
           <Clef>

--- a/mtest/musicxml/io/testSibOttavas_ref.mscx
+++ b/mtest/musicxml/io/testSibOttavas_ref.mscx
@@ -122,6 +122,9 @@
           <subtype>page</subtype>
           </LayoutBreak>
         </VBox>
+      <HBox>
+        <width>5</width>
+        </HBox>
       <Measure>
         <voice>
           <Clef>

--- a/mtest/musicxml/io/testTextQuirkInference_ref.mscx
+++ b/mtest/musicxml/io/testTextQuirkInference_ref.mscx
@@ -655,6 +655,9 @@
             </Rest>
           </voice>
         </Measure>
+      <HBox>
+        <width>10</width>
+        </HBox>
       <Measure>
         <Marker>
           <style>Repeat Text Left</style>

--- a/mtest/musicxml/io/tst_mxml_io.cpp
+++ b/mtest/musicxml/io/tst_mxml_io.cpp
@@ -94,6 +94,7 @@ private slots:
       void chordSymbols2() { mxmlImportTestRef("testChordSymbols2"); }
       void clefs1() { mxmlIoTest("testClefs1"); }
       void clefs2() { mxmlIoTest("testClefs2"); }
+      void codaHBox() { mxmlImportTestRef("testCodaHBox"); }
       void colorExport() { mxmlMscxExportTestRef("testColorExport"); }
       void colors() { mxmlIoTest("testColors"); }
       void completeMeasureRests() { mxmlIoTest("testCompleteMeasureRests"); }

--- a/mtest/musicxml/io/tst_mxml_io.cpp
+++ b/mtest/musicxml/io/tst_mxml_io.cpp
@@ -96,6 +96,7 @@ private slots:
       void chordSymbols2() { mxmlImportTestRef("testChordSymbols2"); }
       void clefs1() { mxmlIoTest("testClefs1"); }
       void clefs2() { mxmlIoTest("testClefs2"); }
+      void codaHBox() { mxmlImportTestRef("testCodaHBox"); }
       void colorExport() { mxmlMscxExportTestRef("testColorExport"); }
       void colors() { mxmlIoTest("testColors"); }
       void completeMeasureRests() { mxmlIoTest("testCompleteMeasureRests"); }


### PR DESCRIPTION
Backports of #23693, 25713, #21595 and the rest of #29197 (commit 2)

* Add support for measure-distance
   Backport of #23693
   TODO: understand and fix the crashing mtest
* Fix crash on measure-layout tag in first measure of piece
   Backport of #25713, fixes an issue with (the backport of) #23693
* Create indentation or gap before codas on XML import
   Backport of #21595 (needs the backport of #23693)
   TODO: understand and fix the failing mtest (just adjusting the test would result in an invalid xml file)
* Remove duplicate hbox at codas
   Backport of #29197, commit 2 (needs the backport of #21595)

