### PR TITLE
Enable some debug commands

### DIFF
--- a/libmscore/check.cpp
+++ b/libmscore/check.cpp
@@ -179,9 +179,7 @@ bool Score::sanityCheck(const QString& name)
             for (int staffIdx = 0; staffIdx < endStaff; ++staffIdx) {
                   Rest* fmrest0 = 0;      // full measure rest in voice 0
                   Fraction voices[VOICES];
-#ifndef NDEBUG
                   m->setCorrupted(staffIdx, false);
-#endif
                   for (Segment* s = m->first(SegmentType::ChordRest); s; s = s->next(SegmentType::ChordRest)) {
                         for (int v = 0; v < VOICES; ++v) {
                               ChordRest* cr = toChordRest(s->element(staffIdx * VOICES + v));
@@ -200,9 +198,7 @@ bool Score::sanityCheck(const QString& name)
                         QString msg = QObject::tr("Measure %1, staff %2 incomplete. Expected: %3; Found: %4").arg(mNumber).arg(staffIdx + 1).arg(mLen.print(), voices[0].print());
                         qDebug() << msg;
                         error += QString("%1\n").arg(msg);
-#ifndef NDEBUG
                         m->setCorrupted(staffIdx, true);
-#endif
                         result = false;
                         // try to fix a bad full measure rest
                         if (fmrest0) {
@@ -217,9 +213,7 @@ bool Score::sanityCheck(const QString& name)
                               QString msg = QObject::tr("Measure %1, staff %2, voice %3 too long. Expected: %4; Found: %5").arg(mNumber).arg(staffIdx + 1).arg(v + 1).arg(mLen.print(), voices[v].print());
                               qDebug() << msg;
                               error += QString("%1\n").arg(msg);
-#ifndef NDEBUG
                               m->setCorrupted(staffIdx, true);
-#endif
                               result = false;
                               }
                         }

--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -94,9 +94,7 @@ class MStaff {
                                           ///< this changes some layout rules
       bool _visible          { true  };
       bool _stemless         { false };
-#ifndef NDEBUG
       bool _corrupted        { false };
-#endif
 
    public:
       MStaff()  {}
@@ -129,10 +127,8 @@ class MStaff {
       bool stemless() const          { return _stemless; }
       void setStemless(bool val)     { _stemless = val;  }
 
-#ifndef NDEBUG
       bool corrupted() const         { return _corrupted; }
       void setCorrupted(bool val)    { _corrupted = val; }
-#endif
       };
 
 MStaff::~MStaff()
@@ -154,9 +150,7 @@ MStaff::MStaff(const MStaff& m)
       _vspacerDown = 0;
       _visible     = m._visible;
       _stemless  = m._stemless;
-#ifndef NDEBUG
       _corrupted   = m._corrupted;
-#endif
       }
 
 //---------------------------------------------------------
@@ -303,10 +297,8 @@ Spacer* Measure::vspacerUp(int staffIdx) const                  { return _mstave
 void Measure::setStaffVisible(int staffIdx, bool visible)       { _mstaves[staffIdx]->setVisible(visible); }
 void Measure::setStaffStemless(int staffIdx, bool stemless)     { _mstaves[staffIdx]->setStemless(stemless); }
 
-#ifndef NDEBUG
 bool Measure::corrupted(int staffIdx) const                     { return _mstaves[staffIdx]->corrupted(); }
 void Measure::setCorrupted(int staffIdx, bool val)              { _mstaves[staffIdx]->setCorrupted(val); }
-#endif
 
 void Measure::setNoText(int staffIdx, MeasureNumber* t)         { _mstaves[staffIdx]->setNoText(t); }
 MeasureNumber* Measure::noText(int staffIdx) const              { return _mstaves[staffIdx]->noText(); }

--- a/libmscore/mscore.cpp
+++ b/libmscore/mscore.cpp
@@ -46,7 +46,6 @@ namespace Ms {
 bool MScore::debugMode = false;
 bool MScore::testMode = false;
 
-// #ifndef NDEBUG
 bool MScore::showSegmentShapes   = false;
 bool MScore::showSkylines        = false;
 bool MScore::showMeasureShapes   = false;
@@ -56,7 +55,6 @@ bool MScore::showBoundingRect    = false;
 bool MScore::showSystemBoundingRect    = false;
 bool MScore::showCorruptedMeasures = true;
 bool MScore::useFallbackFont       = true;
-// #endif
 
 bool  MScore::saveTemplateMode = false;
 bool  MScore::noGui = false;

--- a/libmscore/mscore.h
+++ b/libmscore/mscore.h
@@ -357,7 +357,6 @@ class MScore {
       static int defaultPlayDuration;
       static QString lastError;
 
-// #ifndef NDEBUG
       static bool noHorizontalStretch;
       static bool noVerticalStretch;
       static bool showSegmentShapes;
@@ -367,7 +366,6 @@ class MScore {
       static bool showSystemBoundingRect;
       static bool showCorruptedMeasures;
       static bool useFallbackFont;
-// #endif
       static bool debugMode;
       static bool testMode;
 

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -6692,6 +6692,16 @@ void MuseScore::cmd(QAction* a, const QString& cmd)
                         cs->update();
                         }
                   }
+            else if (cmd == "show-debug") {
+                  MScore::showCorruptedMeasures = a->isChecked();
+                  MScore::showBoundingRect = a->isChecked();
+                  MScore::showSegmentShapes = a->isChecked();
+                  MScore::showSkylines = a->isChecked();
+                  if (cs) {
+                        cs->setLayoutAll();
+                        cs->update();
+                        }
+                  }
             }
 #ifndef NDEBUG
       else if (cmd == "qml-reload-source") {

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -1031,9 +1031,7 @@ void MuseScore::populateFileOperations()
       viewModeCombo->addItem(tr("Page View"), int(LayoutMode::PAGE));
       viewModeCombo->addItem(tr("Continuous View"), int(LayoutMode::LINE));
       viewModeCombo->addItem(tr("Single Page"), int(LayoutMode::SYSTEM));
-#ifdef NDEBUG
       if (enableExperimental)
-#endif
             viewModeCombo->addItem(tr("Floating"), int(LayoutMode::FLOAT));
 
       // Restore the saved view-mode combobox index, if any.
@@ -1469,14 +1467,10 @@ MuseScore::MuseScore()
 
       menuEdit->addAction(getAction("instruments"));
 
-#ifdef NDEBUG
       if (enableExperimental) {
-#endif
             menuEdit->addSeparator();
             menuEdit->addAction(getAction("debugger"));
-#ifdef NDEBUG
             }
-#endif
 
       menuEdit->addSeparator();
       pref = new QAction("", 0);
@@ -1832,7 +1826,6 @@ MuseScore::MuseScore()
       //    Menu Debug
       //---------------------
 
-#ifndef NDEBUG
       menuDebug = mb->addMenu("Debug");
       menuDebug->setObjectName("Debug");
       a = getAction("no-horizontal-stretch");
@@ -1864,7 +1857,6 @@ MuseScore::MuseScore()
       a = getAction("qml-reload-source");
       menuDebug->addAction(a);
       Workspace::addMenuAndString(menuDebug, "menu-debug");
-#endif
 
       //---------------------
       //    Menu Help
@@ -2214,9 +2206,7 @@ void MuseScore::setMenuTitles()
 #ifdef SCRIPT_INTERFACE
             { menuPlugins,          tr("&Plugins")          },
 #endif
-#ifndef NDEBUG
             { menuDebug,            "Debug"                 }, // not translated
-#endif
             { menuHelp,             tr("&Help")             },
             { menuTours,            tr("&Tours")            }
             };
@@ -2271,9 +2261,7 @@ void MuseScore::updateMenus()
 #endif
       updateMenu(menuHelp,        "menu-help",         "Help");
       updateMenu(menuTours,       "menu-tours",        "");
-#ifndef NDEBUG
       updateMenu(menuDebug,       "menu-debug",        "Debug");
-#endif
       connect(openRecent,     SIGNAL(aboutToShow()),       SLOT(openRecentMenu()));
       connect(openRecent,     SIGNAL(triggered(QAction*)), SLOT(selectScore(QAction*)));
       connect(menuWorkspaces, SIGNAL(aboutToShow()),       SLOT(showWorkspaceMenu()));

--- a/mscore/musescore.h
+++ b/mscore/musescore.h
@@ -305,9 +305,7 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
       QMenu* menuPlugins;
       QMenu* menuHelp;
       QMenu* menuTours;
-#ifndef NDEBUG
       QMenu* menuDebug;
-#endif
       AlbumManager* albumManager           { 0 };
       ExportDialog* exportDialog           { 0 };
 

--- a/mscore/musescore.h
+++ b/mscore/musescore.h
@@ -530,7 +530,6 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
       void leaveFeedback(QString medium);
       void openRecentMenu();
       void selectScore(QAction*);
-      void startPreferenceDialog();
       void preferencesChanged(bool fromWorkspace = false, bool changeUI = true);
       void seqStarted();
       void seqStopped();
@@ -614,6 +613,7 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
       void changeWorkspace(Workspace* p, bool first=false);
       void mixerPreferencesChanged(bool showMidiControls);
       void checkForUpdates();
+      void startPreferenceDialog();
       void restartAudioEngine();
 
    public:

--- a/mscore/prefsdialog.cpp
+++ b/mscore/prefsdialog.cpp
@@ -818,9 +818,7 @@ void PreferenceDialog::updateSCListView()
             if (enableExperimental
                         || (!s->key().startsWith("media")
                             && !s->key().startsWith("layer")
-#ifdef NDEBUG
                             && !s->key().startsWith("debugger")
-#endif
                             && !s->key().startsWith("edit_harmony")
                             && !s->key().startsWith("insert-fretframe"))) {
                   shortcutList->addTopLevelItem(newItem);

--- a/mscore/qmldockwidget.cpp
+++ b/mscore/qmldockwidget.cpp
@@ -28,9 +28,7 @@
 
 namespace Ms {
 
-#ifndef NDEBUG
 bool useSourceQmlFiles = false;
-#endif
 
 //---------------------------------------------------------
 //   FocusChainBreak
@@ -241,13 +239,11 @@ void QmlDockWidget::setupStyle()
 
 QString QmlDockWidget::qmlSourcePrefix()
       {
-#ifndef NDEBUG
       if (useSourceQmlFiles) {
             const QFileInfo fi(__FILE__);
             const QDir mscoreDir = fi.absoluteDir();
             return QUrl::fromLocalFile(mscoreDir.absolutePath()).toString() + '/';
             }
-#endif
       static const QString qmlResourcesRoot("qrc:/");
       return qmlResourcesRoot;
       }

--- a/mscore/qmldockwidget.h
+++ b/mscore/qmldockwidget.h
@@ -24,9 +24,7 @@
 
 namespace Ms {
 
-#ifndef NDEBUG
 extern bool useSourceQmlFiles;
-#endif
 
 //---------------------------------------------------------
 //   FocusChainBreak

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -328,10 +328,8 @@ void ScoreView::objectPopup(const QPoint& pos, Element* obj)
       a = popup->addAction(tr("Help"));
       a->setData("help");
 
-#ifndef NDEBUG
       popup->addSeparator();
       popup->addAction("Debugger")->setData("list");
-#endif
 
       popupActive = true;
       a = popup->exec(pos);
@@ -452,9 +450,7 @@ void ScoreView::measurePopup(QContextMenuEvent* ev, Measure* obj)
       a->setEnabled(!obj->isMMRest());
       popup->addSeparator();
 
-#ifndef NDEBUG
       popup->addAction("Object Debugger")->setData("list");
-#endif
 
       a = popup->exec(gpos);
       if (a == 0)
@@ -1172,7 +1168,6 @@ void ScoreView::paintPageBorder(QPainter& p, Page* page)
             }
       }
 
-#ifndef NDEBUG
 //---------------------------------------------------------
 //   drawDebugInfo
 //---------------------------------------------------------
@@ -1222,7 +1217,6 @@ static void drawDebugInfo(QPainter& p, const Element* _e)
                   }
             }
       }
-#endif
 
 //---------------------------------------------------------
 //   drawElements
@@ -1247,10 +1241,8 @@ void ScoreView::drawElements(QPainter& painter, QList<Element*>& el, Element* ed
             painter.translate(pos);
             e->draw(&painter);
             painter.translate(-pos);
-#ifndef NDEBUG
             if (e->selected())
                   drawDebugInfo(painter, e);
-#endif
             }
       }
 
@@ -1367,7 +1359,6 @@ void ScoreView::paint(const QRect& r, QPainter& p)
 
                   drawElements(p, ell, editElement);
 
-#ifndef NDEBUG
                   if (!score()->printing()) {
                         if (MScore::showSystemBoundingRect) {
                               for (const System* system : qAsConst(page->systems())) {
@@ -1433,7 +1424,6 @@ void ScoreView::paint(const QRect& r, QPainter& p)
                                     }
                               }
                         }
-#endif
 
                   p.translate(-pos);
                   r1 -= _matrix.mapRect(pr).toAlignedRect();

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -2258,6 +2258,9 @@ void ScoreView::cmd(const char* s)
             };
 
       static const std::vector<ScoreViewCmd> cmdList {
+            {{"start-preference-dialog"}, [](ScoreView* /*cv*/, const QByteArray&) {
+                  mscore->startPreferenceDialog();
+                  }},
             {{"escape"}, [](ScoreView* cv, const QByteArray&) {
                   cv->escapeCmd();
                   }},

--- a/mscore/shortcut.cpp
+++ b/mscore/shortcut.cpp
@@ -94,6 +94,13 @@ Shortcut Shortcut::_sc[] = {
          },
       {
          MsWidget::MAIN_WINDOW,
+         STATE_NORMAL | STATE_NOTE_ENTRY | STATE_EDIT,
+         "start-preference-dialog",
+         QT_TRANSLATE_NOOP("action","Start Preferences Dialog…"),
+         QT_TRANSLATE_NOOP("action","Start Preferences Dialog")
+         },
+      {
+         MsWidget::MAIN_WINDOW,
          STATE_NORMAL | STATE_NOTE_ENTRY | STATE_EDIT | STATE_PLAY,
          "file-save-a-copy",
          QT_TRANSLATE_NOOP("action","Save a Copy…"),

--- a/mscore/shortcut.cpp
+++ b/mscore/shortcut.cpp
@@ -4141,7 +4141,6 @@ Shortcut Shortcut::_sc[] = {
          Qt::ApplicationShortcut
          },
 #endif
-#ifndef NDEBUG
       {
          MsWidget::MAIN_WINDOW,
          STATE_ALL,
@@ -4232,7 +4231,6 @@ Shortcut Shortcut::_sc[] = {
          Icons::Invalid_ICON,
          Qt::ApplicationShortcut
          },
-#endif
       };
 
 

--- a/mscore/shortcut.cpp
+++ b/mscore/shortcut.cpp
@@ -2722,6 +2722,17 @@ Shortcut Shortcut::_sc[] = {
          },
       {
          MsWidget::MAIN_WINDOW,
+         STATE_NORMAL | STATE_NOTE_ENTRY | STATE_PLAY,
+         "show-debug",
+         QT_TRANSLATE_NOOP("action","Toggle Debug Options"),
+         QT_TRANSLATE_NOOP("action","Toggle Debug Options"),
+         0,
+         Icons::Invalid_ICON,
+         Qt::WindowShortcut,
+         ShortcutFlags::A_SCORE | ShortcutFlags::A_CHECKABLE
+         },
+      {
+         MsWidget::MAIN_WINDOW,
          STATE_NORMAL | STATE_NOTE_ENTRY,
          "show-unprintable",
          QT_TRANSLATE_NOOP("action","Show Unprintable"),


### PR DESCRIPTION
This will enable the _**debug menu**_ as usually found in debug builds, but now in rolling release builds.

+ New command as a "convenience" to toggle showing skylines, bounding boxes, segment shapes, and corrupted measures with one shortcut action.

+ New command to trigger "start-preference-dialog", instead of needing to use the menus. 

I'll be intending to bring over an "Alternative Options" toolbar that will house a handful of icons to perform tasks like "show preferences" that have commands already existing but in one toolbar as a convenience. If undesirable, of course they don't have to be showing. By default the user would have to enable it anyways, but for discoverability's sake I want to implement a Workspace Versioning system that will allow for automatically showing what has been added so that anything new doesn't go under the radar... but that'll hopefully be comin' up.