### PR TITLE
Make MuseScore 3.7 Evolution having its own settings

### DIFF
--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -7674,8 +7674,8 @@ MuseScoreApplication* MuseScoreApplication::initApplication(int& argc, char** ar
             appName  = "MuseScore3Development";
             }
       else {
-            appName2 = "mscore3";
-            appName  = "MuseScore3";
+            appName2 = "mscore3evo";
+            appName  = "MuseScore3Evo";
             }
 
       //! NOTE Disable cache for all platforms


### PR DESCRIPTION
After the recent merges of #1269, #1273, #1280, #1282 and #1283 we have conlicts with workspace settings between 3.6.2 (and older) and 3.7 Evolution due to them sharing all their settings, here esp. the workspaces, in a way that you can't modify the 3.7 workspace, then start 3.6.2, then 3.7 again, as that results in all the changes made to the 3.7 workspace to have reverted to their (new) defaults.
But also in 3.6.2 seeing things in the workspace like a crippled and unusable debug menu, if including the menu bar in the workspace.

So now with this PR MuseScore 3.7 Evolution has its own stettings.