### PR TITLE
fix(musicxml): correct barre fret export for shifted chord diagrams

### DIFF
--- a/importexport/musicxml/exportxml.cpp
+++ b/importexport/musicxml/exportxml.cpp
@@ -8080,7 +8080,7 @@ static void writeMusicXML(const FretDiagram* item, XmlWriter& xml)
             for (int j : bStarts) {
                   xml.stag("frame-note");
                   xml.tag("string", mxmlString);
-                  xml.tag("fret", j);
+                  xml.tag("fret", j + item->fretOffset());
                   xml.tagE("barre type=\"start\"");
                   xml.etag();
                   }
@@ -8088,7 +8088,7 @@ static void writeMusicXML(const FretDiagram* item, XmlWriter& xml)
             for (int j : bEnds) {
                   xml.stag("frame-note");
                   xml.tag("string", mxmlString);
-                  xml.tag("fret", j);
+                  xml.tag("fret", j + item->fretOffset());
                   xml.tagE("barre type=\"stop\"");
                   xml.etag();
                   }


### PR DESCRIPTION
Backport of #32959

Resolves: [musescore#32958](https://www.github.com/musescore/MuseScore/issues/32958)