### PR TITLE
Fix: Failure to read double from workspace (doesn't load Font Size)

### DIFF
--- a/mscore/workspace.cpp
+++ b/mscore/workspace.cpp
@@ -823,12 +823,18 @@ void Workspace::read(XmlReader& e)
                                     break;
                               case QVariant::LongLong:
                                     {
-                                    bool new_longlong = e.readLongLong();
+                                    auto new_longlong = e.readLongLong();
                                     preferences.setLocalPreference(preference_name, QVariant(new_longlong));
                                     break;
                                     }
+                              case QVariant::Double:
+                                    {
+                                    auto new_double = e.readDouble();
+                                    preferences.setLocalPreference(preference_name, QVariant(new_double));
+                                    break;
+                                    }
                               default:
-                                    qDebug() << preferences.defaultValue(preference_name).type() << " not handled.";
+                                    qDebug() << preference_name << ":" << preferences.defaultValue(preference_name).type() << " not handled.";
                                     e.unknown();
                               }
                         }


### PR DESCRIPTION
I've been working on my own fixes/features and had a problem switching between Debug and Release builds: the debug menu doesn't show in Release, but in turn it would affect the workspace since it is sharing workspaces, and then in reloading the workspace in Debug later it would be missing the Debug menu.

That's besides the point, but the point is I found in solving this, that font size isn't being honored when restarting the program. Why? After perusing: turns out they failed to handle Double types in workspace loading. 

And the long long type was got as bool? wtf? Also updated the debug message to include the actual tag name if it shows up in the console logging.

The point here is that now the font size of the UI in preferences gets honored in reading a workspace. It kept defaulting earlier.