### PR TITLE
Import playing technique from MusicXML

### DIFF
--- a/importexport/musicxml/importmxmlpass2.cpp
+++ b/importexport/musicxml/importmxmlpass2.cpp
@@ -3485,6 +3485,23 @@ void MusicXMLParserDirection::direction(const QString& partId,
                         t = new StaffText(_score, Tid::EXPRESSION);
                   else if (_systemDirection)
                         t = new SystemText(_score);
+                  else if (!_play.isEmpty()) {
+                        StaffText* st = new StaffText(_score);
+                        if (_play == "pizzicato" || _play == "mute" || _play == "open") {
+                              st->setChannelName(0, _play);
+                              st->setChannelName(1, _play);
+                              st->setChannelName(2, _play);
+                              st->setChannelName(3, _play);
+                              }
+                        else if (_play == "natural" ) {
+                              st->setChannelName(0, "arco");
+                              st->setChannelName(1, "arco");
+                              st->setChannelName(2, "arco");
+                              st->setChannelName(3, "arco");
+                              }
+                        t = st;
+                        _play.clear();
+                        }
                   else
                         t = new StaffText(_score);
                   t->setXmlText(_wordsText + _metroText);

--- a/mtest/musicxml/io/testStringmute_ref.mscx
+++ b/mtest/musicxml/io/testStringmute_ref.mscx
@@ -143,6 +143,10 @@
       <Measure>
         <voice>
           <StaffText>
+            <channelSwitch voice="0" name="mute"/>
+            <channelSwitch voice="1" name="mute"/>
+            <channelSwitch voice="2" name="mute"/>
+            <channelSwitch voice="3" name="mute"/>
             <color r="69" g="0" b="84" a="255"/>
             <text><sym>stringsMuteOn</sym></text>
             </StaffText>
@@ -183,6 +187,10 @@
       <Measure>
         <voice>
           <StaffText>
+            <channelSwitch voice="0" name="open"/>
+            <channelSwitch voice="1" name="open"/>
+            <channelSwitch voice="2" name="open"/>
+            <channelSwitch voice="3" name="open"/>
             <color r="253" g="169" b="51" a="255"/>
             <text><sym>stringsMuteOff</sym></text>
             </StaffText>


### PR DESCRIPTION
in at least the limited form for strings pizz./arco and brass mute/open

Mu4 does that, probably in a cleaner and more complete way, but but this is about all Mu3 can do about it AFAICT.

Came up in https://musescore.org/en/comment/1328068