### PR TITLE
Update Windows builds to use VS 2026

### DIFF
--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -122,7 +122,7 @@ jobs:
     if: contains(needs.plan.outputs.platforms, 'windows_x64')
     needs:
       - plan
-    runs-on: windows-2022
+    runs-on: windows-2025
     steps:
     - name: Clone repository
       uses: actions/checkout@v7
@@ -200,7 +200,7 @@ jobs:
     if: contains(needs.plan.outputs.platforms, 'windows_x32')
     needs:
       - plan
-    runs-on: windows-2022
+    runs-on: windows-2025
     steps:
     - name: Clone repository
       uses: actions/checkout@v7
@@ -278,7 +278,7 @@ jobs:
     if: contains(needs.plan.outputs.platforms, 'windows_portable_x32')
     needs:
       - plan
-    runs-on: windows-2022
+    runs-on: windows-2025
     steps:
     - name: Clone repository
       uses: actions/checkout@v7
@@ -355,7 +355,7 @@ jobs:
     if: contains(needs.plan.outputs.platforms, 'windows_portable_x64')
     needs:
       - plan
-    runs-on: windows-2022
+    runs-on: windows-2025
     steps:
     - name: Clone repository
       uses: actions/checkout@v7

--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -3,7 +3,7 @@
    "configurations": [
       {
          "name": "x64-RelWithDebInfo",
-         "generator": "Visual Studio 17 2022 Win64",
+         "generator": "Visual Studio 18 2026 Win64",
          "configurationType": "RelWithDebInfo",
          "inheritEnvironments": [ "msvc_x64_x64" ],
          "buildRoot": "${projectDir}\\msvc.build_x64", // "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\build\\${name}",

--- a/build/ci/windows/build.bat
+++ b/build/ci/windows/build.bat
@@ -58,7 +58,7 @@ ECHO "BUILD_UI_MU4: %BUILD_UI_MU4%"
 XCOPY "C:\musescore_dependencies" %CD% /E /I /Y
 ECHO "Finished copy dependencies"
 
-SET GENERATOR_NAME=Visual Studio 17 2022
+SET GENERATOR_NAME=Visual Studio 18 2026
 SET MSCORE_STABLE_BUILD="TRUE"
 
 :: TODO We need define paths during image creation

--- a/msvc_build.bat
+++ b/msvc_build.bat
@@ -40,7 +40,7 @@ IF "%GENERATOR_NAME%"=="" (
 )
 
 IF "%GENERATOR_NAME%"=="" (
-   ECHO "No supported version of Microsoft Visual Studio (2017, 2019 or 2022) found."
+   ECHO "No supported version of Microsoft Visual Studio (2017, 2019, 2022, or 2026) found."
    GOTO :END
 )
 


### PR DESCRIPTION
Reverting an earlier quick fix and as an alternative to that