### PR TITLE
Fix Backport: Fix GH#25901: Crash on cross-staff slurs with TAB staves

### DIFF
--- a/libmscore/slur.cpp
+++ b/libmscore/slur.cpp
@@ -145,8 +145,8 @@ bool SlurSegment::edit(EditData& ed)
                   return false; // Cross-staff slurs don't make sense for TAB staves
             if (cr->staff()->isLinked(e->staff()))
                   return false; // Don't allow slur to cross into staff that's linked to this
-            }
             changeAnchor(ed, cr);
+            }
       return true;
       }
 


### PR DESCRIPTION
Resolves: #1219

See also: https://github.com/Jojo-Schmitz/MuseScore/pull/735

For a minute I was trippin' on this thing. 