### PR TITLE
External Notation Font: Reload when switching fonts (useful for when …

### DIFF
--- a/libmscore/sym.cpp
+++ b/libmscore/sym.cpp
@@ -19,7 +19,6 @@
 
 #include "mscore/preferences.h"
 
-
 #include FT_GLYPH_H
 #include FT_IMAGE_H
 #include FT_BBOX_H
@@ -6648,7 +6647,7 @@ void ScoreFont::scanUserFonts(const QString& path, bool system)
                   QByteArray name = fontName.toLocal8Bit();
                   QByteArray dp = fontDirPath.toLocal8Bit();
                   QByteArray fn = fontFilename.toLocal8Bit();
-                  userfonts << Ms::ScoreFont(name.data(), name.data(), dp.data(), fn.data());
+                  userfonts << Ms::ScoreFont(name.data(), name.data(), dp.data(), fn.data(), true);
                   }
             }
 
@@ -7086,6 +7085,11 @@ void ScoreFont::load(bool system)
                   }
             }
 #endif
+      if (face) {
+            QString converted(face->family_name);
+            _family = converted;
+            }
+
       }
 
 //---------------------------------------------------------
@@ -7109,7 +7113,7 @@ ScoreFont* ScoreFont::fontFactory(QString s)
             return fallbackFont();
             }
 
-      if (!f->face)
+      if (!f->face || f->isExternal())
             f->load();
       return f;
       }
@@ -7283,6 +7287,7 @@ ScoreFont::ScoreFont(const ScoreFont& f)
       _family   = f._family;
       _fontPath = f._fontPath;
       _filename = f._filename;
+      _external = f._external;
 
       // fontImage;
       cache = 0;

--- a/libmscore/sym.h
+++ b/libmscore/sym.h
@@ -3157,6 +3157,7 @@ class ScoreFont {
       std::list<std::pair<Sid, QVariant>> _engravingDefaults;
       double _textEnclosureThickness = 0;
       mutable QFont* font { 0 };
+      bool _external { false };
 
       static QVector<ScoreFont> _builtinScoreFonts;
       static QVector<ScoreFont> _userScoreFonts;
@@ -3169,10 +3170,12 @@ class ScoreFont {
    public:
       ScoreFont() {}
       ScoreFont(const ScoreFont&);
-      ScoreFont(const char* n, const char* f, const char* p, const char* fn)
-         : _name(n), _family(f), _fontPath(p), _filename(fn) {
+      ScoreFont(const char* n, const char* f, const char* p, const char* fn, bool external = false)
+         : _name(n), _family(f), _fontPath(p), _filename(fn), _external(external) {
             _symbols = QVector<Sym>(int(SymId::lastSym) + 1);
             }
+
+      ScoreFont& operator=(const Ms::ScoreFont&)=default;
       ~ScoreFont();
 
       const QString& name() const           { return _name;   }
@@ -3225,6 +3228,7 @@ class ScoreFont {
 
       bool isValid(SymId id) const                    { return sym(id).isValid(); }
       bool useFallbackFont(SymId id) const;
+      bool isExternal() const { return _external; }
 
       Sym sym(SymId id) const;
       };


### PR DESCRIPTION
…doing glyph updates)

Your mentioning SMuFL fonts reminded me:  Here's an update that will reload an external font every time there's a font change in the style settings. That way, if you update the font itself, the update will get shown as soon as the user switches to another font and back to the desired font again. Figured I'd shoot this over to you. Might be useful for anyone trying to make their own font or whatever.