### PR TITLE
Persist count-in setting

### DIFF
--- a/global/settings/types/preferencekeys.h
+++ b/global/settings/types/preferencekeys.h
@@ -44,6 +44,7 @@
 #define PREF_APP_PATHS_MYEXTENSIONS                         "application/paths/myExtensions"
 #define PREF_APP_PLAYBACK_FOLLOWSONG                        "application/playback/followSong"
 #define PREF_APP_PLAYBACK_HIGHLIGHT                         "application/playback/highlight"
+#define PREF_APP_PLAYBACK_COUNTIN                           "application/playback/countin"
 #define PREF_APP_PLAYBACK_PANPLAYBACK                       "application/playback/panPlayback"
 #define PREF_APP_PLAYBACK_PLAYREPEATS                       "application/playback/playRepeats"
 #define PREF_APP_PLAYBACK_SPEEDINCREMENT                    "application/playback/speedIncrement"

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -495,6 +495,7 @@ void MuseScore::preferencesChanged(bool fromWorkspace, bool changeUI)
       getAction("pan")->setChecked(MScore::panPlayback);
       getAction("follow")->setChecked(preferences.getBool(PREF_APP_PLAYBACK_FOLLOWSONG));
       getAction("playback-highlight")->setChecked(preferences.getBool(PREF_APP_PLAYBACK_HIGHLIGHT));
+      getAction("countin")->setChecked(preferences.getBool(PREF_APP_PLAYBACK_COUNTIN));
       getAction("midi-on")->setChecked(preferences.getBool(PREF_IO_MIDI_ENABLEINPUT));
       getAction("toggle-statusbar")->setChecked(preferences.getBool(PREF_UI_APP_SHOWSTATUSBAR));
       getAction("show-tours")->setChecked(preferences.getBool(PREF_UI_APP_STARTUP_SHOWTOURS));
@@ -6422,6 +6423,8 @@ void MuseScore::cmd(QAction* a, const QString& cmd)
             preferences.setPreference(PREF_APP_PLAYBACK_FOLLOWSONG, a->isChecked());
       else if (cmd == "playback-highlight")
             preferences.setPreference(PREF_APP_PLAYBACK_HIGHLIGHT, a->isChecked());
+      else if (cmd == "countin")
+            preferences.setPreference(PREF_APP_PLAYBACK_COUNTIN, a->isChecked());
       else if (cmd == "split-h")
             splitWindow(true);
       else if (cmd == "split-v")

--- a/mscore/preferences.cpp
+++ b/mscore/preferences.cpp
@@ -143,6 +143,7 @@ void Preferences::init(bool storeInMemoryOnly)
             {PREF_APP_PATHS_MYEXTENSIONS,                          new StringPreference(QFileInfo(QString("%1/%2").arg(wd, QCoreApplication::translate("extensions_directory", "Extensions"))).absoluteFilePath(), false)},
             {PREF_APP_PLAYBACK_FOLLOWSONG,                         new BoolPreference(true)},
             {PREF_APP_PLAYBACK_HIGHLIGHT,                          new BoolPreference(true)},
+            {PREF_APP_PLAYBACK_COUNTIN,                            new BoolPreference(false)},
             {PREF_APP_PLAYBACK_PANPLAYBACK,                        new BoolPreference(true, false)},
             {PREF_APP_PLAYBACK_PLAYREPEATS,                        new BoolPreference(true, false)},
             {PREF_APP_PLAYBACK_SPEEDINCREMENT,                     new IntPreference(5)},


### PR DESCRIPTION
By including the countin action in the MuseScore preferences, we make sure the state of the countin toggle is remembered across sessions.

Resolves: The countin action state now survives restart of MuseScore

The countin action is now included in te preferences system - following the recent 'playback-highlight' prefernce as a template. Difference with the template is that te countin is by default switched off, to make it consistent with the present behavious of MuseScore 3.x.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x ] I signed [CLA](https://musescore.org/en/cla)
- [ x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [ x] I made sure the code compiles on my machine
- [ x] I made sure there are no unnecessary changes in the code
- [ x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x ] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x ] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made

I have not created a test script, but visually confirmed that the toggle works as expected, and that its state survives exiting and restarting MuseScore.