### PR TITLE
fix(musicxml): correct barre fret export for shifted chord diagrams

### DIFF
--- a/importexport/musicxml/exportxml.cpp
+++ b/importexport/musicxml/exportxml.cpp
@@ -8037,14 +8037,13 @@ static void writeMusicXML(const FretDiagram* item, XmlWriter& xml)
             for (auto const& j : item->barres()) {
                   FretItem::Barre b = j.second;
                   const int fret = j.first;
-                  int mxmlFret = fret + item->fretOffset();
                   if (!b.exists())
                         continue;
 
                   if (b.startString == i)
-                        bStarts.push_back(mxmlFret);
+                        bStarts.push_back(fret);
                   else if (b.endString == i || (b.endString == -1 && mxmlString == 1))
-                        bEnds.push_back(mxmlFret);
+                        bEnds.push_back(fret);
                   }
 
             if (item->marker(i).exists() && item->marker(i).mtype == FretMarkerType::CIRCLE) {

--- a/importexport/musicxml/exportxml.cpp
+++ b/importexport/musicxml/exportxml.cpp
@@ -8079,7 +8079,7 @@ static void writeMusicXML(const FretDiagram* item, XmlWriter& xml)
             for (int j : bStarts) {
                   xml.stag("frame-note");
                   xml.tag("string", mxmlString);
-                  xml.tag("fret", j);
+                  xml.tag("fret", j + item->fretOffset());
                   xml.tagE("barre type=\"start\"");
                   xml.etag();
                   }
@@ -8087,7 +8087,7 @@ static void writeMusicXML(const FretDiagram* item, XmlWriter& xml)
             for (int j : bEnds) {
                   xml.stag("frame-note");
                   xml.tag("string", mxmlString);
-                  xml.tag("fret", j);
+                  xml.tag("fret", j + item->fretOffset());
                   xml.tagE("barre type=\"stop\"");
                   xml.etag();
                   }

--- a/importexport/musicxml/exportxml.cpp
+++ b/importexport/musicxml/exportxml.cpp
@@ -8246,7 +8246,7 @@ static void writeMusicXML(const FretDiagram* item, XmlWriter& xml)
             for (int j : bStarts) {
                   xml.stag("frame-note");
                   xml.tag("string", mxmlString);
-                  xml.tag("fret", j);
+                  xml.tag("fret", j + item->fretOffset());
                   xml.tagE("barre type=\"start\"");
                   xml.etag();
                   }
@@ -8254,7 +8254,7 @@ static void writeMusicXML(const FretDiagram* item, XmlWriter& xml)
             for (int j : bEnds) {
                   xml.stag("frame-note");
                   xml.tag("string", mxmlString);
-                  xml.tag("fret", j);
+                  xml.tag("fret", j + item->fretOffset());
                   xml.tagE("barre type=\"stop\"");
                   xml.etag();
                   }

--- a/importexport/musicxml/exportxml.cpp
+++ b/importexport/musicxml/exportxml.cpp
@@ -8204,14 +8204,13 @@ static void writeMusicXML(const FretDiagram* item, XmlWriter& xml)
             for (auto const& j : item->barres()) {
                   FretItem::Barre b = j.second;
                   const int fret = j.first;
-                  int mxmlFret = fret + item->fretOffset();
                   if (!b.exists())
                         continue;
 
                   if (b.startString == i)
-                        bStarts.push_back(mxmlFret);
+                        bStarts.push_back(fret);
                   else if (b.endString == i || (b.endString == -1 && mxmlString == 1))
-                        bEnds.push_back(mxmlFret);
+                        bEnds.push_back(fret);
                   }
 
             if (item->marker(i).exists() && item->marker(i).mtype == FretMarkerType::CIRCLE) {


### PR DESCRIPTION
Backport of #32959

Resolves: [musescore#32958](https://wwwgithub.com/musescore/MuseScore/issues/32958)

Involves 'breaking' it first, harmonizing with how upstream/master does it