### PR TITLE
Fix section break pauses with repeats and jumps

### DIFF
--- a/audio/exports/exportmidi.cpp
+++ b/audio/exports/exportmidi.cpp
@@ -485,6 +485,17 @@ void ExportMidi::PauseMap::calculate(const Score* s)
                               }
                         }
                   }
+            if (!qFuzzyIsNull(rs->pause)) {
+                  int utick = rs->utick + rs->len();
+
+                  Fraction timeSig(sigmap->timesig(endTick).timesig());
+                  qreal quarterNotesPerMeasure = (4.0 * timeSig.numerator()) / timeSig.denominator();
+                  int ticksPerMeasure = quarterNotesPerMeasure * DIVISION;
+
+                  tempomapWithPauses->setTempo(this->addPauseTicks(utick), quarterNotesPerMeasure / rs->pause);
+                  this->insert(std::pair<const int, int> (utick, ticksPerMeasure + this->offsetAtUTick(utick)));
+                  tempomapWithPauses->setTempo(this->addPauseTicks(utick), tempomap->tempo(endTick));
+                  }
             }
       }
 

--- a/libmscore/repeatlist.cpp
+++ b/libmscore/repeatlist.cpp
@@ -163,6 +163,7 @@ void RepeatList::updateTempo()
             s->timeOffset = t - ct;
             utick        += s->len();
             t            += tl->tick2time(s->tick + s->len()) - ct;
+            t            += s->pause;
             }
       }
 
@@ -751,6 +752,34 @@ void RepeatList::unwind()
             return;
 
       collectRepeatListElements();
+      QList<std::pair<Measure const*, qreal>> sectionPauses;
+      for (auto sectionIt = _rlElements.cbegin();
+           sectionIt != _rlElements.cend();
+           ++sectionIt) {
+            auto nextSectionIt = sectionIt + 1;
+            if (nextSectionIt == _rlElements.cend())
+                  break;
+
+            Q_ASSERT(!(*sectionIt)->isEmpty());
+
+            auto lastElementIt = (*sectionIt)->cend() - 1;
+            Q_ASSERT((*lastElementIt)->repeatListElementType
+                     == RepeatListElementType::SECTION_BREAK);
+
+            LayoutBreak const* sectionBreak =
+                toMeasureBase((*lastElementIt)->element)->sectionBreakElement();
+
+            if (sectionBreak != nullptr) {
+                  Q_ASSERT(!(*nextSectionIt)->isEmpty());
+
+                  Measure const* nextSectionMeasure =
+                      (*nextSectionIt)->front()->measure;
+
+                  sectionPauses.append(
+                      std::make_pair(nextSectionMeasure,
+                                     sectionBreak->pause()));
+                  }
+            }
 
       // Following variables are used during unwinding, but may be altered when following jumps
       // Therefor they are declared outside of the loop
@@ -999,15 +1028,22 @@ void RepeatList::unwind()
                   ++repeatListElementIt;
                   }
 
-            // Reached the end of this section
-            // Inform the last RepeatSegment that the Section Break pause property should be honored now
-            rs = this->back();
-            repeatListElementIt = (*sectionIt)->cend() - 1;
-            Q_ASSERT((*repeatListElementIt)->repeatListElementType == RepeatListElementType::SECTION_BREAK);
+            }
 
-            LayoutBreak const * const sectionBreak = toMeasureBase((*repeatListElementIt)->element)->sectionBreakElement();
-            if (sectionBreak != nullptr) {
-                  rs->pause = sectionBreak->pause();
+      // Assign each section break pause to the RepeatSegment immediately
+      // preceding the first unwound occurrence of the following section.
+      for (const auto& sectionPause : sectionPauses) {
+            Measure const* sectionStart = sectionPause.first;
+            qreal pause = sectionPause.second;
+
+            for (int i = 1; i < size(); ++i) {
+                  RepeatSegment* current = at(i);
+
+                  if (!current->measureList.isEmpty()
+                      && current->measureList.front()->tick() == sectionStart->tick()) {
+                        at(i - 1)->pause = pause;
+                        break;
+                        }
                   }
             }
 

--- a/libmscore/repeatlist.cpp
+++ b/libmscore/repeatlist.cpp
@@ -752,34 +752,6 @@ void RepeatList::unwind()
             return;
 
       collectRepeatListElements();
-      QList<std::pair<Measure const*, qreal>> sectionPauses;
-      for (auto sectionIt = _rlElements.cbegin();
-           sectionIt != _rlElements.cend();
-           ++sectionIt) {
-            auto nextSectionIt = sectionIt + 1;
-            if (nextSectionIt == _rlElements.cend())
-                  break;
-
-            Q_ASSERT(!(*sectionIt)->isEmpty());
-
-            auto lastElementIt = (*sectionIt)->cend() - 1;
-            Q_ASSERT((*lastElementIt)->repeatListElementType
-                     == RepeatListElementType::SECTION_BREAK);
-
-            LayoutBreak const* sectionBreak =
-                toMeasureBase((*lastElementIt)->element)->sectionBreakElement();
-
-            if (sectionBreak) {
-                  Q_ASSERT(!(*nextSectionIt)->isEmpty());
-
-                  Measure const* nextSectionMeasure =
-                      (*nextSectionIt)->front()->measure;
-
-                  sectionPauses.append(
-                      std::make_pair(nextSectionMeasure,
-                                     sectionBreak->pause()));
-                  }
-            }
 
       // Following variables are used during unwinding, but may be altered when following jumps
       // Therefor they are declared outside of the loop
@@ -1028,23 +1000,17 @@ void RepeatList::unwind()
                   ++repeatListElementIt;
                   }
 
-            }
+            rs = this->back();
+            repeatListElementIt = (*sectionIt)->cend() - 1;
+            Q_ASSERT((*repeatListElementIt)->repeatListElementType
+                     == RepeatListElementType::SECTION_BREAK);
 
-      // Assign each section break pause to the RepeatSegment immediately
-      // preceding the first unwound occurrence of the following section.
-      for (const auto& sectionPause : sectionPauses) {
-            Measure const* sectionStart = sectionPause.first;
-            qreal pause = sectionPause.second;
+            LayoutBreak const* sectionBreak =
+                toMeasureBase((*repeatListElementIt)->element)->sectionBreakElement();
 
-            for (int i = 1; i < size(); ++i) {
-                  RepeatSegment* current = at(i);
+            if (sectionBreak)
+                  rs->pause = sectionBreak->pause();
 
-                  if (!current->measureList.isEmpty()
-                      && current->measureList.front()->tick() == sectionStart->tick()) {
-                        at(i - 1)->pause = pause;
-                        break;
-                        }
-                  }
             }
 
       updateTempo();

--- a/libmscore/repeatlist.cpp
+++ b/libmscore/repeatlist.cpp
@@ -1000,17 +1000,16 @@ void RepeatList::unwind()
                   ++repeatListElementIt;
                   }
 
+            // Reached the end of this section
+            // Inform the last RepeatSegment that the Section Break pause property should be honored now
             rs = this->back();
             repeatListElementIt = (*sectionIt)->cend() - 1;
-            Q_ASSERT((*repeatListElementIt)->repeatListElementType
-                     == RepeatListElementType::SECTION_BREAK);
+            Q_ASSERT((*repeatListElementIt)->repeatListElementType == RepeatListElementType::SECTION_BREAK);
 
-            LayoutBreak const* sectionBreak =
-                toMeasureBase((*repeatListElementIt)->element)->sectionBreakElement();
-
-            if (sectionBreak)
+            LayoutBreak const * const sectionBreak = toMeasureBase((*repeatListElementIt)->element)->sectionBreakElement();
+            if (sectionBreak) {
                   rs->pause = sectionBreak->pause();
-
+                  }
             }
 
       updateTempo();

--- a/libmscore/repeatlist.cpp
+++ b/libmscore/repeatlist.cpp
@@ -769,7 +769,7 @@ void RepeatList::unwind()
             LayoutBreak const* sectionBreak =
                 toMeasureBase((*lastElementIt)->element)->sectionBreakElement();
 
-            if (sectionBreak != nullptr) {
+            if (sectionBreak) {
                   Q_ASSERT(!(*nextSectionIt)->isEmpty());
 
                   Measure const* nextSectionMeasure =

--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -462,12 +462,6 @@ void Score::rebuildTempoAndTimeSigMaps(Measure* measure)
             const Fraction& startTick = measure->tick();
             resetTempoRange(startTick, measure->endTick());
 
-            // Implement section break rest
-            for (MeasureBase* mb = measure->prev(); mb && mb->endTick() == startTick; mb = mb->prev()) {
-                  if (mb->pause())
-                        setPause(startTick, mb->pause());
-                  }
-
             // Add pauses from the end of the previous measure (at measure->tick()):
             for (Segment* s = measure->first(); s && s->tick() == startTick; s = s->prev1()) {
                   if (!s->isBreathType())


### PR DESCRIPTION
Resolves: #1275

Section break pauses were previously associated with their written score position. When playback was unwound because of repeats or jumps, this could cause the pause to occur at the wrong point in playback or more than once.

This change handles section break pauses in the unwound playback sequence instead:

- Section break pauses are no longer added to the written-score tempo map.
- During unwinding, the first measure of the section following each section break is recorded together with the pause duration.
- After the playback sequence has been fully unwound, the pause is assigned to the RepeatSegment immediately preceding the first unwound occurrence of that section.
- RepeatSegment::pause is included when calculating the unwound playback time.

This ensures, for example, that:

- a section break following a repeated passage is played only after the final pass through the repeat;
- with D.C. al Fine, a section break following the Fine is played after the Fine is reached during the D.C. playback;
- if the following section itself starts with a repeat, the section break pause occurs only when first entering that section, not when returning to its start for the repeat.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made

I did not create a test, but inspected behaviour on a file where potential problem situations were included. 
