### PR TITLE
Fix layout of full score when ending edit on empty text

### DIFF
--- a/libmscore/textedit.cpp
+++ b/libmscore/textedit.cpp
@@ -160,6 +160,10 @@ void TextBase::endEdit(EditData& ed)
                   Filter::Link,
                   };
 
+            CmdState& cs = score()->cmdState();
+            cs.reset();
+            cs.setTick(tick());
+
             if (newlyAdded && !undo->current()->hasUnfilteredChildren(filters, this)) {
                   for (Filter f : filters)
                         undo->current()->filterChildren(f, this);


### PR DESCRIPTION
Think this fixes: #1231

Updates the code block where there's an empty string before calling `endCmd()`. I've verified that it fixes the problem. The reset was required because 0/1 was the `_startTick` at this moment, so it wouldn't update without it