### PR TITLE
Fix #308890: Recognize ''H' in chord symbols even in non-German setup

### DIFF
--- a/libmscore/harmony.cpp
+++ b/libmscore/harmony.cpp
@@ -637,7 +637,7 @@ static int convertNote(const QString& s, NoteSpellingType noteSpelling, NoteCase
                   r = 4;
             else if (ss == "la")
                   r = 5;
-            else if (ss == "si")
+            else if (ss == "si" || ss == "ti")
                   r = 6;
             else
                   return Tpc::TPC_INVALID;

--- a/libmscore/harmony.cpp
+++ b/libmscore/harmony.cpp
@@ -650,6 +650,7 @@ static int convertNote(const QString& s, NoteSpellingType noteSpelling, NoteCase
                   case 'f':   r = 3; break;
                   case 'g':   r = 4; break;
                   case 'a':   r = 5; break;
+                  case 'h':   // allow for German 'h' too, silently turn into 'b'
                   case 'b':   r = 6; break;
                   default:    return Tpc::TPC_INVALID;
                   }


### PR DESCRIPTION
just silently turn it into  "B"

While at it make Solfeggio mode to accept "ti" as chord name, as an alternative to "si"

Resolves: [#308890](https://musescore.org/en/node/308890)

Backport of #33096