### PR TITLE
Fix #1242: Restore the maximized state of the main window

### DIFF
--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -189,6 +189,13 @@ extern Ms::Synthesizer* createZerberus();
 #define endl Qt::endl
 #endif
 
+#if defined(Q_OS_WIN)
+// for SystemParametersInfo(SPI_GETSCREENREADER), see screenReaderActive()
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
+#include <windows.h>
+#endif
+
 namespace Ms {
 
 MuseScore* mscore;
@@ -4723,6 +4730,25 @@ void MuseScore::writeSettings()
       }
 
 //---------------------------------------------------------
+//   screenReaderActive
+//    QAccessible::isActive() only tells whether some accessibility client
+//    attached itself; on Windows that is the case even when no screen reader
+//    is running at all, so there ask the system itself
+//---------------------------------------------------------
+
+static bool screenReaderActive()
+      {
+#if defined(Q_OS_WIN)
+      BOOL screenReader = FALSE;
+      if (!SystemParametersInfo(SPI_GETSCREENREADER, 0, &screenReader, 0))
+            return false;
+      return screenReader;
+#else
+      return QAccessible::isActive();
+#endif
+      }
+
+//---------------------------------------------------------
 //   readSettings
 //---------------------------------------------------------
 
@@ -4753,6 +4779,9 @@ void MuseScore::readSettings()
             }
 
       MuseScore::restoreGeometry(this);
+      // remember the restored state: when a session gets restored the main
+      // window is shown again in init(), which would drop the maximized state
+      _startMaximized = isMaximized();
 
       // Grab the mixer visible state before the beginGroup.
       // Previously the showMixer() call was made at the end of
@@ -4767,8 +4796,9 @@ void MuseScore::readSettings()
 
       //for some reason when MuseScore starts maximized the screen-reader
       //doesn't respond to QAccessibleEvents --> so force normal mode
-      if (isMaximized() && QAccessible::isActive()) {
+      if (isMaximized() && screenReaderActive()) {
             showNormal();
+            _startMaximized = false;
             }
       mscore->showPalette(settings.value("showPanel", "1").toBool());
       mscore->showInspector(settings.value("showInspector", "1").toBool());
@@ -4780,6 +4810,7 @@ void MuseScore::readSettings()
       //if we were in full screen mode, go to maximized mode
       if (isFullScreen()) {
             showMaximized();
+            _startMaximized = true;
             }
 
       _horizontalSplit = settings.value("split", true).toBool();
@@ -8318,7 +8349,10 @@ void MuseScore::init(QStringList& argv)
 #endif
 
       mscore->changeState(mscore->noScore() ? STATE_DISABLED : STATE_NORMAL);
-      mscore->show();
+      if (mscore->_startMaximized)
+            mscore->showMaximized();
+      else
+            mscore->show();
 
       if (!restoredSession || files) {
             showSplashMessage(sc, tr("Loading scores…"));

--- a/mscore/musescore.h
+++ b/mscore/musescore.h
@@ -363,6 +363,7 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
       int _midiRecordId                  { -1 };
 
       bool _fullscreen                   { false };
+      bool _startMaximized               { false };
       QList<LanguageItem> _languages;
 
       Startcenter* startcenter             { 0 };


### PR DESCRIPTION
Resolves: #1242

On Windows the main window never opened maximized, whatever geometry was saved. Two separate things caused that:

**1. The screen-reader workaround in `readSettings()`**

`readSettings()` forced `showNormal()` whenever `QAccessible::isActive()`, as a maximized window seemed to not deliver `QAccessibleEvents` to screen readers. But `QAccessible::isActive()` only tells whether *some* accessibility client attached itself to the process, and on Windows that is the case even when no screen reader is running at all - so the workaround fired on every single start.

Rather than dropping the workaround, this asks the system itself on Windows, through `SystemParametersInfo(SPI_GETSCREENREADER, ...)`, so it keeps applying for people who actually do run a screen reader. On the other platforms `QAccessible::isActive()` is still used, so nothing changes there.

**2. `show()` after a restored session in `init()`**

Fixing 1. alone is not enough: when a session is restored, `init()` calls `mscore->show()` after `readSettings()` has restored the geometry, which drops the maximized state again. `readSettings()` now remembers whether the restored geometry was maximized (and clears that flag when the screen-reader workaround does kick in), and `init()` calls `showMaximized()` accordingly. The same flag is set where `readSettings()` already converts a saved fullscreen state to maximized, so the Ctrl+U route you mentioned in the issue keeps working too.

**Testing**

Windows 11, local MSVC 2022 / Qt 5.15.2 RelWithDebInfo build. Checked with the Win32 `GetWindowPlacement` (`showCmd == SW_SHOWMAXIMIZED`) rather than by eye: a maximized window now survives a restart, both with an empty session and with a restored session, and an unmaximized window stays unmaximized.

On that machine `SystemParametersInfo(SPI_GETSCREENREADER)` reports 0, i.e. no screen reader, so that test does not exercise the workaround itself - I have no screen reader setup to check that side, and neither macOS nor Linux. Behaviour there is unchanged apart from the added `showMaximized()` after a session restore.

---

Made with the help of Claude (Claude Code) and Codex - Codex reviewed the change and rightly pushed back on my first version, which simply deleted the accessibility workaround.
