### PR TITLE
3.7 Evolution transition from official 3.x series for discrete settings

### DIFF
--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -1125,6 +1125,151 @@ void MuseScore::populatePlaybackControls()
       }
 
 //---------------------------------------------------------
+//   dataLocationForApplication
+//---------------------------------------------------------
+
+static QString dataLocationForApplication(const QString& applicationName)
+      {
+      const QString currentApplicationName = QCoreApplication::applicationName();
+
+      QCoreApplication::setApplicationName(applicationName);
+      const QString path = QStandardPaths::writableLocation(QStandardPaths::DataLocation);
+      QCoreApplication::setApplicationName(currentApplicationName);
+
+      return path;
+      }
+
+//---------------------------------------------------------
+//   copyDirectory
+//---------------------------------------------------------
+
+static bool copyDirectory(const QString& sourcePath,
+                          const QString& destinationPath)
+      {
+      QDir sourceDir(sourcePath);
+
+      if (!sourceDir.exists())
+            return false;
+
+      QDir destinationDir;
+      if (!destinationDir.mkpath(destinationPath))
+            return false;
+
+      const QFileInfoList entries = sourceDir.entryInfoList(
+            QDir::NoDotAndDotDot
+            | QDir::AllEntries
+            | QDir::Hidden
+            | QDir::System);
+
+      for (const QFileInfo& entry : entries) {
+            const QString source =
+                  entry.absoluteFilePath();
+            const QString destination =
+                  QDir(destinationPath).filePath(entry.fileName());
+
+            if (entry.isDir()) {
+                  if (!copyDirectory(source, destination))
+                        return false;
+                  }
+            else {
+                  if (QFile::exists(destination))
+                        continue;
+
+                  if (!QFile::copy(source, destination))
+                        return false;
+                  }
+            }
+
+      return true;
+      }
+
+//---------------------------------------------------------
+//   migrateEvolutionSettings
+//
+//   On first use of the separate 3.7 Evolution profile,
+//   copy the existing MuseScore3 settings and application
+//   data so that users retain their preferences, workspaces,
+//   shortcuts, sessions, etc.
+//
+//   Once the migration has been handled, never import the
+//   MuseScore3 profile again. This prevents later use of
+//   MuseScore 3.6.2 from affecting the Evolution profile.
+//
+//   Do not migrate when a custom configuration folder or
+//   factory settings have been explicitly requested.
+//---------------------------------------------------------
+
+static void migrateEvolutionSettings()
+      {
+      if (!dataPath.isEmpty())
+            return;
+
+      if (useFactorySettings)
+            return;
+
+      const QString newDataPath =
+            QStandardPaths::writableLocation(QStandardPaths::DataLocation);
+
+      static constexpr const char* migrationKey =
+            "migration/fromMuseScore3";
+
+      QSettings newSettings;
+
+      if (newSettings.value(migrationKey, false).toBool())
+            return;
+
+      const bool haveNewSettings = !newSettings.allKeys().isEmpty();
+
+      QSettings oldSettings(QSettings::defaultFormat(),
+                            QSettings::UserScope,
+                            "MuseScore",
+                            "MuseScore3");
+
+      const QString oldDataPath =
+            dataLocationForApplication("MuseScore3");
+
+      const bool haveOldSettings = !oldSettings.allKeys().isEmpty();
+      const bool haveOldData = QDir(oldDataPath).exists();
+
+      if (!haveOldSettings && !haveOldData) {
+            newSettings.setValue(migrationKey, true);
+            newSettings.sync();
+            return;
+            }
+
+      if (haveOldData && !copyDirectory(oldDataPath, newDataPath)) {
+            qWarning("Failed to migrate MuseScore3 application data from <%s> to <%s>",
+                     qPrintable(oldDataPath),
+                     qPrintable(newDataPath));
+            return;
+            }
+
+      if (haveOldSettings && !haveNewSettings) {
+            for (const QString& key : oldSettings.allKeys())
+                  newSettings.setValue(key, oldSettings.value(key));
+
+            newSettings.sync();
+
+            if (newSettings.status() != QSettings::NoError) {
+                  qWarning("Failed to migrate MuseScore3 settings");
+                  return;
+                  }
+            }
+
+      // Only mark the migration complete after all required data and
+      // settings have been copied successfully.
+      newSettings.setValue(migrationKey, true);
+      newSettings.sync();
+
+      if (newSettings.status() != QSettings::NoError) {
+            qWarning("Failed to mark MuseScore3 settings migration complete");
+            return;
+            }
+
+      qInfo("Migrated MuseScore3 settings to MuseScore3Evo");
+      }
+
+//---------------------------------------------------------
 //   MuseScore
 //---------------------------------------------------------
 
@@ -7674,8 +7819,8 @@ MuseScoreApplication* MuseScoreApplication::initApplication(int& argc, char** ar
             appName  = "MuseScore3Development";
             }
       else {
-            appName2 = "mscore3";
-            appName  = "MuseScore3";
+            appName2 = "mscore3evo";
+            appName  = "MuseScore3Evo";
             }
 
       //! NOTE Disable cache for all platforms
@@ -8095,6 +8240,8 @@ int runApplication(int& argc, char** av)
 
       if (cmdLineParseResult.exit)
             return 0;
+
+      migrateEvolutionSettings();
 
       MuseScore::init(cmdLineParseResult.argv);
 


### PR DESCRIPTION
Should supercede https://github.com/Jojo-Schmitz/MuseScore/pull/1284 

Performs a transitional copying from 3.x (e.g. 3.6.2) into the 3.7 Evolution settings

I've tested this starting out with just 3.6.2 settings and no special 3.7 folder yet, and verifying that the result is two separate settings copied originally from 3.6.2 settings (source being MuseScore3 and result being MuseScore3Evo), and then afterwards being able to alter things will not alter 3.6.2 and vice versa. A nice addendum to getting the workspace migration also working in the earlier update. 

More testing is definitely appreciated but from what I can tell it's doing good. 

The important thing is making damn sure that it doesn't happen more than once after it's completed, so there's an internal setting that gets set into the ini settings for that just in case as a safeguard, even though the presence of the folder is already good enough generally speaking unless there was a partial copying error or something, but that has a fix too. If something goes wrong, the next run should take care of it, though I don't see why anything should go wrong during the transition except for a power outage or something crazy.

I went with the MuseScore3Evo term, although MuseScore3Evolution would work too as a folder name if wanted. 



**To re-iterate**:

Old share state is currently:

MuseScore3 settings/data
- user's preferences
- user's customized workspace
- workspace has lost `<uiVersion>` because 3.6.2 rewrote it

First launch of the newly isolated Evolution:
MuseScore3  —— Copy ——> MuseScore3Evo

Then normal Evolution startup continues.
Workspace reader sees `int uiVersion = 0;` because 3.6.2 stripped the attribute

Then: `migrate(uiVersion);` runs and restores whatever Evolution-specific actions are required.


Finally Evolution writes: `<uiVersion>1</uiVersion>` into its own copy.

From then on: 
3.6.2 == MuseScore3
3.7-Evolution == MuseScore3Evo

…and both are then permanently separated