### PR TITLE
[MusicXML] improve handling of alter values

### DIFF
--- a/importexport/musicxml/exportxml.cpp
+++ b/importexport/musicxml/exportxml.cpp
@@ -3923,21 +3923,11 @@ static void writePitch(XmlWriter& xml, const Note* const note, const bool useDru
       xml.stag(useDrumset ? "unpitched" : "pitch");
       xml.tag(useDrumset  ? "display-step" : "step", step);
       // Check for microtonal accidentals and overwrite "alter" tag
-      const Accidental* acc = note->accidental();
-      double microtonalAlter  = 0.0;
-      if (acc) {
-            switch (acc->accidentalType()) {
-                  case AccidentalType::MIRRORED_FLAT:  microtonalAlter  = -0.5; break;
-                  case AccidentalType::SHARP_SLASH:    microtonalAlter  =  0.5; break;
-                  case AccidentalType::MIRRORED_FLAT2: microtonalAlter  = -1.5; break;
-                  case AccidentalType::SHARP_SLASH4:   microtonalAlter  =  1.5; break;
-                  default:                                                      break;
-                  }
-            }
-      // Override accidental with explicit note tuning
+      qreal microtonalAlter = note->centOffset() / 100.0;
+      // Explicit note tuning
       qreal tuning = note->tuning();
       if (!qFuzzyIsNull(tuning))
-            microtonalAlter  = tuning / 100.0;
+            microtonalAlter += tuning / 100.0;
       if (alter || microtonalAlter )
             xml.tag("alter", alter + microtonalAlter );
       xml.tag(useDrumset ? "display-octave" : "octave", octave);

--- a/importexport/musicxml/importmxmlnotepitch.cpp
+++ b/importexport/musicxml/importmxmlnotepitch.cpp
@@ -118,7 +118,7 @@ void mxmlNotePitch::pitch(QXmlStreamReader& e)
             if (e.name() == "alter") {
                   const QString alter = e.readElementText();
                   bool ok;
-                  _alter = MxmlSupport::stringToInt(alter, &ok);       // fractions not supported by mscore
+                  _alter = MxmlSupport::stringToInt(alter, &ok);
                   if (!ok || _alter < -2 || _alter > 2) {
                         _logger->logError(QString("invalid alter '%1'").arg(alter), &e);
                         bool ok2;

--- a/importexport/musicxml/musicxmlsupport.cpp
+++ b/importexport/musicxml/musicxmlsupport.cpp
@@ -21,6 +21,7 @@
  MusicXML support.
  */
 
+#include "libmscore/accidental.h"
 #include "libmscore/articulation.h"
 #include "libmscore/chord.h"
 #include "libmscore/sym.h"
@@ -745,52 +746,23 @@ QString mxmlAccidentalTextToChar(const QString mxmlName)
       }
 
 //---------------------------------------------------------
-//   isAppr
-//---------------------------------------------------------
-
-/**
- Check if v approximately equals ref.
- Used to prevent floating point comparison for equality from failing
- */
-
-static bool isAppr(const double v, const double ref, const double epsilon)
-      {
-      return v > ref - epsilon && v < ref + epsilon;
-      }
-
-//---------------------------------------------------------
 //   microtonalGuess
 //---------------------------------------------------------
 
 /**
  Convert a MusicXML alter tag into a microtonal accidental in MuseScore enum AccidentalType.
- Works only for quarter tone, half tone, three-quarters tone and whole tone accidentals.
  */
 
 AccidentalType microtonalGuess(double val)
       {
-      const double eps = 0.001;
-      if (isAppr(val, -2, eps))
-            return AccidentalType::FLAT2;
-      else if (isAppr(val, -1.5, eps))
-            return AccidentalType::MIRRORED_FLAT2;
-      else if (isAppr(val, -1, eps))
-            return AccidentalType::FLAT;
-      else if (isAppr(val, -0.5, eps))
-            return AccidentalType::MIRRORED_FLAT;
-      else if (isAppr(val, 0, eps))
-            return AccidentalType::NATURAL;
-      else if (isAppr(val, 0.5, eps))
-            return AccidentalType::SHARP_SLASH;
-      else if (isAppr(val, 1, eps))
-            return AccidentalType::SHARP;
-      else if (isAppr(val, 1.5, eps))
-            return AccidentalType::SHARP_SLASH4;
-      else if (isAppr(val, 2, eps))
-            return AccidentalType::SHARP2;
-      else
-            qDebug("Guess for microtonal accidental corresponding to value %f failed.", val);        // TODO
+      for (int i = 1; i < static_cast<int>(AccidentalType::END); ++i) {
+            AccidentalType type = static_cast<AccidentalType>(i);
+            double altVal = static_cast<int>(Accidental::subtype2value(type)) + Accidental::subtype2centOffset(type) / 100.0;
+            if (qFuzzyCompare(val, altVal))
+                  return type;
+            }
 
+      qDebug("Guess for microtonal accidental corresponding to value %f failed.", val);
       // default
       return AccidentalType::NONE;
       }

--- a/libmscore/accidental.cpp
+++ b/libmscore/accidental.cpp
@@ -48,25 +48,25 @@ static Acc accList[] = {
       Acc(AccidentalVal::SHARP,      0, SymId::accidentalNaturalSharp), // NATURAL_SHARP
       Acc(AccidentalVal::SHARP2,     0, SymId::accidentalSharpSharp),   // SHARP_SHARP
 
+      // Stein-Zimmermann
+      Acc(AccidentalVal::NATURAL,   -50, SymId::accidentalQuarterToneFlatStein), // MIRRORED_FLAT
+      Acc(AccidentalVal::NATURAL,  -150, SymId::accidentalThreeQuarterTonesFlatZimmermann), // MIRRORED_FLAT2
+      Acc(AccidentalVal::NATURAL,    50, SymId::accidentalQuarterToneSharpStein),       // SHARP_SLASH
+      Acc(AccidentalVal::NATURAL,   150, SymId::accidentalThreeQuarterTonesSharpStein), // SHARP_SLASH4
+
       // Gould arrow quartertone
-      Acc(AccidentalVal::NATURAL,   -50, SymId::accidentalQuarterToneFlatArrowUp),        // FLAT_ARROW_UP
-      Acc(AccidentalVal::NATURAL,  -150, SymId::accidentalThreeQuarterTonesFlatArrowDown),// FLAT_ARROW_DOWN
-      Acc(AccidentalVal::NATURAL,    50, SymId::accidentalQuarterToneSharpNaturalArrowUp),// NATURAL_ARROW_UP
+      Acc(AccidentalVal::NATURAL,   -50, SymId::accidentalQuarterToneFlatArrowUp),          // FLAT_ARROW_UP
+      Acc(AccidentalVal::NATURAL,  -150, SymId::accidentalThreeQuarterTonesFlatArrowDown),  // FLAT_ARROW_DOWN
+      Acc(AccidentalVal::NATURAL,    50, SymId::accidentalQuarterToneSharpNaturalArrowUp),  // NATURAL_ARROW_UP
       Acc(AccidentalVal::NATURAL,   -50, SymId::accidentalQuarterToneFlatNaturalArrowDown), // NATURAL_ARROW_DOWN
-      Acc(AccidentalVal::NATURAL,   150, SymId::accidentalThreeQuarterTonesSharpArrowUp), // SHARP_ARROW_UP
-      Acc(AccidentalVal::NATURAL,    50, SymId::accidentalQuarterToneSharpArrowDown),     // SHARP_ARROW_DOWN
+      Acc(AccidentalVal::NATURAL,   150, SymId::accidentalThreeQuarterTonesSharpArrowUp),   // SHARP_ARROW_UP
+      Acc(AccidentalVal::NATURAL,    50, SymId::accidentalQuarterToneSharpArrowDown),       // SHARP_ARROW_DOWN
       Acc(AccidentalVal::NATURAL,   250, SymId::accidentalFiveQuarterTonesSharpArrowUp),    // SHARP2_ARROW_UP
       Acc(AccidentalVal::NATURAL,   150, SymId::accidentalThreeQuarterTonesSharpArrowDown), // SHARP2_ARROW_DOWN
       Acc(AccidentalVal::NATURAL,  -150, SymId::accidentalThreeQuarterTonesFlatArrowUp),    // FLAT2_ARROW_UP
       Acc(AccidentalVal::NATURAL,  -250, SymId::accidentalFiveQuarterTonesFlatArrowDown),   // FLAT2_ARROW_DOWN
       Acc(AccidentalVal::NATURAL,   -50, SymId::accidentalArrowDown), // ARROW_DOWN
       Acc(AccidentalVal::NATURAL,    50, SymId::accidentalArrowUp),   // ARROW_UP
-
-      // Stein-Zimmermann
-      Acc(AccidentalVal::NATURAL,   -50, SymId::accidentalQuarterToneFlatStein), // MIRRORED_FLAT
-      Acc(AccidentalVal::NATURAL,  -150, SymId::accidentalThreeQuarterTonesFlatZimmermann), // MIRRORED_FLAT2
-      Acc(AccidentalVal::NATURAL,    50, SymId::accidentalQuarterToneSharpStein),       // SHARP_SLASH
-      Acc(AccidentalVal::NATURAL,   150, SymId::accidentalThreeQuarterTonesSharpStein), // SHARP_SLASH4
 
       // Arel-Ezgi-Uzdilek (AEU)
       Acc(AccidentalVal::NATURAL,   -89, SymId::accidentalBuyukMucennebFlat),  // FLAT_SLASH2
@@ -342,12 +342,27 @@ AccidentalType Accidental::name2subtype(const QString& tag)
       }
 
 //---------------------------------------------------------
+//   subtype2centoffset
+//---------------------------------------------------------
+
+qreal Accidental::subtype2centOffset(AccidentalType st)
+      {
+      return accList[int(st)].centOffset;
+      }
+//---------------------------------------------------------
 //   setSubtype
 //---------------------------------------------------------
 
 void Accidental::setSubtype(const QString& tag)
       {
       setAccidentalType(name2subtype(tag));
+      }
+
+void Accidental::setAccidentalType(AccidentalType t)
+      {
+      _accidentalType = t;
+      if (note())
+            note()->setCentOffset(Accidental::subtype2centOffset(t));
       }
 
 //---------------------------------------------------------

--- a/libmscore/accidental.h
+++ b/libmscore/accidental.h
@@ -82,7 +82,7 @@ class Accidental final : public Element {
 
       QString subtypeUserName() const;
       void setSubtype(const QString& s);
-      void setAccidentalType(AccidentalType t)     { _accidentalType = t;    }
+      void setAccidentalType(AccidentalType t);
 
       AccidentalType accidentalType() const        { return _accidentalType; }
       AccidentalRole role() const                  { return _role;           }
@@ -127,6 +127,7 @@ class Accidental final : public Element {
       static AccidentalType value2subtype(AccidentalVal);
       static AccidentalType name2subtype(const QString&);
       static bool isMicrotonal(AccidentalType t)  { return t > AccidentalType::FLAT3; }
+      static qreal subtype2centOffset(AccidentalType);
 
       QString accessibleInfo() const override;
       };

--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -717,6 +717,7 @@ Note::Note(const Note& n, bool link)
       _ghost             = n._ghost;
       dragMode           = n.dragMode;
       _pitch             = n._pitch;
+      _centOffset        = n._centOffset;
       _tpc[0]            = n._tpc[0];
       _tpc[1]            = n._tpc[1];
       _dotsHidden        = n._dotsHidden;

--- a/libmscore/note.h
+++ b/libmscore/note.h
@@ -292,6 +292,7 @@ class Note final : public Element {
       int _string         { -1 };
       mutable int _tpc[2] { Tpc::TPC_INVALID, Tpc::TPC_INVALID }; ///< tonal pitch class  (concert/transposing)
       mutable int _pitch  { 0  };   ///< Note pitch as midi value (0 - 127).
+      mutable qreal _centOffset = 0.0; // Pitch offset in cents (100 cents = 1 semitone)
 
       int _veloOffset     { 0 };    ///< velocity user offset in percent, or absolute velocity for this note
       int _fixedLine      { 0 };    // fixed line number if _fixed == true
@@ -378,6 +379,10 @@ class Note final : public Element {
       void setPitch(int val);
       void setPitch(int pitch, int tpc1, int tpc2);
       int pitch() const                   { return _pitch;    }
+
+      qreal centOffset() const            { return _centOffset; }
+      void setCentOffset(double v)        { _centOffset = v;  }
+
       int ottaveCapoFret() const;
       int ppitch() const;           ///< playback pitch
       int epitch() const;           ///< effective pitch

--- a/libmscore/types.h
+++ b/libmscore/types.h
@@ -162,6 +162,12 @@ enum class AccidentalType : unsigned char{
       NATURAL_SHARP,
       SHARP_SHARP,
 
+      // Stein-Zimmermann
+      MIRRORED_FLAT,
+      MIRRORED_FLAT2,
+      SHARP_SLASH,
+      SHARP_SLASH4,
+
       // Gould arrow quartertone
       FLAT_ARROW_UP,
       FLAT_ARROW_DOWN,
@@ -175,12 +181,6 @@ enum class AccidentalType : unsigned char{
       FLAT2_ARROW_DOWN,
       ARROW_DOWN,
       ARROW_UP,
-
-      // Stein-Zimmermann
-      MIRRORED_FLAT,
-      MIRRORED_FLAT2,
-      SHARP_SLASH,
-      SHARP_SLASH4,
 
       // Arel-Ezgi-Uzdilek (AEU)
       FLAT_SLASH2,


### PR DESCRIPTION
Backport of #34379

Plus some needed infrastructure: `Accidental::subtype2centoffset()`, `Note::centOffset()`, `Note::setCentOffset()` and an `Accidental::setSubtype()` that makes use of the latter