### PR TITLE
Fix "Fix piano roll editor click add note to existing crash", 2025-04-12

### DIFF
--- a/mscore/pianoroll/pianoview.cpp
+++ b/mscore/pianoroll/pianoview.cpp
@@ -1318,8 +1318,10 @@ QVector<Note*> PianoView::addNote(Fraction startTick, Fraction duration, int pit
                   }
             }
 
-      for (auto it : addedNotes)
-            toggleTie(it);
+      for (auto note : addedNotes) {
+            if (note != addedNotes.last())
+                  toggleTie(note);
+            }
 
       return addedNotes;
       }


### PR DESCRIPTION
Resolves: #1197

Just check if it's not the last of the QVector (if std::vector was used instead, would probably just revert to how it was but be extra cautious with *it or screw it move over to c++20 views)

The way the last person did it made it so that there was an application of a tie on the last note.

Their edit was:

<img width="1005" height="135" alt="image" src="https://github.com/user-attachments/assets/4c2b192a-a492-48fa-bec3-b5b62be7edc1" />

which could've been fixed instead probably by just wrapping it in a !empty clause. Kind of a catch-22 because the new foreach doesn't give access to the iterator, and shouldn't be named it since it's a pointer to a Note