### PR TITLE
Provide user-defined PDF export directory

### DIFF
--- a/global/settings/types/preferencekeys.h
+++ b/global/settings/types/preferencekeys.h
@@ -69,6 +69,8 @@
 #define PREF_EXPORT_MUSICXML_EXPORTINVISIBLEELEMENTS        "export/musicXML/exportInvisibleElements"
 #define PREF_EXPORT_MUSICXML_MU3_COMPAT                     "export/musicXML/exportMu3Compat"
 #define PREF_EXPORT_PDF_DPI                                 "export/pdf/dpi"
+#define PREF_EXPORT_PDF_DIRECTORY                           "export/pdf/directory"
+#define PREF_EXPORT_PDF_DIRECTORY_ENABLED                   "export/pdf/directory/enabled"
 #define PREF_EXPORT_PNG_RESOLUTION                          "export/png/resolution"
 #define PREF_EXPORT_PNG_USETRANSPARENCY                     "export/png/useTransparency"
 #define PREF_EXPORT_BG_STYLE                                "export/bg/style"

--- a/mscore/exportdialog.cpp
+++ b/mscore/exportdialog.cpp
@@ -17,6 +17,7 @@
 //  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 //=============================================================================
 
+#include "icons.h"
 #include "exportdialog.h"
 #include "musescore.h"
 #include "preferences.h"
@@ -63,6 +64,10 @@ ExportDialog::ExportDialog(Score* s, QWidget* parent)
 
       connect(listWidget, &QListWidget::itemChanged, this, &ExportDialog::setOkButtonEnabled);
       connect(fileTypeComboBox, SIGNAL(currentIndexChanged(int)), SLOT(fileTypeChosen(int)));
+
+      connect(pdfDirectoryButton, &QToolButton::clicked, this, &ExportDialog::selectPdfDirectory);
+      connect(pdfDirectoryEnabled, &QToolButton::clicked, this, &ExportDialog::enablePdfDirectory);
+      pdfDirectoryButton->setIcon(*icons[int(Icons::fileOpen_ICON)]);
 
       pdfSeparateOrSingleFiles = new QButtonGroup(this);
       pdfSeparateOrSingleFiles->addButton(pdfSeparateFilesRadioButton, 0);
@@ -209,6 +214,9 @@ void ExportDialog::loadValues()
                         break;
                   }
             }
+
+      pdfDirectoryEnabled->setChecked(preferences.getBool(PREF_EXPORT_PDF_DIRECTORY_ENABLED));
+      pdfDirectory->setText(preferences.getString(PREF_EXPORT_PDF_DIRECTORY));
       }
 
 //---------------------------------------------------------
@@ -278,6 +286,33 @@ void ExportDialog::clearSelection()
             ExportScoreItem* item = static_cast<ExportScoreItem*>(listWidget->item(i));
             item->setChecked(false);
             }
+      }
+
+//---------------------------------------------------------
+//   selectPdfDirectory
+//---------------------------------------------------------
+
+void ExportDialog::selectPdfDirectory()
+      {
+      QString s = QFileDialog::getExistingDirectory(
+            this,
+            tr("Choose Score Folder"),
+            pdfDirectory->text(),
+            QFileDialog::ShowDirsOnly | (preferences.getBool(PREF_UI_APP_USENATIVEDIALOGS)
+                  ? QFileDialog::Options()
+                  : QFileDialog::DontUseNativeDialog));
+
+      if (!s.isNull())
+            pdfDirectory->setText(s);
+      }
+
+//---------------------------------------------------------
+//   enablePdfDirectory
+//---------------------------------------------------------
+
+void ExportDialog::enablePdfDirectory()
+      {
+      pdfDirectory->setEnabled(pdfDirectoryEnabled->isChecked());
       }
 
 //---------------------------------------------------------
@@ -395,7 +430,14 @@ void ExportDialog::accept()
       
       // Ask for save name and location
       QString saveDirectory;
-      if (cs->masterScore()->fileInfo()->exists())
+
+      const bool useDirPref = pdfDirectoryEnabled->isChecked();
+      preferences.setPreference(PREF_EXPORT_PDF_DIRECTORY_ENABLED, useDirPref);
+      if (useDirPref) {
+            preferences.setPreference(PREF_EXPORT_PDF_DIRECTORY, pdfDirectory->text());
+            saveDirectory = pdfDirectory->text();
+            }
+      else if (cs->masterScore()->fileInfo()->exists())
             saveDirectory = cs->masterScore()->fileInfo()->dir().path();
       else {
             QSettings set;

--- a/mscore/exportdialog.h
+++ b/mscore/exportdialog.h
@@ -71,6 +71,8 @@ class ExportDialog : public AbstractDialog, public Ui::ExportDialog {
       void selectParts();
       void clearSelection();
       void setOkButtonEnabled();
+      void selectPdfDirectory();
+      void enablePdfDirectory();
 
    protected:
       virtual void retranslate();

--- a/mscore/exportdialog.ui
+++ b/mscore/exportdialog.ui
@@ -10,7 +10,7 @@
     <x>0</x>
     <y>0</y>
     <width>757</width>
-    <height>424</height>
+    <height>649</height>
    </rect>
   </property>
   <property name="minimumSize">
@@ -226,48 +226,6 @@
             </layout>
            </widget>
           </item>
-          <item row="3" column="0">
-           <widget class="QWidget" name="pdfFileOptionWidget" native="true">
-            <property name="minimumSize">
-             <size>
-              <width>0</width>
-              <height>0</height>
-             </size>
-            </property>
-            <layout class="QGridLayout" name="gridLayout_10">
-             <property name="leftMargin">
-              <number>0</number>
-             </property>
-             <item row="0" column="0">
-              <widget class="QLabel" name="pdfFileOptionsLabel">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="text">
-                <string>Export each score</string>
-               </property>
-              </widget>
-             </item>
-             <item row="1" column="0">
-              <widget class="QRadioButton" name="pdfSeparateFilesRadioButton">
-               <property name="text">
-                <string>As a separate file</string>
-               </property>
-              </widget>
-             </item>
-             <item row="2" column="0">
-              <widget class="QRadioButton" name="pdfOneFileRadioButton">
-               <property name="text">
-                <string>Combined into a single file</string>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </widget>
-          </item>
           <item row="5" column="0" colspan="2">
            <widget class="QWidget" name="pngFileOptionWidget" native="true">
             <property name="sizePolicy">
@@ -454,6 +412,88 @@
              </size>
             </property>
            </spacer>
+          </item>
+          <item row="3" column="0" colspan="2">
+           <widget class="QWidget" name="pdfFileOptionWidget" native="true">
+            <property name="minimumSize">
+             <size>
+              <width>0</width>
+              <height>0</height>
+             </size>
+            </property>
+            <layout class="QGridLayout" name="gridLayout_10">
+             <property name="leftMargin">
+              <number>0</number>
+             </property>
+             <item row="0" column="0">
+              <widget class="QLabel" name="pdfFileOptionsLabel">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="text">
+                <string>Export each score</string>
+               </property>
+              </widget>
+             </item>
+             <item row="2" column="0">
+              <widget class="QRadioButton" name="pdfOneFileRadioButton">
+               <property name="text">
+                <string>Combined into a single file</string>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="0">
+              <widget class="QRadioButton" name="pdfSeparateFilesRadioButton">
+               <property name="text">
+                <string>As a separate file</string>
+               </property>
+              </widget>
+             </item>
+             <item row="3" column="0">
+              <layout class="QHBoxLayout" name="horizontalLayout_2">
+               <property name="bottomMargin">
+                <number>0</number>
+               </property>
+               <item>
+                <widget class="QCheckBox" name="pdfDirectoryEnabled">
+                 <property name="minimumSize">
+                  <size>
+                   <width>0</width>
+                   <height>0</height>
+                  </size>
+                 </property>
+                 <property name="maximumSize">
+                  <size>
+                   <width>225</width>
+                   <height>16777215</height>
+                  </size>
+                 </property>
+                 <property name="text">
+                  <string>Location:</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QLineEdit" name="pdfDirectory">
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QToolButton" name="pdfDirectoryButton">
+                 <property name="text">
+                  <string>...</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </item>
+            </layout>
+           </widget>
           </item>
          </layout>
         </widget>
@@ -1045,18 +1085,18 @@
  </widget>
  <customwidgets>
   <customwidget>
+   <class>Awl::ColorLabel</class>
+   <extends>QPushButton</extends>
+   <header>awl/colorlabel.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
    <class>Ms::ClickableLabel</class>
    <extends>QLabel</extends>
    <header>clickableLabel.h</header>
    <slots>
     <signal>clicked()</signal>
    </slots>
-  </customwidget>
-  <customwidget>
-   <class>Awl::ColorLabel</class>
-   <extends>QPushButton</extends>
-   <header>awl/colorlabel.h</header>
-   <container>1</container>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/mscore/preferences.cpp
+++ b/mscore/preferences.cpp
@@ -174,6 +174,8 @@ void Preferences::init(bool storeInMemoryOnly)
             {PREF_EXPORT_MUSICXML_EXPORTINVISIBLEELEMENTS,         new BoolPreference(false)},
             {PREF_EXPORT_MUSICXML_MU3_COMPAT,                      new BoolPreference(false)},
             {PREF_EXPORT_PDF_DPI,                                  new IntPreference(DPI, false)},
+            {PREF_EXPORT_PDF_DIRECTORY,                            new StringPreference("",  false)},
+            {PREF_EXPORT_PDF_DIRECTORY_ENABLED,                    new BoolPreference(false, false)},
             {PREF_EXPORT_PNG_RESOLUTION,                           new DoublePreference(DPI, false)},
             {PREF_EXPORT_PNG_USETRANSPARENCY,                      new BoolPreference(true, false)},
             {PREF_EXPORT_BG_STYLE,                                 new IntPreference(0, false)},


### PR DESCRIPTION
- it can be toggled off (and this is remembered) so that the score's directory takes precedence as usual

<img width="1069" height="585" alt="image" src="https://github.com/user-attachments/assets/b671f3da-515f-431c-a52d-37d2873a6934" />
