### PR TITLE
Add string data to violin, viola and violoncello

### DIFF
--- a/mtest/musicxml/io/testFinaleInstr2_ref.mscx
+++ b/mtest/musicxml/io/testFinaleInstr2_ref.mscx
@@ -65,6 +65,13 @@
         <minPitchA>55</minPitchA>
         <maxPitchA>88</maxPitchA>
         <instrumentId>strings.violin</instrumentId>
+        <StringData>
+          <frets>24</frets>
+          <string>55</string>
+          <string>62</string>
+          <string>69</string>
+          <string>76</string>
+          </StringData>
         <Articulation>
           <velocity>100</velocity>
           <gateTime>100</gateTime>
@@ -141,6 +148,13 @@
         <minPitchA>55</minPitchA>
         <maxPitchA>88</maxPitchA>
         <instrumentId>strings.violin</instrumentId>
+        <StringData>
+          <frets>24</frets>
+          <string>55</string>
+          <string>62</string>
+          <string>69</string>
+          <string>76</string>
+          </StringData>
         <Articulation>
           <velocity>100</velocity>
           <gateTime>100</gateTime>
@@ -220,6 +234,13 @@
         <maxPitchA>79</maxPitchA>
         <instrumentId>strings.viola</instrumentId>
         <clef>C3</clef>
+        <StringData>
+          <frets>24</frets>
+          <string>48</string>
+          <string>55</string>
+          <string>62</string>
+          <string>69</string>
+          </StringData>
         <Articulation>
           <velocity>100</velocity>
           <gateTime>100</gateTime>
@@ -297,6 +318,13 @@
         <maxPitchA>79</maxPitchA>
         <instrumentId>strings.viola</instrumentId>
         <clef>C3</clef>
+        <StringData>
+          <frets>24</frets>
+          <string>48</string>
+          <string>55</string>
+          <string>62</string>
+          <string>69</string>
+          </StringData>
         <Articulation>
           <velocity>100</velocity>
           <gateTime>100</gateTime>
@@ -376,6 +404,13 @@
         <maxPitchA>79</maxPitchA>
         <instrumentId>strings.viola</instrumentId>
         <clef>C3</clef>
+        <StringData>
+          <frets>24</frets>
+          <string>48</string>
+          <string>55</string>
+          <string>62</string>
+          <string>69</string>
+          </StringData>
         <Articulation>
           <velocity>100</velocity>
           <gateTime>100</gateTime>
@@ -454,6 +489,13 @@
         <maxPitchA>67</maxPitchA>
         <instrumentId>strings.cello</instrumentId>
         <clef>F</clef>
+        <StringData>
+          <frets>24</frets>
+          <string>36</string>
+          <string>43</string>
+          <string>50</string>
+          <string>57</string>
+          </StringData>
         <Articulation>
           <velocity>100</velocity>
           <gateTime>100</gateTime>
@@ -531,6 +573,13 @@
         <maxPitchA>79</maxPitchA>
         <instrumentId>strings.viola</instrumentId>
         <clef>C3</clef>
+        <StringData>
+          <frets>24</frets>
+          <string>48</string>
+          <string>55</string>
+          <string>62</string>
+          <string>69</string>
+          </StringData>
         <Articulation>
           <velocity>100</velocity>
           <gateTime>100</gateTime>

--- a/mtest/musicxml/io/testNoteAttributes2_ref.mscx
+++ b/mtest/musicxml/io/testNoteAttributes2_ref.mscx
@@ -39,6 +39,13 @@
         <minPitchA>55</minPitchA>
         <maxPitchA>88</maxPitchA>
         <instrumentId>strings.violin</instrumentId>
+        <StringData>
+          <frets>24</frets>
+          <string>55</string>
+          <string>62</string>
+          <string>69</string>
+          <string>76</string>
+          </StringData>
         <Articulation>
           <velocity>100</velocity>
           <gateTime>100</gateTime>

--- a/mtest/musicxml/io/testNoteflightStartRepeatBarline_ref.mscx
+++ b/mtest/musicxml/io/testNoteflightStartRepeatBarline_ref.mscx
@@ -51,6 +51,13 @@
         <minPitchA>55</minPitchA>
         <maxPitchA>88</maxPitchA>
         <instrumentId>strings.violin</instrumentId>
+        <StringData>
+          <frets>24</frets>
+          <string>55</string>
+          <string>62</string>
+          <string>69</string>
+          <string>76</string>
+          </StringData>
         <Articulation>
           <velocity>100</velocity>
           <gateTime>100</gateTime>

--- a/mtest/musicxml/io/testStringmute_ref.mscx
+++ b/mtest/musicxml/io/testStringmute_ref.mscx
@@ -40,6 +40,13 @@
         <minPitchA>55</minPitchA>
         <maxPitchA>88</maxPitchA>
         <instrumentId>strings.violin</instrumentId>
+        <StringData>
+          <frets>24</frets>
+          <string>55</string>
+          <string>62</string>
+          <string>69</string>
+          <string>76</string>
+          </StringData>
         <Articulation>
           <velocity>100</velocity>
           <gateTime>100</gateTime>

--- a/share/instruments/instruments.xml
+++ b/share/instruments/instruments.xml
@@ -13984,6 +13984,13 @@ Aeolus organ synthesizer, currently disabled -->
                   <barlineSpan>1</barlineSpan>
                   <aPitchRange>55-88</aPitchRange>
                   <pPitchRange>55-103</pPitchRange>
+                  <StringData>
+                        <frets>24</frets>
+                        <string>55</string>
+                        <string>62</string>
+                        <string>69</string>
+                        <string>76</string>
+                  </StringData>
                   <glissandoStyle>portamento</glissandoStyle>
                   <Channel name="arco">
                         <!--MIDI: Bank 0, Prog 40; MS General: Violin-->
@@ -14045,6 +14052,13 @@ Aeolus organ synthesizer, currently disabled -->
                   <barlineSpan>1</barlineSpan>
                   <aPitchRange>48-79</aPitchRange>
                   <pPitchRange>48-93</pPitchRange>
+                  <StringData>
+                        <frets>24</frets>
+                       <string>48</string>
+                        <string>55</string>
+                        <string>62</string>
+                        <string>69</string>
+                  </StringData>
                   <glissandoStyle>portamento</glissandoStyle>
                   <Channel name="arco">
                         <!--MIDI: Bank 0, Prog 41; MS General: Viola-->
@@ -14105,6 +14119,13 @@ Aeolus organ synthesizer, currently disabled -->
                   <barlineSpan>1</barlineSpan>
                   <aPitchRange>36-67</aPitchRange>
                   <pPitchRange>36-90</pPitchRange>
+                  <StringData>
+                        <frets>24</frets>
+                        <string>36</string>
+                        <string>43</string>
+                        <string>50</string>
+                        <string>57</string>
+                  </StringData>
                   <glissandoStyle>portamento</glissandoStyle>
                   <Channel name="arco">
                         <!--MIDI: Bank 0, Prog 42; MS General: Cello-->


### PR DESCRIPTION
as taken from the string quartet template and to allow for tablature notation.

Resolves: [musescore#22499](https://www.github.com/musescore/MuseScore/issues/22499)