### PR TITLE
Debug Console Logger

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,9 @@ include (GetCompilerVersion)
 set(CMAKE_AUTOMOC     TRUE)
 set(USE_SSE           TRUE)
 
+# Enable qDebug() output and message context in release builds
+set(ENABLE_RELEASE_DEBUG_LOG ON)
+
 set(MUSESCORE_REVISION "" CACHE STRING "Build revision")
 
 # Set revision for local builds
@@ -74,6 +77,10 @@ endif(MUSESCORE_REVISION STREQUAL "")
 message(STATUS "MUSESCORE_REVISION: ${MUSESCORE_REVISION}")
 
 add_definitions(-DMUSESCORE_REVISION="${MUSESCORE_REVISION}")
+
+if (ENABLE_RELEASE_DEBUG_LOG)
+      add_definitions(-DQT_MESSAGELOGCONTEXT)
+endif()
 
 # Setup version number and general build settings
 SET(MUSESCORE_BUILD_CONFIG "dev" CACHE STRING "Build config")
@@ -269,8 +276,14 @@ else (APPLE)
          set(CMAKE_C_FLAGS    "${CMAKE_C_FLAGS} /arch:SSE")
       endif (USE_SSE)
       set(CMAKE_CXX_FLAGS_DEBUG          "/MT /permissive- /std:c++20 /Zc:__cplusplus /W4 /Zi /Ob0 /Od /RTC1 /wd4996")
-      set(CMAKE_CXX_FLAGS_RELEASE        "/MT /permissive- /std:c++20 /Zc:__cplusplus /W4 /O2 /Ob2 /DNDEBUG /DQT_NO_DEBUG /DQT_NO_DEBUG_OUTPUT")
-      set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "/MT /permissive- /std:c++20 /Zc:__cplusplus /W4 /Zi /O2 /Ob1 /DNDEBUG /DQT_NO_DEBUG /DQT_NO_DEBUG_OUTPUT /wd4996")
+      set(CMAKE_CXX_FLAGS_RELEASE        "/MT /permissive- /std:c++20 /Zc:__cplusplus /W4 /O2 /Ob2 /DNDEBUG /DQT_NO_DEBUG")
+      set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "/MT /permissive- /std:c++20 /Zc:__cplusplus /W4 /Zi /O2 /Ob1 /DNDEBUG /DQT_NO_DEBUG /wd4996")
+
+      if (NOT ENABLE_RELEASE_DEBUG_LOG)
+            set(CMAKE_CXX_FLAGS_RELEASE        "${CMAKE_CXX_FLAGS_RELEASE} /DQT_NO_DEBUG_OUTPUT")
+            set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} /DQT_NO_DEBUG_OUTPUT")
+      endif()
+
       set(CMAKE_C_FLAGS_DEBUG            "/MT /W4 /Zi /Ob0 /Od /RTC1")
       set(CMAKE_C_FLAGS_RELEASE          "/MT /W4 /O2 /Ob2 /DNDEBUG")
       set(CMAKE_C_FLAGS_RELWITHDEBINFO   "/MT /W4 /Zi /O2 /Ob1 /DNDEBUG")
@@ -295,7 +308,10 @@ else (APPLE)
          endif (ARCH_TYPE=_x64)
          set(CMAKE_CXX_FLAGS         "${CMAKE_CXX_FLAGS} -fPIC")
          set(CMAKE_CXX_FLAGS_DEBUG   "${CMAKE_CXX_FLAGS_DEBUG} -Wall -Wextra -Woverloaded-virtual")
-         set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -DQT_NO_DEBUG_OUTPUT")
+
+         if (NOT ENABLE_RELEASE_DEBUG_LOG)
+               set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -DQT_NO_DEBUG_OUTPUT")
+         endif()
       endif (MINGW)
       set(CMAKE_CXX_FLAGS_DEBUG   "${CMAKE_CXX_FLAGS_DEBUG} -Wno-deprecated-declarations -Wno-cast-function-type") # don't want to see those in 3.x when using Qt 5.15
    endif (MSVC)

--- a/global/settings/types/preferencekeys.h
+++ b/global/settings/types/preferencekeys.h
@@ -61,6 +61,7 @@
 #define PREF_APP_TELEMETRY_ALLOWED                          "application/telemetry/allowed"
 #define PREF_APP_BACKUP_GENERATE_BACKUP                     "application/backup/generateBackup"
 #define PREF_APP_BACKUP_SUBFOLDER                           "application/backup/subfolder"
+#define PREF_APP_DEBUG_LOG_ENABLED                          "application/debugLog/enabled"
 #define PREF_EXPORT_AUDIO_NORMALIZE                         "export/audio/normalize"
 #define PREF_EXPORT_AUDIO_SAMPLERATE                        "export/audio/sampleRate"
 #define PREF_EXPORT_AUDIO_PCMRATE                           "export/audio/PCMRate"

--- a/mscore/CMakeLists.txt
+++ b/mscore/CMakeLists.txt
@@ -209,7 +209,7 @@ add_library(mscoreapp STATIC
       abstractdialog.h accessibletoolbutton.h albummanager.h
       analyse.h articulationprop.h
       bendcanvas.h breaksdialog.h
-      chordview.h click.h clickableLabel.h continuouspanel.h downloadUtils.h
+      chordview.h click.h clickableLabel.h continuouspanel.h debuglog.h downloadUtils.h
       drumroll.h drumtools.h drumview.h easeinoutcanvas.h editdrumset.h
       editinstrument.h editpitch.h editraster.h editstaff.h
       editstafftype.h editstringdata.h editstyle.h enableplayforwidget.h
@@ -244,7 +244,7 @@ add_library(mscoreapp STATIC
       editinstrument.cpp editstyle.cpp easeinoutcanvas.cpp
       clickableLabel.cpp
       instrdialog.cpp instrwidget.cpp
-      debugger/debugger.cpp menus.cpp
+      debugger/debugger.cpp debuglog.cpp menus.cpp
       mssplashscreen.cpp musescore.cpp musescoredialogs.cpp navigator.cpp pagesettings.cpp palette.cpp
       sessionstatusobserver.cpp
       timeline.cpp

--- a/mscore/debuglog.cpp
+++ b/mscore/debuglog.cpp
@@ -1,0 +1,403 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//=============================================================================
+
+#include "debuglog.h"
+
+#include "preferences.h"
+
+#include <QApplication>
+#include <QCheckBox>
+#include <QClipboard>
+#include <QDateTime>
+#include <QFontDatabase>
+#include <QHBoxLayout>
+#include <QMutex>
+#include <QMutexLocker>
+#include <QPlainTextEdit>
+#include <QPushButton>
+#include <QScrollBar>
+#include <QSignalBlocker>
+#include <QTimer>
+#include <QVBoxLayout>
+#include <QWidget>
+
+#include <cstdio>
+
+namespace Ms {
+
+namespace {
+
+constexpr int MAX_LOG_MESSAGES = 10000;
+
+QMutex debugLogMutex;
+QStringList pendingCompactMessages;
+QStringList pendingDetailedMessages;
+
+QtMessageHandler previousMessageHandler = nullptr;
+bool messageHandlerInstalled = false;
+
+//---------------------------------------------------------
+//   messageTypeName
+//---------------------------------------------------------
+
+const char* messageTypeName(QtMsgType type)
+	  {
+	  switch (type) {
+			case QtDebugMsg:
+				  return "Debug";
+			case QtInfoMsg:
+				  return "Info";
+			case QtWarningMsg:
+				  return "Warning";
+			case QtCriticalMsg:
+				  return "Critical";
+			case QtFatalMsg:
+				  return "Fatal";
+			}
+	  return "Log";
+	  }
+
+//---------------------------------------------------------
+//   debugLogMessageHandler
+//---------------------------------------------------------
+
+void debugLogMessageHandler(QtMsgType type,
+							const QMessageLogContext& context,
+							const QString& msg)
+	  {
+	  const QString typeName =
+			QString::fromLatin1(messageTypeName(type));
+
+	  const QString compactMessage =
+			QString("%1: %2").arg(typeName, msg);
+
+	  QStringList contextParts;
+
+	  if (context.file && *context.file) {
+			QString source = QString::fromUtf8(context.file);
+
+			if (context.line > 0)
+				  source += QString(":%1").arg(context.line);
+
+			contextParts.append(source);
+			}
+
+	  if (context.function && *context.function)
+			contextParts.append(QString::fromUtf8(context.function));
+
+	  const QString timestamp =
+			QDateTime::currentDateTime().toString("HH:mm:ss.zzz");
+
+	  QString detailedMessage =
+			QString("%1 %2").arg(timestamp, typeName);
+
+	  if (!contextParts.isEmpty())
+			detailedMessage += QString(" [%1]").arg(contextParts.join(" | "));
+
+	  detailedMessage += QString(": %1").arg(msg);
+
+	  {
+	  QMutexLocker locker(&debugLogMutex);
+
+	  pendingCompactMessages.append(compactMessage);
+	  pendingDetailedMessages.append(detailedMessage);
+
+	  while (pendingCompactMessages.size() > MAX_LOG_MESSAGES) {
+			pendingCompactMessages.removeFirst();
+			pendingDetailedMessages.removeFirst();
+			}
+	  }
+
+	  // Preserve the existing message output:
+	  if (previousMessageHandler)
+			// Windows debug build may already have mscoreMessageHandler()
+			previousMessageHandler(type, context, msg);
+	  else {
+			const QByteArray formatted =
+				  qFormatLogMessage(type, context, msg).toLocal8Bit();
+
+			fprintf(stderr, "%s\n", formatted.constData());
+			fflush(stderr);
+			}
+	  }
+
+//---------------------------------------------------------
+//   takePendingMessages
+//---------------------------------------------------------
+
+void takePendingMessages(QStringList* compactMessages,
+						 QStringList* detailedMessages)
+	  {
+	  QMutexLocker locker(&debugLogMutex);
+
+	  compactMessages->swap(pendingCompactMessages);
+	  detailedMessages->swap(pendingDetailedMessages);
+	  }
+
+//---------------------------------------------------------
+//   clearPendingMessages
+//---------------------------------------------------------
+
+void clearPendingMessages()
+	  {
+	  QMutexLocker locker(&debugLogMutex);
+
+	  pendingCompactMessages.clear();
+	  pendingDetailedMessages.clear();
+	  }
+
+} // namespace
+
+//---------------------------------------------------------
+//   installDebugLogMessageHandler
+//---------------------------------------------------------
+
+void setDebugLogMessageHandlerEnabled(bool enabled)
+	  {
+	  if (enabled) {
+			if (messageHandlerInstalled)
+				  return;
+
+			previousMessageHandler =
+				  qInstallMessageHandler(debugLogMessageHandler);
+
+			messageHandlerInstalled = true;
+			}
+	  else {
+			if (!messageHandlerInstalled)
+				  return;
+
+			qInstallMessageHandler(previousMessageHandler);
+
+			previousMessageHandler = nullptr;
+			messageHandlerInstalled = false;
+			}
+	  }
+
+//---------------------------------------------------------
+//   debugLogMessageHandlerEnabled
+//---------------------------------------------------------
+
+bool debugLogMessageHandlerEnabled()
+	  {
+	  return messageHandlerInstalled;
+	  }
+
+//---------------------------------------------------------
+//   DebugLogDock
+//---------------------------------------------------------
+
+DebugLogDock::DebugLogDock(QWidget* parent)
+   : QDockWidget(parent)
+	  {
+	  setObjectName("debug-log");
+	  setWindowTitle("Debug Log");
+
+	  QWidget* content = new QWidget(this);
+	  QVBoxLayout* layout = new QVBoxLayout(content);
+	  layout->setContentsMargins(4, 4, 4, 4);
+	  layout->setSpacing(4);
+
+	  QHBoxLayout* controls = new QHBoxLayout;
+
+	  QPushButton* clearButton = new QPushButton(tr("Clear"), content);
+	  QPushButton* copyButton = new QPushButton(tr("Copy All"), content);
+
+	  _enabledCheck = new QCheckBox(tr("Enabled"), content);
+	  _enabledCheck->setChecked(preferences.getBool(PREF_APP_DEBUG_LOG_ENABLED));
+
+	  QCheckBox* detailsCheck = new QCheckBox(tr("Details"), content);
+	  detailsCheck->setChecked(false);
+
+	  QCheckBox* autoScrollCheck = new QCheckBox(tr("Autoscroll"), content);
+	  autoScrollCheck->setChecked(true);
+
+	  controls->addWidget(clearButton);
+	  controls->addWidget(copyButton);
+	  controls->addStretch();
+	  controls->addWidget(_enabledCheck);
+	  controls->addWidget(detailsCheck);
+	  controls->addWidget(autoScrollCheck);
+
+	  layout->addLayout(controls);
+
+	  _output = new QPlainTextEdit(content);
+	  _output->setReadOnly(true);
+	  _output->setLineWrapMode(QPlainTextEdit::NoWrap);
+	  _output->setFont(QFontDatabase::systemFont(QFontDatabase::FixedFont));
+
+	  layout->addWidget(_output);
+
+	  setWidget(content);
+
+	  connect(clearButton, &QPushButton::clicked, this, [this]() {
+			clearPendingMessages();
+
+			_compactMessages.clear();
+			_detailedMessages.clear();
+
+			_output->clear();
+			});
+
+	  connect(copyButton, &QPushButton::clicked, this, [this]() {
+			QApplication::clipboard()->setText(_output->toPlainText());
+			});
+
+	  connect(_enabledCheck, &QCheckBox::toggled, this, [](bool enabled) {
+			if (preferences.getBool(PREF_APP_DEBUG_LOG_ENABLED) != enabled)
+				  preferences.setPreference(PREF_APP_DEBUG_LOG_ENABLED, enabled);
+			});
+
+	  connect(detailsCheck, &QCheckBox::toggled, this, [this](bool checked) {
+			flushMessages();
+
+			_showDetails = checked;
+			refreshOutput();
+			});
+
+	  connect(autoScrollCheck, &QCheckBox::toggled, this, [this](bool checked) {
+			_autoScroll = checked;
+
+			if (_autoScroll) {
+				  QScrollBar* scrollBar = _output->verticalScrollBar();
+				  scrollBar->setValue(scrollBar->maximum());
+				  }
+			});
+
+	  _flushTimer = new QTimer(this);
+	  _flushTimer->setInterval(100);
+
+	  connect(_flushTimer, &QTimer::timeout, this, [this]() {
+			flushMessages();
+			});
+
+	  _preferenceListenerId =
+			preferences.addOnSetListener([this](const QString& key,
+												const QVariant& value) {
+				  if (key != PREF_APP_DEBUG_LOG_ENABLED)
+						return;
+
+				  const bool enabled = value.toBool();
+
+				  if (_enabledCheck->isChecked() != enabled) {
+						QSignalBlocker blocker(_enabledCheck);
+						_enabledCheck->setChecked(enabled);
+						}
+
+				  setLoggingEnabled(enabled);
+				  });
+
+	  setLoggingEnabled(preferences.getBool(PREF_APP_DEBUG_LOG_ENABLED));
+	  }
+
+//---------------------------------------------------------
+//   setLoggingEnabled
+//---------------------------------------------------------
+
+void DebugLogDock::setLoggingEnabled(bool enabled)
+	  {
+	  if (enabled) {
+			setDebugLogMessageHandlerEnabled(true);
+
+			// Immediately display anything collected between
+			// startup and creation the DebugLogDock:
+			flushMessages();
+
+			if (_flushTimer && !_flushTimer->isActive())
+				  _flushTimer->start();
+			}
+	  else {
+			// Stop new messages entering the queue
+			setDebugLogMessageHandlerEnabled(false);
+
+			// Flush anything that reached the handler before it was removed
+			flushMessages();
+
+			if (_flushTimer)
+				  _flushTimer->stop();
+			}
+	  }
+
+//---------------------------------------------------------
+//   ~DebugLogDock
+//---------------------------------------------------------
+
+DebugLogDock::~DebugLogDock()
+	  {
+	  if (_preferenceListenerId)
+			preferences.removeOnSetListener(_preferenceListenerId);
+
+	  setDebugLogMessageHandlerEnabled(false);
+	  }
+
+//---------------------------------------------------------
+//   flushMessages
+//---------------------------------------------------------
+
+void DebugLogDock::flushMessages()
+	  {
+	  QStringList compactMessages;
+	  QStringList detailedMessages;
+
+	  takePendingMessages(&compactMessages, &detailedMessages);
+
+	  if (compactMessages.isEmpty())
+			return;
+
+	  QScrollBar* scrollBar = _output->verticalScrollBar();
+	  const int oldScrollValue = scrollBar->value();
+
+	  _compactMessages.append(compactMessages);
+	  _detailedMessages.append(detailedMessages);
+
+	  bool removedOldMessages = false;
+
+	  while (_compactMessages.size() > MAX_LOG_MESSAGES) {
+			_compactMessages.removeFirst();
+			_detailedMessages.removeFirst();
+			removedOldMessages = true;
+			}
+
+	  if (removedOldMessages) {
+            // Synchronize the retained message lists and the widget
+			refreshOutput();
+			return;
+			}
+
+	  const QStringList& messages =
+			_showDetails ? detailedMessages : compactMessages;
+
+	  _output->appendPlainText(messages.join('\n'));
+
+	  if (_autoScroll)
+			scrollBar->setValue(scrollBar->maximum());
+	  else
+			scrollBar->setValue(oldScrollValue);
+	  }
+
+//---------------------------------------------------------
+//   refreshOutput
+//---------------------------------------------------------
+
+void DebugLogDock::refreshOutput()
+	  {
+	  QScrollBar* scrollBar = _output->verticalScrollBar();
+	  const int oldScrollValue = scrollBar->value();
+
+	  const QStringList& messages =
+			_showDetails ? _detailedMessages : _compactMessages;
+
+	  _output->setPlainText(messages.join('\n'));
+
+	  if (_autoScroll)
+			scrollBar->setValue(scrollBar->maximum());
+	  else
+			scrollBar->setValue(oldScrollValue);
+	  }
+
+} // namespace Ms

--- a/mscore/debuglog.h
+++ b/mscore/debuglog.h
@@ -1,0 +1,54 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//=============================================================================
+
+#ifndef __DEBUGLOG_H__
+#define __DEBUGLOG_H__
+
+#include <QDockWidget>
+#include <QStringList>
+
+#include <cstdint>
+
+class QCheckBox;
+class QPlainTextEdit;
+class QTimer;
+
+namespace Ms {
+
+//---------------------------------------------------------
+//   DebugLogDock
+//---------------------------------------------------------
+
+class DebugLogDock : public QDockWidget {
+	  QPlainTextEdit* _output { nullptr };
+	  QCheckBox* _enabledCheck { nullptr };
+	  QTimer* _flushTimer { nullptr };
+
+	  QStringList _compactMessages;
+	  QStringList _detailedMessages;
+
+	  bool _autoScroll { true };
+	  bool _showDetails { false };
+
+	  uint32_t _preferenceListenerId { 0 };
+
+	  void flushMessages();
+	  void refreshOutput();
+	  void setLoggingEnabled(bool enabled);
+
+   public:
+	  explicit DebugLogDock(QWidget* parent = nullptr);
+	  ~DebugLogDock();
+	  };
+
+void setDebugLogMessageHandlerEnabled(bool enabled);
+bool debugLogMessageHandlerEnabled();
+
+} // namespace Ms
+
+#endif

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -18,6 +18,7 @@
 
 #include "accessibletoolbutton.h"
 #include "config.h"
+#include "debuglog.h"
 #include "drumroll.h"
 #include "drumtools.h"
 #include "editraster.h"
@@ -1410,6 +1411,10 @@ MuseScore::MuseScore()
       }
       addDockWidget(Qt::BottomDockWidgetArea, scoreCmpTool);
 
+      _debugLogDock = new DebugLogDock(this);
+      addDockWidget(Qt::BottomDockWidgetArea, _debugLogDock);
+      _debugLogDock->hide();
+
       if (MuseScore::unstable()) {
             scriptRecorder = new ScriptRecorderWidget(this, this);
             scriptRecorder->setVisible(false);
@@ -2068,6 +2073,21 @@ MuseScore::MuseScore()
       menuDebug->addAction(a);
       a = getAction("qml-reload-source");
       menuDebug->addAction(a);
+
+      menuDebug->addSeparator();
+
+      _debugLogAction = new QAction(this);
+      _debugLogAction->setCheckable(true);
+      _debugLogAction->setChecked(_debugLogDock->isVisible());
+
+      connect(_debugLogAction, &QAction::toggled,
+              this, &MuseScore::showDebugLog);
+      connect(_debugLogDock, &QDockWidget::visibilityChanged,
+              _debugLogAction, &QAction::setChecked);
+
+      menuDebug->addAction(_debugLogAction);
+      Workspace::addActionAndString(_debugLogAction, "debug-log");
+
       Workspace::addMenuAndString(menuDebug, "menu-debug");
 
       //---------------------
@@ -2338,6 +2358,12 @@ void MuseScore::retranslate()
       setMenuTitles();
       _positionLabel->setToolTip(tr("Measure:Beat:Tick"));
       pref->setText(tr("&Preferences…"));
+
+      if (_debugLogAction)
+            _debugLogAction->setText(tr("Debug Log"));
+      if (_debugLogDock)
+            _debugLogDock->setWindowTitle(tr("Debug Log"));
+
       aboutAction->setText(tr("&About…"));
       aboutQtAction->setText(tr("About &Qt…"));
       aboutMusicXMLAction->setText(tr("About &MusicXML…"));
@@ -2475,9 +2501,16 @@ void MuseScore::updateMenus()
       updateMenu(menuHelp,        "menu-help",         "Help");
       updateMenu(menuTours,       "menu-tours",        "");
       updateMenu(menuDebug,       "menu-debug",        "Debug");
+
+      if (menuDebug && _debugLogAction && !menuDebug->actions().contains(_debugLogAction)) {
+            menuDebug->addSeparator();
+            menuDebug->addAction(_debugLogAction);
+            }
+
       connect(openRecent,     SIGNAL(aboutToShow()),       SLOT(openRecentMenu()));
       connect(openRecent,     SIGNAL(triggered(QAction*)), SLOT(selectScore(QAction*)));
       connect(menuWorkspaces, SIGNAL(aboutToShow()),       SLOT(showWorkspaceMenu()));
+
       setMenuTitles();
 #ifdef SCRIPT_INTERFACE
       addPluginMenuEntries();
@@ -3236,6 +3269,16 @@ void MuseScore::showPageSettings()
       pageSettings->setScore(cs);
       pageSettings->show();
       pageSettings->raise();
+      }
+
+//---------------------------------------------------------
+//   showDebugLog
+//---------------------------------------------------------
+
+void MuseScore::showDebugLog(bool visible)
+      {
+      if (_debugLogDock)
+            reDisplayDockWidget(_debugLogDock, visible);
       }
 
 //---------------------------------------------------------
@@ -8298,6 +8341,16 @@ void MuseScore::init(QStringList& argv)
             QFile::remove(settings.fileName() + ".lock"); //forcibly remove lock
             QFile::remove(settings.fileName());
             settings.clear();
+            }
+
+      if (!MScore::noGui) {
+            QSettings settings;
+            // Need access to the preference prior to Preferences::init()
+            // to capture the initial messages
+            const bool debugLogEnabled =
+                  settings.value(PREF_APP_DEBUG_LOG_ENABLED, false).toBool();
+
+            setDebugLogMessageHandlerEnabled(debugLogEnabled);
             }
 
       // create local plugin directory

--- a/mscore/musescore.h
+++ b/mscore/musescore.h
@@ -50,6 +50,7 @@ class PlayPanel;
 class IPlayPanel;
 class Mixer;
 class Debugger;
+class DebugLogDock;
 class MeasureListEditor;
 class MasterScore;
 class Score;
@@ -320,6 +321,8 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
       Mixer* mixer                         { 0 };
       SynthControl* synthControl           { 0 };
       Debugger* debugger                   { 0 };
+      DebugLogDock* _debugLogDock          { nullptr };
+      QAction* _debugLogAction             { nullptr };
       MeasureListEditor* measureListEdit   { 0 };
       PageSettings* pageSettings           { 0 };
 
@@ -539,6 +542,7 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
       void cmdInsertMeasures();
       void zoomBoxChanged(const ZoomIndex, const qreal);
       void showPageSettings();
+      void showDebugLog(bool visible);
       void removeTab(int);
       void removeTab();
       void clipboardChanged();

--- a/mscore/preferences.cpp
+++ b/mscore/preferences.cpp
@@ -166,6 +166,7 @@ void Preferences::init(bool storeInMemoryOnly)
             {PREF_MIGRATION_DO_NOT_ASK_ME_AGAIN_XML,               new BoolPreference(false, false)},
             {PREF_APP_BACKUP_GENERATE_BACKUP,                      new BoolPreference(true)},
             {PREF_APP_BACKUP_SUBFOLDER,                            new StringPreference(".mscbackup")},
+            {PREF_APP_DEBUG_LOG_ENABLED,                           new BoolPreference(false)},
             {PREF_EXPORT_AUDIO_NORMALIZE,                          new BoolPreference(true, false)},
             {PREF_EXPORT_AUDIO_SAMPLERATE,                         new IntPreference(44100, false)},
             {PREF_EXPORT_AUDIO_PCMRATE,                            new IntPreference(16)},

--- a/mscore/workspace.cpp
+++ b/mscore/workspace.cpp
@@ -1528,6 +1528,17 @@ void WorkspacesManager::clearWorkspaces()
 
 void Workspace::addActionAndString(QAction* action, QString string)
       {
+      // Action identifiers are unique, so replace an existing mapping
+      // rather than retaining a possibly stale QAction pointer. This
+      // is in accord with how the workspace code already assumes invariance:
+      // one action ID mapped to one QAction*
+      for (auto& pair : actionToStringList) {
+            if (pair.second == string) {
+                  pair.first = action;
+                  return;
+                  }
+            }
+
       QPair<QAction*, QString> pair;
       pair.first = action;
       pair.second = string;


### PR DESCRIPTION
Hey Jojo, check this out. In the debug menu, we can have a debugger log, what we would normally have in the CLI or in Qt Creator's output or whatever inside of MuseScore itself. I have it disabled for Release builds, but we could even have it for release builds by enabling the switch put into the CMakeList.txt file. Let me know if you find it worth putting in. For debugging it could be a convenience benefit  to see the qDebug logs in the program itself.

<img width="1266" height="512" alt="image" src="https://github.com/user-attachments/assets/0d66a941-7abe-4dfd-b7b1-0c94a24c14bf" />

Qt already had the mechanism to do it practically already, just needed to be wired up and updated with some options . I have it on 100ms update which is fairly slow but that's okay. Doesn't need to be too fast