### PR TITLE
Workspace versioning: ensure separator entries also

### DIFF
--- a/mscore/workspace.cpp
+++ b/mscore/workspace.cpp
@@ -34,6 +34,7 @@
 #include "thirdparty/qzip/qzipwriter_p.h"
 
 #include <cstring>
+#include <iterator>
 
 #include <QDialog>
 
@@ -1022,6 +1023,44 @@ void Workspace::ensureToolbarEntry(std::list<const char*>& entries,
             }
 
       entries.push_back(actionId);
+      }
+
+//---------------------------------------------------------
+//   ensureToolbarSeparator
+//---------------------------------------------------------
+
+void Workspace::ensureToolbarSeparator(std::list<const char*>& entries,
+                                       const char* anchorId,
+                                       InsertPosition position)
+      {
+      auto anchor = std::find_if(
+            entries.begin(),
+            entries.end(),
+            [anchorId](const char* entry) {
+                  return !strcmp(entry, anchorId);
+                  });
+
+      if (anchor == entries.end())
+            return;
+
+      if (position == InsertPosition::AFTER) {
+            auto next = std::next(anchor);
+
+            if (next != entries.end() && !strcmp(*next, ""))
+                  return;
+
+            entries.insert(next, "");
+            }
+      else {
+            if (anchor != entries.begin()) {
+                  auto previous = std::prev(anchor);
+
+                  if (!strcmp(*previous, ""))
+                        return;
+                  }
+
+            entries.insert(anchor, "");
+            }
       }
 
 //---------------------------------------------------------

--- a/mscore/workspace.h
+++ b/mscore/workspace.h
@@ -60,6 +60,11 @@ class Workspace : public QObject {
             const char* anchorActionId = nullptr,
             InsertPosition position = InsertPosition::BEFORE);
 
+      static void ensureToolbarSeparator(
+            std::list<const char*>& entries,
+            const char* anchorId,
+            InsertPosition position);
+
       static QString findStringFromAction(QAction* action);
       static QAction* findActionFromString(QString string);
       static QString findStringFromMenu(QMenu* menu);


### PR DESCRIPTION
Just in case, if we add a separator into an entry, let that also be ensured to manifest. Not that big of a deal since it's up to the user to re-arrange things as they see fit, but doesn't hurt to allow it if a separator is added along with a new toolbar icon.