### PR TITLE
Apply Palette: Measure Number

### DIFF
--- a/mscore/palette.cpp
+++ b/mscore/palette.cpp
@@ -592,6 +592,10 @@ bool Palette::applyPaletteElement(Element* element, Qt::KeyboardModifiers modifi
             else if (element->isSlur()) {
                   viewer->cmdAddSlur(toSlur(element));
                   }
+            else if (element->isMeasureNumber()) {
+                  if (auto m = sel.findMeasure())
+                        m->undoChangeProperty(Pid::MEASURE_NUMBER_MODE, static_cast<int>(MeasureNumberMode::SHOW));
+                  }
             else if (element->isSLine() && !element->isGlissando() && addSingle) {
                   Segment* startSegment = cr1->segment();
                   Segment* endSegment = cr2->segment();
@@ -755,6 +759,10 @@ bool Palette::applyPaletteElement(Element* element, Qt::KeyboardModifiers modifi
                         spanner->styleChanged();
                         score->cmdAddSpanner(spanner, i, startSegment, endSegment);
                         }
+                  }
+            else if (element->isMeasureNumber()) {
+                  if (auto m = sel.startSegment()->measure())
+                        m->undoChangeProperty(Pid::MEASURE_NUMBER_MODE, static_cast<int>(MeasureNumberMode::SHOW));
                   }
             else if (element->isTextBase()) {
                   Ms::Segment* firstSegment = sel.startSegment();


### PR DESCRIPTION
of very little concern, but shouldn't hurt to add this in:

Apparently 316360b3a4 ("Add Measure Number element to palettes", 2020-02-24) only implemented Drag&Drop and not Apply (non drag to measure) 

Resolves: no issue posted

Seems to work in MSS4, but don't know exactly what happened. The drag/drop versus apply palettes code is kind of a mess in 3.x imo
