### PR TITLE
Added nullptr check to avoid crash in Score::cmdToggleLayoutBreak

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -3948,7 +3948,8 @@ void Score::cmdToggleLayoutBreak(LayoutBreak::Type type)
                               // if measure is mmrest, then propagate to last original measure
                               if (measure)
                                     mb = measure->isMMRest() ? measure->mmRestLast() : measure;
-                              allNoBreaks = mb->noBreak();
+                              if (mb)
+                                    allNoBreaks = mb->noBreak();
                               }
                         }
                   }


### PR DESCRIPTION
Resolves: https://github.com/Jojo-Schmitz/MuseScore/issues/1243

In cmd.cpp, in `void Score::cmdToggleLayoutBreak(LayoutBreak::Type type)`, a nullptr check is missing. This leads to a crash due to nullptr dereference when one tries to add a system break while a slur is selected (and possibly also in other situations).

This PR fixes the crash by adding a nullptr check. In the situation described in the ticket, the app would then just do nothing instead of crashing.
I am not deeply enough into the code to assess whether anything else should actually be done here.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
