### PR TITLE
Allow melismas under rests

### DIFF
--- a/libmscore/repeatlist.cpp
+++ b/libmscore/repeatlist.cpp
@@ -21,7 +21,6 @@
 #include "score.h"
 #include "segment.h"
 #include "tempo.h"
-#include "types.h"
 #include "volta.h"
 
 namespace Ms {
@@ -434,10 +433,12 @@ void RepeatList::collectRepeatListElements()
       volta = nullptr;
       for (; mb; mb = mb->next()) {
             if (mb->isMeasure()) {
+                  Measure* m = toMeasure(mb);
                   sectionEndMeasureBase = mb; // ending measure of section is the most recently encountered actual Measure
+                  Measure* underlyingMeasure = m->isMMRest() ? m->mmRestFirst() : m;
 
                   // Volta ?
-                  if ((!preProcessedVoltas.empty()) && (preProcessedVoltas.front()->startMeasure() == mb)) {
+                  if ((!preProcessedVoltas.empty()) && (preProcessedVoltas.front()->startMeasure() == underlyingMeasure)) {
                         if (volta != nullptr) {
                               //if (volta->endMeasure()->tick() < mb->tick()) {
                                     // The previous volta was supposed to end before us (open volta case) -> insert the end
@@ -455,7 +456,7 @@ void RepeatList::collectRepeatListElements()
                   // Start
                   if (mb->repeatStart()) {
                         if (volta != nullptr) {
-                              if (volta->startMeasure() != toMeasure(mb)) {
+                              if (volta->startMeasure() != underlyingMeasure) {
                                     // Volta and Start repeat are not on the same measure
                                     // assume the previous volta was supposed to end before us (open volta case) -> insert the end
                                     // Warning: This might "break" a volta prematurely if its explicit notated end is later than this point

--- a/mscore/editlyrics.cpp
+++ b/mscore/editlyrics.cpp
@@ -402,10 +402,6 @@ void ScoreView::lyricsUnderscore()
                         break;
                   }
             segment = segment->prev1(SegmentType::ChordRest);
-            // if the segment has a rest in this track, stop going back
-            Element* e = segment ? segment->element(track) : 0;
-            if (e && !e->isChord())
-                  break;
             }
 
       // one-chord melisma?


### PR DESCRIPTION
Actually more across rests, i.e. not starting or ending at a rest. Once added and saved they show in older (like 3.6.2) and newer (like 4.7.4) versions too, so this seems pretty backwards compatible.

Backport of #34013, 1st and 2nd to last commit only (and in reverse order), as the other commits don't seem to apply to 3.x

Resolves: [musescore#33735](https://www.github.com/musescore/MuseScore/issues/33735)