### PR TITLE
Make Revision in Score properties and About box a clickable URL to the corresponding commit

### DIFF
--- a/libmscore/page.cpp
+++ b/libmscore/page.cpp
@@ -10,25 +10,21 @@
 //  the file LICENCE.GPL
 //=============================================================================
 
-#include "page.h"
-#include "score.h"
-#include "text.h"
-#include "xml.h"
-#include "measure.h"
-#include "style.h"
-#include "chord.h"
 #include "beam.h"
-#include "tuplet.h"
-#include "note.h"
-#include "barline.h"
-#include "slur.h"
-#include "hook.h"
 #include "bracket.h"
 #include "line.h"
-#include "staff.h"
-#include "system.h"
+#include "measure.h"
 #include "mscore.h"
+#include "note.h"
+#include "page.h"
+#include "score.h"
 #include "segment.h"
+#include "staff.h"
+#include "style.h"
+#include "system.h"
+#include "text.h"
+#include "tuplet.h"
+#include "xml.h"
 
 namespace Ms {
 
@@ -483,10 +479,11 @@ QString Page::replaceTextMacros(const QString& s) const
                                     }
                               else {
                                     int rev = score()->mscoreRevision();
-                                    if (rev > 99999)  // MuseScore 1.3 is decimal 5702, 2.0 and later uses a 7-digit hex SHA
-                                          d += QString::number(rev, 16);
-                                    else
+                                    if (rev > 0 && rev < 5709)  // MuseScore 1.x and earlier used decimal numbers, referring to a commit on SourceForge.net, the largest being 5709
                                           d += QString::number(rev, 10);
+                                    else if (rev > 0xffffff) // MuseScore 2.0 and later use a >= 7-digit hex SHA, referring to a commit on GitHub.com
+                                          d += QString::number(rev, 16);
+                                    // else unknown, like in a self-built development version, or in a very old version of MuseScore before the revision number was tracked
                                     }
                               break;
                         case '$':

--- a/mscore/aboutbox.ui
+++ b/mscore/aboutbox.ui
@@ -113,6 +113,9 @@
              <property name="text">
               <string notr="true" extracomment="gets replaced programmatically">Revision: nnnnnnn</string>
              </property>
+             <property name="openExternalLinks">
+              <bool>true</bool>
+             </property>
             </widget>
            </item>
            <item>

--- a/mscore/metaedit.cpp
+++ b/mscore/metaedit.cpp
@@ -17,13 +17,14 @@
 //  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 //=============================================================================
 
+#include "icons.h"
 #include "metaedit.h"
+#include "musescore.h"
+#include "openfilelocation.h"
+#include "preferences.h"
+
 #include "libmscore/score.h"
 #include "libmscore/undo.h"
-#include "musescore.h"
-#include "preferences.h"
-#include "icons.h"
-#include "openfilelocation.h"
 
 namespace Ms {
 
@@ -42,14 +43,16 @@ MetaEditDialog::MetaEditDialog(Score* score, QWidget* parent)
       QDialog::setWindowFlag(Qt::WindowContextHelpButtonHint, false);
       QDialog::setWindowFlag(Qt::WindowMinMaxButtonsHint);
 
-      version->setText(m_score->mscoreVersion());
+      QString mscoreVersion = m_score->mscoreVersion();
+      version->setText(mscoreVersion);
       level->setText(QString::number(m_score->mscVersion()));
 
       int rev = m_score->mscoreRevision();
-      if (rev > 99999)  // MuseScore 1.3 is decimal 5702, 2.0 and later uses a 7-digit hex SHA
-            revision->setText(QString::number(rev, 16));
-      else
-            revision->setText(QString::number(rev, 10));
+      if (rev > 0 && rev <= 5709) // MuseScore 1.x and earlier used decimal numbers, referring to a commit on SourceForge.net, the largest being 5709
+            revision->setText(QString("<a href=\"https://sourceforge.net/p/mscore/code/%1/\">%1</a>").arg(QString::number(rev, 10)));
+      else if (rev > 0xffffff) // MuseScore 2.0 and later use a >= 7-digit hex SHA, referring to a commit on GitHub.com
+            revision->setText(QString("<a href=\"https://github.com/%1/MuseScore/commit/%2\">%2</a>").arg(mscoreVersion == "3.6.3" ? "Jojo-Schmitz": "musescore", QString::number(rev, 16)));
+      //else unknown, like in a self-built development version, or in a very old version of MuseScore before the revision number was tracked
 
       QString currentFileName  = score->masterScore()->fileInfo()->absoluteFilePath();
       QString previousFileName = score->importedFilePath();

--- a/mscore/metaedit.ui
+++ b/mscore/metaedit.ui
@@ -62,8 +62,11 @@
        <property name="text">
         <string>No revision</string>
        </property>
+       <property name="openExternalLinks">
+        <bool>true</bool>
+       </property>
        <property name="textInteractionFlags">
-        <set>Qt::TextSelectableByMouse</set>
+        <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
        </property>
       </widget>
      </item>

--- a/mscore/musescoredialogs.cpp
+++ b/mscore/musescoredialogs.cpp
@@ -17,10 +17,10 @@
 //  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 //=============================================================================
 
-#include "musescoredialogs.h"
 #include "icons.h"
-#include "preferences.h"
 #include "musescore.h"
+#include "musescoredialogs.h"
+#include "preferences.h"
 #include "scoreview.h"
 
 namespace Ms {
@@ -151,18 +151,23 @@ AboutBoxDialog::AboutBoxDialog()
       else {
             auto msVersion = QString(VERSION);
             if (strlen(BUILD_NUMBER))
-                  msVersion += QString(".") + QString(BUILD_NUMBER);// +QString(" Beta");
+                  msVersion += QString("-") + QString(BUILD_NUMBER); // + QString(" Beta");
             versionLabel->setText(tr("Version: %1").arg(msVersion) + tr(" Evolution"));
       }
 
-      revisionLabel->setText(tr("Revision: %1").arg(revision));
+      if (!revision.isEmpty())
+            revisionLabel->setText(tr("Revision: %1").arg(QString("<a href=\"https://github.com/Jojo-Schmitz/musescore/commit/%1\">%1</a>").arg(revision)));
+      else {
+            revisionLabel->setText("");
+            copyRevisionButton->setVisible(false);
+            }
       setWindowFlags(this->windowFlags() & ~Qt::WindowContextHelpButtonHint);
 
       auto compilerDateISO = []() -> QString {
             // Attempt to convert __DATE__ into ISO 8601 format (YYYY-MM-DD)
             QDate date = QDate::fromString(__DATE__, "MMM dd yyyy");
             if (!date.isValid())
-                  date = QDate::fromString(__DATE__, "MMM  d yyyy");
+                  date = QDate::fromString(__DATE__, "MMM  d yyyy"); // for single digit days __DATE__ may use a leading space rather than a leading 0
             return date.isValid() ? date.toString(Qt::ISODate) : __DATE__;
             };
 
@@ -170,15 +175,17 @@ AboutBoxDialog::AboutBoxDialog()
       dateTime += preferences.getBool(PREF_UI_APP_BUILD_DATE_ISO) ? compilerDateISO() : __DATE__;
       dateTime += " ";
       dateTime += __TIME__;
+      if (!revision.isEmpty())
+            dateTime += " UTC"; // local builds (most likely not having revision set) use local time, GitHub CI uses UTC
 
       buildDateLabel->setText(tr("Build date: %1").arg(dateTime));
 
       QString visitAndDonateString;
-#if !defined(FOR_WINSTORE) && 0
+#if !defined(FOR_WINSTORE)
       visitAndDonateString = tr("Visit %1 for new versions and more information.\nGet %2help%3 with the program or %4contribute%5 to its development.")
-                  .arg("<a href=\"https://www.musescore.org/\">www.musescore.org</a>",
+                  .arg("<a href=\"https://github.com/Jojo-Schmitz/MuseScore/wiki\">github.com/Jojo-Schmitz/MuseScore/wiki</a>",
                        "<a href=\"https://www.musescore.org/forum\">", "</a>",
-                       "<a href=\"https://www.musescore.org/contribute\">", "</a>");
+                       "<a href=\"https://github.com/Jojo-Schmitz/MuseScore/wiki/Contribute\">", "</a>");
       visitAndDonateString += "\n\n";
 #endif
       QString finalString = visitAndDonateString + tr("Copyright &copy; 1999-2026 MuseScore Limited and others.\nPublished under the %1GNU General Public License version 2%2.")
@@ -195,23 +202,15 @@ AboutBoxDialog::AboutBoxDialog()
 
 void AboutBoxDialog::copyRevisionToClipboard()
       {
-      QClipboard* cb = QApplication::clipboard();
-      QString sysinfo = "OS: ";
-      sysinfo += QSysInfo::prettyProductName();
-      if (QSysInfo::productType() == "windows" && (QSysInfo::productVersion() == "10" || QSysInfo::productVersion() == "11"))
-            sysinfo += " or later";
-      sysinfo += ", Arch.: ";
-      sysinfo += QSysInfo::currentCpuArchitecture();
-      // endianness?
-      sysinfo += ", MuseScore version (";
-      sysinfo += QSysInfo::WordSize==32 ? "32" : "64";
-      sysinfo += "-bit): " + QString(VERSION);
-      if (strlen(BUILD_NUMBER))
-            sysinfo += QString(".") + QString(BUILD_NUMBER);
-      sysinfo += ", revision: ";
-      sysinfo += "GitHub-Jojo-Schmitz-MuseScore-";
-      sysinfo += revision;
-      cb->setText(sysinfo);
+      QApplication::clipboard()->setText(
+            QString("OS: %1, Arch.: %2, MuseScore Studio version (%3-bit): %4-%5")
+                  .arg(QSysInfo::prettyProductName()
+                       + ((QSysInfo::productType() == "windows" && (QSysInfo::productVersion() == "10" || QSysInfo::productVersion() == "11"))
+                          ? " or later" : ""), QSysInfo::currentCpuArchitecture())
+                  .arg(QSysInfo::WordSize)
+                  .arg(VERSION, BUILD_NUMBER)
+            + QString(revision.isEmpty() ? "" : ", revision: [%1](https://github.com/Jojo-Schmitz/MuseScore/commit/%1)")
+                  .arg(revision));
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
Backport of #33712

Also advertising MuseScore 3.7 Evolution in the About box rather than having the advertising for the upsteam version disabled entirely ;-)