### PR TITLE
Fix MusicXML import: Norwegian Ø (and lone $) incorrectly replaced with coda/segno symbol

### DIFF
--- a/importexport/musicxml/importmxmlpass2.cpp
+++ b/importexport/musicxml/importmxmlpass2.cpp
@@ -650,10 +650,16 @@ static void setPartInstruments(MxmlLogger* logger, const QXmlStreamReader* const
 //---------------------------------------------------------
 
 /**
- Convert SMuFL code points to MuseScore <sym>...</sym>
+ Convert SMuFL code points to MuseScore <sym>...</sym> notation.
+ When \p isDolet is true (i.e. the file was produced by Dolet and the text comes
+ from a MusicXML \c \<words\> or \c \<rehearsal\> element), every occurrence of \c $
+ or \c Ø within the text is treated as a Dolet-plugin segno/coda shorthand and replaced
+ with the corresponding SMuFL symbol — including when embedded in longer strings such as
+ "Dal $ al Ø" or "To Ø".  In all other contexts (non-Dolet files, or lyric text) the
+ characters are preserved as-is.
  */
 
-static QString text2syms(const QString& t)
+static QString text2syms(const QString& t, bool isDolet = false)
       {
       //QTime time;
       //time.start();
@@ -676,9 +682,10 @@ static QString text2syms(const QString& t)
                   maxStringSize = string.size();
             }
 
-      // Special case Dolet inference (TODO: put behind a setting or export type flag)
-      map.insert("$", SymId::segno);
-      map.insert("Ø", SymId::coda);
+      if (isDolet) {
+            map.insert("$", SymId::segno);
+            map.insert("Ø", SymId::coda);
+            }
 
       //qDebug("text2syms map count %d maxsz %d filling time elapsed: %d ms",
       //       map.size(), maxStringSize, time.elapsed());
@@ -745,11 +752,7 @@ static QString decodeEntities( const QString& src )
 
 // TODO: probably should be shared between pass 1 and 2
 
-/**
- Read the next part of a MusicXML formatted string and convert to MuseScore internal encoding.
- */
-
-static QString nextPartOfFormattedString(QXmlStreamReader& e)
+static QString nextPartOfFormattedString(QXmlStreamReader& e, bool isDolet = false)
       {
       //QString lang       = e.attribute(QString("xml:lang"), "it");
       QString fontWeight = e.attributes().value("font-weight").toString();
@@ -763,7 +766,7 @@ static QString nextPartOfFormattedString(QXmlStreamReader& e)
       QString txt        = e.readElementText();
       // replace HTML entities
       txt = decodeEntities(txt);
-      QString syms       = text2syms(txt);
+      QString syms       = text2syms(txt, isDolet);
 
       QString importedtext;
 
@@ -3761,7 +3764,7 @@ void MusicXMLParserDirection::directionType(QList<MusicXmlSpannerDesc>& starts,
                   _metroText = metronome(_tpoMetro);
             else if (_e.name() == "words") {
                   _enclosure      = _e.attributes().value("enclosure").toString();
-                  QString nextPart = nextPartOfFormattedString(_e);
+                  QString nextPart = nextPartOfFormattedString(_e, _pass1.dolet());
                   textToDynamic(nextPart);
                   textToCrescLine(nextPart);
                   _wordsText += nextPart;
@@ -3770,7 +3773,7 @@ void MusicXMLParserDirection::directionType(QList<MusicXmlSpannerDesc>& starts,
                   _enclosure      = _e.attributes().value("enclosure").toString();
                   if (_enclosure.isEmpty())
                         _enclosure = "square";  // note different default
-                  _rehearsalText += nextPartOfFormattedString(_e);
+                  _rehearsalText += nextPartOfFormattedString(_e, _pass1.dolet());
                   }
             else if (_e.name() == "pedal")
                   pedal(type, n, starts, stops);

--- a/mtest/musicxml/io/testLyricsNorwegianOSlash.xml
+++ b/mtest/musicxml/io/testLyricsNorwegianOSlash.xml
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 4.0 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<!--
+     Purpose-made regression test: the Norwegian/Danish letters Ø and ø must be
+     imported as-is and must never be converted to a coda sign (𝄉), and a lyric
+     of "$" must never be converted to a segno sign. Both were bugs caused by
+     Dolet font shorthand substitution being applied to all MusicXML files.
+     The pitches and rhythm are arbitrary; only the lyric text is relevant.
+-->
+<score-partwise version="4.0">
+  <identification>
+    <encoding>
+      <software>TestExporter</software>
+      <encoding-date>2026-06-09</encoding-date>
+      </encoding>
+    </identification>
+  <part-list>
+    <score-part id="P1">
+      <part-name>Voice</part-name>
+      <score-instrument id="P1-I1">
+        <instrument-name>Voice</instrument-name>
+        </score-instrument>
+      </score-part>
+    </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>0</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        </attributes>
+      <!-- "Øj-" — the uppercase Ø must not become a coda sign -->
+      <note>
+        <pitch><step>C</step><octave>5</octave></pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <lyric number="1">
+          <syllabic>begin</syllabic>
+          <text>Øj</text>
+          </lyric>
+        </note>
+      <!-- "-ne" -->
+      <note>
+        <pitch><step>D</step><octave>5</octave></pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <lyric number="1">
+          <syllabic>end</syllabic>
+          <text>ne</text>
+          </lyric>
+        </note>
+      <!-- "svøm-" — the lowercase ø must also be preserved -->
+      <note>
+        <pitch><step>E</step><octave>5</octave></pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <lyric number="1">
+          <syllabic>begin</syllabic>
+          <text>svøm</text>
+          </lyric>
+        </note>
+      <!-- "-me" -->
+      <note>
+        <pitch><step>F</step><octave>5</octave></pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <lyric number="1">
+          <syllabic>end</syllabic>
+          <text>me</text>
+          </lyric>
+        </note>
+      </measure>
+    <measure number="2">
+      <!-- "$5" — a dollar sign in a multi-char lyric must be preserved as-is -->
+      <note>
+        <pitch><step>G</step><octave>5</octave></pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <lyric number="1">
+          <syllabic>single</syllabic>
+          <text>$5</text>
+          </lyric>
+        </note>
+      <!-- "$" — even a lone dollar sign must be preserved, not converted to segno -->
+      <note>
+        <pitch><step>A</step><octave>5</octave></pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <lyric number="1">
+          <syllabic>single</syllabic>
+          <text>$</text>
+          </lyric>
+        </note>
+      <note>
+        <rest/>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>half</type>
+        </note>
+      </measure>
+    </part>
+  </score-partwise>

--- a/mtest/musicxml/io/testLyricsNorwegianOSlash_ref.mscx
+++ b/mtest/musicxml/io/testLyricsNorwegianOSlash_ref.mscx
@@ -1,0 +1,179 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<museScore version="3.02">
+  <Score>
+    <LayerTag id="0" tag="default"></LayerTag>
+    <currentLayer>0</currentLayer>
+    <Division>480</Division>
+    <Style>
+      <hideInstrumentNameIfOneInstrument>0</hideInstrumentNameIfOneInstrument>
+      <Spatium>1.74978</Spatium>
+      </Style>
+    <showInvisible>1</showInvisible>
+    <showUnprintable>1</showUnprintable>
+    <showFrames>1</showFrames>
+    <showMargins>0</showMargins>
+    <metaTag name="arranger"></metaTag>
+    <metaTag name="composer"></metaTag>
+    <metaTag name="copyright"></metaTag>
+    <metaTag name="lyricist"></metaTag>
+    <metaTag name="movementNumber"></metaTag>
+    <metaTag name="movementTitle"></metaTag>
+    <metaTag name="poet"></metaTag>
+    <metaTag name="source"></metaTag>
+    <metaTag name="translator"></metaTag>
+    <metaTag name="workNumber"></metaTag>
+    <metaTag name="workTitle"></metaTag>
+    <Part>
+      <Staff id="1">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        <hideWhenEmpty>3</hideWhenEmpty>
+        </Staff>
+      <trackName>Voice</trackName>
+      <Instrument id="voice">
+        <longName>Voice</longName>
+        <trackName>Voice</trackName>
+        <minPitchP>38</minPitchP>
+        <maxPitchP>84</maxPitchP>
+        <minPitchA>41</minPitchA>
+        <maxPitchA>79</maxPitchA>
+        <instrumentId>voice.vocals</instrumentId>
+        <Articulation>
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="staccatissimo">
+          <velocity>100</velocity>
+          <gateTime>33</gateTime>
+          </Articulation>
+        <Articulation name="staccato">
+          <velocity>100</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="portato">
+          <velocity>100</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="tenuto">
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="marcato">
+          <velocity>120</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="sforzato">
+          <velocity>150</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="sforzatoStaccato">
+          <velocity>150</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="marcatoStaccato">
+          <velocity>120</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="marcatoTenuto">
+          <velocity>120</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Channel>
+          <program value="52"/>
+          <controller ctrl="10" value="63"/>
+          </Channel>
+        </Instrument>
+      </Part>
+    <Staff id="1">
+      <VBox>
+        <height>10</height>
+        </VBox>
+      <Measure>
+        <voice>
+          <Clef>
+            <concertClefType>G</concertClefType>
+            <transposingClefType>G</transposingClefType>
+            </Clef>
+          <TimeSig>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+            </TimeSig>
+          <Chord>
+            <durationType>quarter</durationType>
+            <Lyrics>
+              <syllabic>begin</syllabic>
+              <text>Øj</text>
+              </Lyrics>
+            <Note>
+              <pitch>72</pitch>
+              <tpc>14</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <durationType>quarter</durationType>
+            <Lyrics>
+              <syllabic>end</syllabic>
+              <text>ne</text>
+              </Lyrics>
+            <Note>
+              <pitch>74</pitch>
+              <tpc>16</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <durationType>quarter</durationType>
+            <Lyrics>
+              <syllabic>begin</syllabic>
+              <text>svøm</text>
+              </Lyrics>
+            <Note>
+              <pitch>76</pitch>
+              <tpc>18</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <durationType>quarter</durationType>
+            <Lyrics>
+              <syllabic>end</syllabic>
+              <text>me</text>
+              </Lyrics>
+            <Note>
+              <pitch>77</pitch>
+              <tpc>13</tpc>
+              </Note>
+            </Chord>
+          </voice>
+        </Measure>
+      <Measure>
+        <voice>
+          <Chord>
+            <durationType>quarter</durationType>
+            <Lyrics>
+              <text>$5</text>
+              </Lyrics>
+            <Note>
+              <pitch>79</pitch>
+              <tpc>15</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <durationType>quarter</durationType>
+            <Lyrics>
+              <text>$</text>
+              </Lyrics>
+            <Note>
+              <pitch>81</pitch>
+              <tpc>17</tpc>
+              </Note>
+            </Chord>
+          <Rest>
+            <durationType>half</durationType>
+            </Rest>
+          <BarLine>
+            </BarLine>
+          </voice>
+        </Measure>
+      </Staff>
+    </Score>
+  </museScore>

--- a/mtest/musicxml/io/testTextQuirkInference.xml
+++ b/mtest/musicxml/io/testTextQuirkInference.xml
@@ -7,7 +7,8 @@
   <identification>
     <creator type="composer">Henry Ives</creator>
     <encoding>
-      <software>MuseScore 0.7.0</software>
+      <software>Sibelius 20231.1</software>
+      <software>Dolet 6.6 for Sibelius</software>
       <encoding-date>2007-09-10</encoding-date>
       <supports element="accidental" type="yes"/>
       <supports element="beam" type="yes"/>

--- a/mtest/musicxml/io/tst_mxml_io.cpp
+++ b/mtest/musicxml/io/tst_mxml_io.cpp
@@ -224,6 +224,7 @@ private slots:
       void lyricExtensions2() { mxmlImportTestRef("testLyricExtensions"); }
       void lyricExtensions3() { mxmlIoTest("testLyricExtension2"); }
       void lyricExtensions4() { mxmlImportTestRef("testLyricExtension2"); }
+      void lyricsNorwegianOSlash() { mxmlImportTestRef("testLyricsNorwegianOSlash"); }
       void lyricPos() { mxmlImportTestRef("testLyricPos"); }
       void lyrics1() { mxmlIoTestRef("testLyrics1"); }
       void lyricsVoice2a() { mxmlIoTest("testLyricsVoice2a"); }


### PR DESCRIPTION
Backport of #33745

Resolves: [musescore#33747](https://www.github.com/musescore/MuseScore/issues/33747)