### PR TITLE
Remove leftover QtWebEngineProcess install on non-Apple Unix

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -228,21 +228,6 @@ if (MINGW)
 else (MINGW)
 
    if ( NOT MSVC )
-      ## install qwebengine core
-      if (NOT APPLE)
-         install(PROGRAMS
-            ${QT_INSTALL_LIBEXECS}/QtWebEngineProcess
-            DESTINATION bin
-            )
-         install(DIRECTORY
-            ${QT_INSTALL_DATA}/resources
-            DESTINATION lib/qt5
-            )
-         install(DIRECTORY
-            ${QT_INSTALL_TRANSLATIONS}/qtwebengine_locales
-            DESTINATION lib/qt5/translations
-            )
-      endif(NOT APPLE)
 
       set_target_properties (
          mscore


### PR DESCRIPTION
WebEngine support was removed in eea2c0d, but main/CMakeLists.txt still 
unconditionally installed QtWebEngineProcess and related resources on 
non-Apple Unix. That breaks `cmake --install` when Qt WebEngine is not 
present in the prefix.

As WebEngine support was already removed, this commit finishes that cleanup 
by deleting the leftover install rules rather than restoring a
BUILD_WEBENGINE/USE_WEBENGINE toggle. 

Official Linux/AppImage builds still ship Qt WebEngine in the prefix and are 
left unchanged; this only fixes `cmake --install` when Qt WebEngine is not 
present in the prefix.